### PR TITLE
Paramterise font size, improve facet label in ggplot boxplot

### DIFF
--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -131,7 +131,9 @@ boxplot <- function(input, output, session, eselist) {
   })
 
   output$quartilesPlotly <- renderPlotly({
-    plotly_quartiles(selectMatrix(), idToLabel(rownames(selectMatrix()), getExperiment()), getAssayMeasure(), whisker_distance = input$whiskerDistance)
+    selected_matrix <- selectMatrix()
+    ese <- getExperiment()
+    plotly_quartiles(selectMatrix(), idToLabel(rownames(selected_matrix), ese), getAssayMeasure(), whisker_distance = input$whiskerDistance)
   })
 
   output$densityPlotly <- renderPlotly({

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -141,7 +141,8 @@ boxplot <- function(input, output, session, eselist) {
   output$sampleBoxplot <- renderPlot(
     {
       withProgress(message = "Making sample boxplot", value = 0, {
-        ggplot_boxplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), whisker_distance = input$whiskerDistance, palette = getPalette())
+        p <- ggplot_boxplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), whisker_distance = input$whiskerDistance, palette = getPalette())
+        print(p)
       })
     },
     height = 600
@@ -150,7 +151,8 @@ boxplot <- function(input, output, session, eselist) {
   # Provide the plot for download
 
   plotSampleBoxplot <- reactive({
-    ggplot_boxplot(selectMatrix(), selectColData(), colorBy())
+    p <- ggplot_boxplot(selectMatrix(), selectColData(), colorBy())
+    print(p)
   })
 
   # Call to plotdownload module
@@ -184,7 +186,7 @@ boxplot <- function(input, output, session, eselist) {
 #' data(airway, package = "airway")
 #' ggplot_boxplot(assays(airway)[[1]], data.frame(colData(airway)), colorby = "dex")
 #'
-ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", whisker_distance = 1.5) {
+ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", whisker_distance = 1.5, base_size = 11) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby)
 
   if (!is.null(colorby)) {
@@ -207,15 +209,14 @@ ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = N
     p <- p + facet_wrap(~ type, ncol = n_col)
   }
 
-  p <- p + theme_bw() + theme(
+  p <- p + theme_bw(base_size=base_size) + theme(
     axis.text.x = element_text(angle = 90, hjust = 1, size = rel(1.5)), axis.title.x = element_blank(), legend.position = "bottom",
-    axis.text.y = element_text(size = rel(1.5)), legend.text = element_text(size = rel(1.2)), title = element_text(size = rel(1.3))
+    axis.text.y = element_text(size = rel(1.5)), legend.text = element_text(size = rel(1.2)), title = element_text(size = rel(1.3)),
+    strip.text.x = element_text(size = 10)
   ) + ylab(splitStringToFixedwidthLines(paste0(
     "log2(",
     prettifyVariablename(expressiontype), ")"
   ), 15))
-
-  print(p)
 }
 
 #' Make a boxplot with coloring by experimental variable

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -298,7 +298,7 @@ plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, ex
 #'
 #' @return output A \code{ggplot} output
 
-ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression") {
+ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", base_size = 16) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, value_type = "density", annotate_samples = TRUE)
   ncats <- length(unique(plotdata$name))
   palette <- makeColorScale(ncats)
@@ -319,7 +319,7 @@ ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette
     p <- p + facet_wrap(~type, ncol = 1, scales = "free_y")
   }
 
-  p + theme_bw(base_size = 16) + theme(
+  p + theme_bw(base_size = base_size) + theme(
     legend.position = "bottom"
   )
 }

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -173,7 +173,7 @@ boxplot <- function(input, output, session, eselist) {
 #' @param whisker_distance Passed to \code{\link[ggplot2]{geom_boxplot}} as
 #' \code{coef}, controlling the length of the whiskers. See documentation of
 #' that function for more info (default: 1.5).
-#' @param base_size Passed to ggplot's \code(theme())
+#' @param base_size Passed to ggplot's \code{theme()}
 #'
 #' @return output A \code{ggplot} output
 #'
@@ -294,7 +294,7 @@ plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, ex
 #' @param palette Palette of colors, one for each unique value derived from
 #' \code{colorby}.
 #' @param expressiontype Expression type for use in y axis label
-#' @param base_size Passed to ggplot's \code(theme())
+#' @param base_size Passed to ggplot's \code{theme()}
 #'
 #' @export
 #'

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -173,6 +173,7 @@ boxplot <- function(input, output, session, eselist) {
 #' @param whisker_distance Passed to \code{\link[ggplot2]{geom_boxplot}} as
 #' \code{coef}, controlling the length of the whiskers. See documentation of
 #' that function for more info (default: 1.5).
+#' @param base_size Passed to ggplot's \code(theme())
 #'
 #' @return output A \code{ggplot} output
 #'
@@ -293,6 +294,7 @@ plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, ex
 #' @param palette Palette of colors, one for each unique value derived from
 #' \code{colorby}.
 #' @param expressiontype Expression type for use in y axis label
+#' @param base_size Passed to ggplot's \code(theme())
 #'
 #' @export
 #'

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -546,6 +546,9 @@ interactiveHeatmap <- function(plotmatrix, displaymatrix, sample_annotation, clu
 
   if (nrow(plotmatrix) < 2) {
     cluster_rows <- FALSE
+    
+    # This is a little hack to work around a bug in d3heatmap with single-row data
+    plotmatrix <- rbind(plotmatrix, plotmatrix)
   }
 
   # Specify how the dendrogram should be created

--- a/R/rnaseq.R
+++ b/R/rnaseq.R
@@ -55,7 +55,7 @@ rnaseqInput <- function(id, eselist) {
 
   exploratory_menu <- list("QC/ exploratory", tabPanel("Distribution plots", sidebarLayout(sidebarPanel(boxplotInput(ns("boxplot"), eselist), width = 3), mainPanel(boxplotOutput(ns("boxplot")),
     width = 9
-  )), icon = icon("bar-chart-o", verify_fa = FALSE)), tabPanel("PCA", sidebarLayout(sidebarPanel(pcaInput(ns("pca"), eselist), width = 3), mainPanel(pcaOutput(ns("pca")),
+  )), icon = icon("chart-column", verify_fa = FALSE)), tabPanel("PCA", sidebarLayout(sidebarPanel(pcaInput(ns("pca"), eselist), width = 3), mainPanel(pcaOutput(ns("pca")),
     width = 9
   )), icon = icon("cube")), tabPanel("PCA vs Experiment", sidebarLayout(sidebarPanel(heatmapInput(ns("heatmap-pca"), eselist, type = "pca"),
     width = 3

--- a/man/ggplot_boxplot.Rd
+++ b/man/ggplot_boxplot.Rd
@@ -10,7 +10,8 @@ ggplot_boxplot(
   colorby = NULL,
   palette = NULL,
   expressiontype = "expression",
-  whisker_distance = 1.5
+  whisker_distance = 1.5,
+  base_size = 11
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ ggplot_boxplot(
 \item{whisker_distance}{Passed to \code{\link[ggplot2]{geom_boxplot}} as
 \code{coef}, controlling the length of the whiskers. See documentation of
 that function for more info (default: 1.5).}
+
+\item{base_size}{Passed to ggplot's \code(theme())}
 }
 \value{
 output A \code{ggplot} output

--- a/man/ggplot_boxplot.Rd
+++ b/man/ggplot_boxplot.Rd
@@ -30,7 +30,7 @@ ggplot_boxplot(
 \code{coef}, controlling the length of the whiskers. See documentation of
 that function for more info (default: 1.5).}
 
-\item{base_size}{Passed to ggplot's \code(theme())}
+\item{base_size}{Passed to ggplot's \code{theme()}}
 }
 \value{
 output A \code{ggplot} output

--- a/man/ggplot_densityplot.Rd
+++ b/man/ggplot_densityplot.Rd
@@ -25,7 +25,7 @@ ggplot_densityplot(
 
 \item{expressiontype}{Expression type for use in y axis label}
 
-\item{base_size}{Passed to ggplot's \code(theme())}
+\item{base_size}{Passed to ggplot's \code{theme()}}
 }
 \value{
 output A \code{ggplot} output

--- a/man/ggplot_densityplot.Rd
+++ b/man/ggplot_densityplot.Rd
@@ -9,7 +9,8 @@ ggplot_densityplot(
   experiment,
   colorby = NULL,
   palette = NULL,
-  expressiontype = "expression"
+  expressiontype = "expression",
+  base_size = 16
 )
 }
 \arguments{
@@ -23,6 +24,8 @@ ggplot_densityplot(
 \code{colorby}.}
 
 \item{expressiontype}{Expression type for use in y axis label}
+
+\item{base_size}{Passed to ggplot's \code(theme())}
 }
 \value{
 output A \code{ggplot} output


### PR DESCRIPTION
This PR makes some changes to allow more control over font sizing in boxplots etc, by providing an interface to ggplot `base_size`.