### PR TITLE
Remove explicit separator specifications

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -599,13 +599,11 @@ eselistfromConfig <-
       colData <- read_metadata(
         filename = exp$coldata$file,
         id_col = exp$coldata$id,
-        sep = exp$coldata$sep
       )
       annotation <-
         read_metadata(
           exp$annotation$file,
           id_col = exp$annotation$id,
-          sep = exp$annotation$sep,
           stringsAsFactors = FALSE
         )
 
@@ -617,7 +615,6 @@ eselistfromConfig <-
           mat$file,
           sample_metadata = colData,
           feature_metadata = annotation,
-          sep = mat$sep,
           row.names = 1
         )
       }))
@@ -643,7 +640,6 @@ eselistfromConfig <-
           if ("type" %in% names(assaytests) && assaytests$type == "uncompiled") {
             compile_contrast_data(
               differential_stats_files = assaytests$files,
-              sep = assaytests$sep,
               feature_id_column = assaytests$feature_id_column,
               fc_column = assaytests$fc_column,
               pval_column = assaytests$pval_column, qval_column = assaytests$qval_column,
@@ -1019,7 +1015,6 @@ read_differential <- function(filename,
 
 compile_contrast_data <-
   function(differential_stats_files,
-           sep = "\t",
            feature_id_column = NULL,
            pval_column = NULL,
            qval_column = NULL,

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -51,7 +51,7 @@ option_list <- list(
     c("-e", "--assay_files"),
     type = "character",
     default = NULL,
-    help = "Comma-separated list of TSV-format file expression matrix files."
+    help = "Comma-separated list of CSV or TSV-format file expression matrix files."
   ),
   make_option(
     c("-w", "--assay_names"),
@@ -87,7 +87,7 @@ option_list <- list(
     c("-d", "--differential_results"),
     type = "character",
     default = NULL,
-    help = "Tab-separated files containing at least fold change and p value, one for each row of the contrast file."
+    help = "Comma-separated list of CSV or TSV-format files containing at least fold change and p value, one for each row of the contrast file."
   ),
   make_option(
     c("-k", "--fold_change_column"),
@@ -198,7 +198,6 @@ contrast_stats[[opt$assay_entity_name]] <- lapply(contrast_stats_files, function
     "pval_column" = opt$pval_column,
     "qval_column" = opt$qval_column,
     "unlog_foldchanges" = opt$unlog_foldchanges,
-    "sep" = "\t"
   )
 })
 
@@ -213,19 +212,16 @@ experiments[[opt$assay_entity_name]] <- list(
   "coldata" = list(
     "file" = opt$sample_metadata,
     "id" = opt$sample_id_col,
-    "sep" = ","
   ),
   "annotation" = list(
     "file" = opt$feature_metadata,
     "id" = opt$feature_id_col,
-    "sep" = "\t",
     "label" = "gene_name"
   ),
   "expression_matrices" = lapply(assay_files, function(x) {
     list(
       file = x,
       measure = "counts",
-      sep = "\t"
     )
   })
 )

--- a/man/compile_contrast_data.Rd
+++ b/man/compile_contrast_data.Rd
@@ -6,7 +6,6 @@
 \usage{
 compile_contrast_data(
   differential_stats_files,
-  sep = "\\t",
   feature_id_column = NULL,
   pval_column = NULL,
   qval_column = NULL,
@@ -16,8 +15,6 @@ compile_contrast_data(
 }
 \arguments{
 \item{differential_stats_files}{Tabular files with differential stats}
-
-\item{sep}{Separator in stats files}
 
 \item{feature_id_column}{Feature identifier column in stats files}
 


### PR DESCRIPTION
Remove relics of the need for explicit separator specification (now inferred from file extension). 