### PR TITLE
Guess unlog

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -577,12 +577,14 @@ eselistFromYAML <- function(configfile) {
 #' Build an ExploratorySummarisedExperimentList from a description provided in a list
 #'
 #' @param config Hierachical named list with input components. See \code{eselistFromYAML} for detail.
+#' @param guess_unlog_matrices Should we guess the log status of matrices and
+#'   unlog where things seem logged?
 #'
 #' @return out An ExploratorySummarizedExperimentList object suitable for passing to \code{\link{prepareApp}}
 #' @export
 
 eselistfromConfig <-
-  function(config) {
+  function(config, guess_unlog_matrices = FALSE) {
     # 'Experiments' are sets of results from a common set of samples
 
     experiments <- config$experiments
@@ -626,6 +628,7 @@ eselistfromConfig <-
           sample_metadata = colData,
           feature_metadata = annotation,
           row.names = 1
+          guess_unlog = guess_unlog_matrices
         )
       }))
 
@@ -760,11 +763,13 @@ eselistfromConfig <-
 #' @param feature_metadata Data fraome of feature metadata
 #' @param sep Sepaarator in matrix file
 #' @param row.names Matrix column number or name containing feature identifiers
+#' @param guess_unlog Should we guess the log status of matrices and unlog where
+#'   things seem logged?
 #'
 #' @return output Numeric matrix
 #' @export
 
-read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, sep = NULL, row.names = 1) {
+read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, sep = NULL, row.names = 1, guess_unlog = FALSE) {
   if (is.null(sep)) {
     sep <- getSeparator(matrix_file)
   }
@@ -803,7 +808,16 @@ read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, s
     }
   }
 
-  as.matrix(matrix_data[, rownames(sample_metadata)])
+  matrix_data <- as.matrix(matrix_data[, rownames(sample_metadata)])
+  
+  # Guess the log status
+
+  if (guess_unlog && max(matrix_data) <= 20){
+    2^matrix_data
+  }else{
+    matrix_data
+  }
+
 }
 
 #' Read a metadata file

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -627,7 +627,7 @@ eselistfromConfig <-
           mat$file,
           sample_metadata = colData,
           feature_metadata = annotation,
-          row.names = 1
+          row.names = 1,
           guess_unlog = guess_unlog_matrices
         )
       }))

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -311,7 +311,7 @@ if (!is.null(opt$description)) {
   shiny_config[['report']] <- opt$report_markdown_file
 }
 
-myesel <- eselistfromConfig(shiny_config)
+myesel <- eselistfromConfig(shiny_config, guess_unlog_matrices = opt$guess_unlog_matrices)
 
 # Write output
 

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -115,6 +115,12 @@ option_list <- list(
     help = "Set this option if fold changes should be unlogged."
   ),
   make_option(
+    c("-gum", "--guess_unlog_matrices"),
+    action = "store_true",
+    default = FALSE,
+    help = "Should we guess the log status of matrices and unlog where things seem logged?"
+  ),
+  make_option(
     c("-p", "--pval_column"),
     type = "character",
     default = "padj",

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -115,7 +115,7 @@ option_list <- list(
     help = "Set this option if fold changes should be unlogged."
   ),
   make_option(
-    c("-gum", "--guess_unlog_matrices"),
+    "--guess_unlog_matrices",
     action = "store_true",
     default = FALSE,
     help = "Should we guess the log status of matrices and unlog where things seem logged?"

--- a/man/eselistfromConfig.Rd
+++ b/man/eselistfromConfig.Rd
@@ -4,10 +4,13 @@
 \alias{eselistfromConfig}
 \title{Build an ExploratorySummarisedExperimentList from a description provided in a list}
 \usage{
-eselistfromConfig(config)
+eselistfromConfig(config, guess_unlog_matrices = FALSE)
 }
 \arguments{
 \item{config}{Hierachical named list with input components. See \code{eselistFromYAML} for detail.}
+
+\item{guess_unlog_matrices}{Should we guess the log status of matrices and
+unlog where things seem logged?}
 }
 \value{
 out An ExploratorySummarizedExperimentList object suitable for passing to \code{\link{prepareApp}}

--- a/man/read_matrix.Rd
+++ b/man/read_matrix.Rd
@@ -9,7 +9,8 @@ read_matrix(
   sample_metadata,
   feature_metadata = NULL,
   sep = NULL,
-  row.names = 1
+  row.names = 1,
+  guess_unlog = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ read_matrix(
 \item{sep}{Sepaarator in matrix file}
 
 \item{row.names}{Matrix column number or name containing feature identifiers}
+
+\item{guess_unlog}{Should we guess the log status of matrices and unlog where
+things seem logged?}
 }
 \value{
 output Numeric matrix


### PR DESCRIPTION
This PR allows the read_matrix function to guess and reverse log status at object creation. This assists in the consistent display of expression values from different assays when multiple such are provided by pipelines. 