### PR TITLE
Don't make assumptions about column numbers in contrast files 

### DIFF
--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -238,9 +238,9 @@ shiny_config <- list(
   "contrasts" = list(
     "comparisons" = apply(contrasts, 1, function(x) {
       list(
-        "Variable" = x[1],
-        "Group.1" = x[2],
-        "Group.2" = x[3]
+        "Variable" = x['variable'],
+        "Group.1" = x['reference'],
+        "Group.2" = x['target']
       )
     }),
     "stats" = contrast_stats


### PR DESCRIPTION
I've encountered a problem with this script with example data in an [nf-core module](https://github.com/nf-core/modules/pull/2315/), after adding an additional identifier column to the contrasts file. The script here makes assumptions about the column index (rather than name) used in contrast files). This PR switches the assumptions to column names instead.  