### PR TITLE
Centralise default palette generation, fix issues

### DIFF
--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -305,12 +305,14 @@ plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, ex
 ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", base_size = 16) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, value_type = "density", annotate_samples = TRUE)
   ncats <- length(unique(plotdata$name))
-  palette <- makeColorScale(ncats)
+  if (is.null(palette)) {
+    palette <- makeColorScale(ncats)
+  }
 
   p <- ggplot(data = plotdata) +
     geom_area(aes(x = value, y = density, fill = name, color = name), alpha = 0.4) +
-    scale_fill_manual(name = prettifyVariablename(colorby), values = makeColorScale(ncats, palette = "Set1")) +
-    scale_color_manual(name = prettifyVariablename(colorby), values = makeColorScale(ncats, palette = "Set1")) +
+    scale_fill_manual(name = prettifyVariablename(colorby), values = palette) +
+    scale_color_manual(name = prettifyVariablename(colorby), values = palette) +
     ylab("Density") +
     xlab(splitStringToFixedwidthLines(paste0(
       "log2(",
@@ -347,7 +349,9 @@ ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette
 plotly_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression") {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, value_type = "density", annotate_samples = TRUE)
   ncats <- length(unique(plotdata$name))
-  palette <- makeColorScale(ncats)
+  if (is.null(palette)) {
+    palette <- makeColorScale(ncats)
+  }
 
   plotdata %>%
     group_by(type) %>%

--- a/R/colormaker.R
+++ b/R/colormaker.R
@@ -76,7 +76,7 @@ colormaker <- function(input, output, session, getNumberCategories) {
 #' @examples
 #' makeColorScale(10)
 #'
-makeColorScale <- function(ncolors, palette = "Dark2") {
+makeColorScale <- function(ncolors, palette = "Set1") {
   paletteinfo <- RColorBrewer::brewer.pal.info
 
   if (ncolors > paletteinfo["Set1", "maxcolors"]) {

--- a/R/dendro.R
+++ b/R/dendro.R
@@ -189,6 +189,9 @@ clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, cor_met
 
     p3 <- p3 + geom_point(data = labs, aes_string(x = "x", y = 0), size = 4)
   } else {
+    if (is.null(palette)) {
+        palette <- makeColorScale(length(unique(experiment[[colorby]])))
+    }
     labs[[colorby]] <- as.character(experiment[[colorby]][match(labs$label, rownames(experiment))])
     labs[[colorby]] <- na.replace(labs[[colorby]], replacement = "N/A")
 

--- a/exec/differential_plots.R
+++ b/exec/differential_plots.R
@@ -187,8 +187,7 @@ plot_args <- list(
   hline_thresholds = hline_thresholds,
   vline_thresholds = vline_thresholds,
   show_labels = FALSE,
-  legend_title = "Differential status",
-  palette = makeColorScale(2, 'Set1')
+  legend_title = "Differential status"
 )
 
 print("Writing volcano plots...")

--- a/exec/exploratory_plots.R
+++ b/exec/exploratory_plots.R
@@ -212,12 +212,12 @@ print("Writing boxplots...")
 
 if (opt$write_html){
   print("... interactive")
-  interactive_boxplot <- plotly_boxplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene", palette = makeColorScale(2, "Set1"))
+  interactive_boxplot <- plotly_boxplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene")
   htmlwidgets::saveWidget(plotly::as_widget(interactive_boxplot), file.path(html_outdir, "boxplot.html"), selfcontained = TRUE)
 }
 
 print("... static")
-static_boxplot <- ggplot_boxplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene", palette = makeColorScale(2, "Set1"))
+static_boxplot <- ggplot_boxplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene")
 png(filename = file.path(png_outdir, "boxplot.png"), width = 800, height = 600)
 static_boxplot
 dev.off()
@@ -232,12 +232,12 @@ print("Writing density plots...")
 
 if (opt$write_html){
   print("...interactive")
-  interactive_densityplot <- plotly_densityplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene", palette = makeColorScale(2, "Set1"))
+  interactive_densityplot <- plotly_densityplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene")
   htmlwidgets::saveWidget(plotly::as_widget(interactive_densityplot), file.path(html_outdir, "density.html"), selfcontained = TRUE)
 }
 
 print("... static")
-static_densityplot <- ggplot_densityplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene", palette = makeColorScale(2, "Set1"))
+static_densityplot <- ggplot_densityplot(assay_data, experiment = sample_metadata, colorby = opt$contrast_variable, expressiontype = "count per gene")
 png(filename = file.path(png_outdir, "density.png"), width = 800, height = 600)
 static_densityplot
 dev.off()
@@ -274,7 +274,6 @@ for (d in names(plot_types)) {
     ylab = labels[2],
     colorby = plotdata$colorby,
     plot_type = plot_types[[d]],
-    palette = makeColorScale(length(unique(plotdata$colorby)), "Set1"),
     legend_title = prettifyVariablename(opt$contrast_variable),
     labels = plotdata$name,
     show_labels = TRUE
@@ -317,8 +316,7 @@ clusteringDendrogram(
   colorby = opt$contrast_variable,
   cor_method = "spearman",
   plot_title = paste0("Sample clustering dendrogram, ", opt$n_genes, " most variable genes"),
-  cluster_method = "ward.D2",
-  palette = makeColorScale(length(unique(sample_metadata[[opt$contrast_variable]])), palette = "Set1")
+  cluster_method = "ward.D2"
 )
 dev.off()
 
@@ -340,7 +338,6 @@ mad_plot_args <- list(
   y = plotdata$mad,
   color = plotdata$outlier,
   hline_thresholds = c("Outlier threshold" = -5),
-  palette = makeColorScale(2, palette = "Set1"),
   legend_title = "Outlier status",
   labels = rownames(plotdata),
   show_labels = TRUE,

--- a/man/makeColorScale.Rd
+++ b/man/makeColorScale.Rd
@@ -4,7 +4,7 @@
 \alias{makeColorScale}
 \title{Make a color palette of a specified length}
 \usage{
-makeColorScale(ncolors, palette = "Dark2")
+makeColorScale(ncolors, palette = "Set1")
 }
 \arguments{
 \item{ncolors}{Integer specifying the number of colors}


### PR DESCRIPTION
This PR removes some assumptions on group numbers for palette generation in the exec scripts, which were hanging over from testing, and actually fixes routines so no explicit palette specification is required in most cases.