### PR TITLE
Don't assume fold change values are already logged in differential plots

### DIFF
--- a/exec/differential_plots.R
+++ b/exec/differential_plots.R
@@ -170,7 +170,7 @@ vline_thresholds[[paste(opt$fold_change_col, '<-', opt$fold_change_threshold)]] 
 vline_thresholds[[paste(opt$fold_change_col, '>', opt$fold_change_threshold)]] = opt$fold_change_threshold
 
 plot_args <- list(
-  x = differential[[opt$fold_change_col]],
+  x = log2(differential[[opt$fold_change_col]]),
   y = -log10(differential[[opt$p_value_column]]),
   colorby = differential$differential_status,
   ylab = paste("-log(10)", opt$p_value_column),


### PR DESCRIPTION
Currently the differential plotting script assumes fold changes in input tables are pre-logged, which is inconsistent with its treatment of p values. So let's switch the assumption to unlogged.