### PR TITLE
App separate feature ID for differential files

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -708,8 +708,6 @@ eselistfromConfig <-
 
     # Check that number of differential results sets is equal to number of contrasts
 
-    saveRDS(expsumexps, file="expsumexps.rds")
-
     for (ese in expsumexps) {
       if (ncol(ese@contrast_stats[[1]]$fold_changes) != length(config$contrasts$comparisons)) {
         stop(paste0("Number of supplied contrasts (", length(config$contrasts$comparisons), ") not equal to the number of sets of differential statistics supplied (", ncol(ese@contrast_stats[[1]]$fold_changes), ")"))

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -36,13 +36,6 @@ option_list <- list(
     help = "Column in sample metadata used as sample identifier. Should be used to name columns of expression matrices, and duplicate rows will be removed based on this column."
   ),
   make_option(
-    c("-n", "--diff_feature_id_col"),
-    type = "character",
-    metavar = "string",
-    help = "Differential file column name containing feature identifiers.",
-    default = "gene_id"
-  ),
-  make_option(
     c("-f", "--feature_metadata"),
     type = "character",
     default = NULL,
@@ -53,6 +46,13 @@ option_list <- list(
     type = "character",
     default = "gene_id",
     help = "Column in feature metadata used as feature identifier. Should be used to name columns of expression matrices."
+  ),
+  make_option(
+    c("-n", "--diff_feature_id_col"),
+    type = "character",
+    metavar = "string",
+    help = "Differential file column name containing feature identifiers.",
+    default = "gene_id"
   ),
   make_option(
     c("-e", "--assay_files"),

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -20,8 +20,14 @@ option_list <- list(
   make_option(
     c("-r", "--description"),
     type = "character",
-    default = "Look what  gone done",
-    help = "Joe Bloggs."
+    default = NULL,
+    help = "A description to display in the app."
+  ),
+  make_option(
+    c("-m", "--report_markdown_file"),
+    type = "character",
+    default = NULL,
+    help = "Path to file with descripion/ reporting in markdown. Alternative to 'description' for more extensive description content."
   ),
   make_option(
     c("-s", "--sample_metadata"),
@@ -292,6 +298,12 @@ if (!is.null(opt$group_vars)) {
   opt$group_vars <- simpleSplit(opt$group_vars, ",")
   shiny_config[["group_vars"]] <- opt$group_vars
   shiny_config[["default_groupvar"]] <- opt$group_vars[1]
+}
+
+if (!is.null(opt$description)) {
+  shiny_config[['description']] <- opt$description
+} else if (!is.null(opt$report_markdown_file)) {
+  shiny_config[['report']] <- opt$report_markdown_file
 }
 
 myesel <- eselistfromConfig(shiny_config)

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -161,7 +161,6 @@ mandatory <-
   c(
     "title",
     "author",
-    "description",
     "sample_metadata",
     "sample_id_col",
     "feature_metadata",

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -36,6 +36,13 @@ option_list <- list(
     help = "Column in sample metadata used as sample identifier. Should be used to name columns of expression matrices, and duplicate rows will be removed based on this column."
   ),
   make_option(
+    c("-n", "--diff_feature_id_col"),
+    type = "character",
+    metavar = "string",
+    help = "Differential file column name containing feature identifiers.",
+    default = "gene_id"
+  ),
+  make_option(
     c("-f", "--feature_metadata"),
     type = "character",
     default = NULL,
@@ -153,6 +160,7 @@ mandatory <-
     "sample_id_col",
     "feature_metadata",
     "feature_id_col",
+    "diff_feature_id_col",
     "assay_files",
     "assay_entity_name",
     "output_directory",
@@ -232,7 +240,7 @@ contrast_stats[[opt$assay_entity_name]] <- lapply(contrast_stats_files, function
   list(
     "files" = x,
     "type" = "uncompiled",
-    "feature_id_column" = opt$feature_id_col,
+    "feature_id_column" = opt$diff_feature_id_col,
     "fc_column" = opt$fold_change_column,
     "pval_column" = opt$pval_column,
     "qval_column" = opt$qval_column,


### PR DESCRIPTION
This PR:

- Adds a separate field to use for feature ID in the differential files (can't be assumed to be the same as the one in the matrix file).
- Wires in the description fields so they will actually work. 