### PR TITLE
Final palette fixes

### DIFF
--- a/R/colormaker.R
+++ b/R/colormaker.R
@@ -79,7 +79,7 @@ colormaker <- function(input, output, session, getNumberCategories) {
 makeColorScale <- function(ncolors, palette = "Set1") {
   paletteinfo <- RColorBrewer::brewer.pal.info
 
-  if (ncolors > paletteinfo["Set1", "maxcolors"]) {
+  if (ncolors > paletteinfo[palette, "maxcolors"]) {
     cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(ncolors)
   } else if (ncolors < 3) {
     cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(3)

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -403,6 +403,8 @@ plotly_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scat
 
   if (any(labelled) && is.null(palette) && !is.null(colorby)) {
     palette <- makeColorScale(length(unique(colorby[labelled])))
+  }else{
+    palette <- makeColorScale(1)
   }
 
   plotargs <- list(
@@ -500,11 +502,13 @@ static_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scat
   if ((!is.null(colorby)) && !is.factor(colorby)) {
     colorby <- factor(colorby)
   }
-
+  
   if (any(labelled) && is.null(palette) && !is.null(colorby)) {
     palette <- makeColorScale(length(unique(colorby[labelled])))
+  }else{
+    palette <- makeColorScale(1)
   }
-
+  
   if (plot_type == "scatter") {
     plotdata <- data.frame(
       x = x,


### PR DESCRIPTION
This PR just addresses a lingering issue carried over from the last PR. Some form of palette needs to be generated for scatterplots even without multiple classes of point, which this ensures.