### PR TITLE
Better contrasts, miscellaneous bugs

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -26,5 +26,5 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: '"warning"'
+          error-on: '"error"'
           args: 'c("--no-manual", "--as-cran", "--no-examples")'

--- a/R/ExploratorySummarizedExperiment-class.R
+++ b/R/ExploratorySummarizedExperiment-class.R
@@ -118,7 +118,7 @@ ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield
 
   # Build the object
 
-  sumexp <- SummarizedExperiment(assays = assays, colData = DataFrame(colData))
+  sumexp <- SummarizedExperiment(assays = assays, colData = DataFrame(colData, check.names = FALSE))
   mcols(sumexp) <- annotation
 
   new("ExploratorySummarizedExperiment", sumexp,

--- a/R/ExploratorySummarizedExperimentList-class.R
+++ b/R/ExploratorySummarizedExperimentList-class.R
@@ -127,7 +127,7 @@ ExploratorySummarizedExperimentList <- function(eses, title = "", author = "", d
   # Set grouping variales as any non-integer field applied to more than one sample
 
   if (length(group_vars) == 0) {
-    group_vars <- chooseGroupingVariables(data.frame(colData(eses[[1]])))
+    group_vars <- chooseGroupingVariables(data.frame(colData(eses[[1]]), check.names = FALSE))
     default_groupvar <- group_vars[1]
   }
 

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -725,7 +725,7 @@ eselistfromConfig <-
       author = config$author,
       group_vars = config$group_vars,
       default_groupvar = config$default_groupvar,
-      contrasts = lapply(config$contrasts$comparisons, function(x) as.character(x[1:3]))
+      contrasts = lapply(config$contrasts$comparisons, function(x) unlist(x))
     )
 
     # Optional things
@@ -969,11 +969,12 @@ read_contrasts <-
 
     if (convert_to_list) {
       contrasts <- apply(contrasts, 1, function(x) {
-        list(
-          "Variable" = x["variable"],
-          "Group.1" = x["reference"],
-          "Group.2" = x["target"]
-        )
+        conlist <- split(unname(x),names(x))[names(x)]
+        rename <- c('variable' = 'Variable', 'reference' = 'Group.1', 'target' = 'Group.2')
+        rename_ind <- match(names(rename), names(conlist))
+        names(conlist)[rename_ind] <- rename
+        nonempty <- unlist(lapply(conlist, function(y) ! (is.na(y) || is.null(y) || grepl("^\\s*$", y))))
+        conlist[nonempty]
       })
     }
 

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -328,7 +328,7 @@ contrasts <- function(input, output, session, eselist, selectmatrix_reactives = 
       ese <- getExperiment()
       contrasts <- getAllContrasts()
       matrix <- getAssayMatrix()
-      coldata <- data.frame(colData(ese))
+      coldata <- data.frame(colData(ese), check.names = FALSE)
 
       validate(need(nrow(matrix) > 0, "Waiting for input matrix"))
 

--- a/R/experimenttable.R
+++ b/R/experimenttable.R
@@ -101,7 +101,7 @@ experimenttableOutput <- function(id) {
 #'
 experimenttable <- function(input, output, session, eselist) {
   getExperiment <- reactive({
-    experiment <- data.frame(colData(eselist[[input$experiment]]))
+    experiment <- data.frame(colData(eselist[[input$experiment]]), check.names = FALSE)
     colnames(experiment) <- prettifyVariablename(colnames(experiment))
     experiment
   })

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -298,7 +298,6 @@ heatmap <- function(input, output, session, eselist, type = "expression") {
     validate(
         need(length(informative_variables) > 0, "Warning: supplied filters have reduced sample metadata selections so as to render all variables uninformative (number of unique values = 1 or N)")
     )
-    print(paste("informative variables:", length(informative_variables)))
 
     anova_pca_metadata(pca_coords = pca$x, pcameta = pcameta, fraction_explained = fraction_explained)
   })

--- a/R/sampleselect.R
+++ b/R/sampleselect.R
@@ -83,6 +83,7 @@ sampleselectInput <- function(id, eselist, getExperiment, select_samples = TRUE)
 #' @param getExperiment Reactive expression that returns a
 #'   \code{ExploratorySummarizedExperiment} with assays and metadata. Usually a
 #'   result of a user selection
+#' @param allow_summarise Boolean, show controls for matrix summarisation?
 #'
 #' @return output A list of reactive functions for interrogating the selected
 #' samples/ columns.

--- a/R/sampleselect.R
+++ b/R/sampleselect.R
@@ -92,8 +92,10 @@ sampleselectInput <- function(id, eselist, getExperiment, select_samples = TRUE)
 #' @examples
 #' selectSamples <- callModule(sampleselect, "selectmatrix", getExperiment)
 #'
-sampleselect <- function(input, output, session, eselist, getExperiment) {
-  getSummaryType <- callModule(summarisematrix, "summarise")
+sampleselect <- function(input, output, session, eselist, getExperiment, allow_summarise = TRUE) {
+  if (allow_summarise){
+    getSummaryType <- callModule(summarisematrix, "summarise")
+  }
 
   # Render the sampleGroupVal() element based on sampleGroupVar
 
@@ -105,7 +107,11 @@ sampleselect <- function(input, output, session, eselist, getExperiment) {
       group_values <- as.character(unique(ese[[isolate(input$sampleGroupVar)]]))
       ns <- session$ns
 
-      list(checkboxGroupInput(ns("sampleGroupVal"), "Groups", group_values, selected = group_values), summarisematrixInput(ns("summarise")))
+      inputs <- list(checkboxGroupInput(ns("sampleGroupVal"), "Groups", group_values, selected = group_values))
+      if (allow_summarise){
+        inputs <- pushToList(inputs, summarisematrixInput(ns("summarise"))) 
+      }
+      inputs
     }
   })
 
@@ -152,5 +158,11 @@ sampleselect <- function(input, output, session, eselist, getExperiment) {
     })
   })
 
-  list(selectSamples = selectSamples, getSampleGroupVar = getSampleGroupVar, getSummaryType = getSummaryType, getSampleSelect = getSampleSelect)
+  reactives <- list(selectSamples = selectSamples, getSampleGroupVar = getSampleGroupVar, getSampleSelect = getSampleSelect)
+
+  if (allow_summarise){
+    reactives[['getSummaryType']] <- getSummaryType
+  }
+
+  reactives
 }

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -194,6 +194,8 @@ scatterplot <- function(input, output, session, getDatamatrix, getThreedee = NUL
   output$scatter <- renderPlotly({
     withProgress(message = "Drawing scatter plot", value = 0, {
       if (!is.null(colorBy)) {
+        cb = colorBy()
+          
         # If a palette was supplied, or if we made our own...
 
         if (is.null(getPalette)) {
@@ -201,10 +203,12 @@ scatterplot <- function(input, output, session, getDatamatrix, getThreedee = NUL
         } else {
           palette <- getPalette()
         }
+      }else{
+        cb = NULL
       }
 
       plotly_scatterplot(
-        x = xdata(), y = ydata(), z = zdata(), colorby = colorBy(), plot_type = plotType(), title = getTitle(),
+        x = xdata(), y = ydata(), z = zdata(), colorby = cb, plot_type = plotType(), title = getTitle(),
         xlab = colnames(getDatamatrix())[getXAxis()], ylab = colnames(getDatamatrix())[getYAxis()],
         zlab = colnames(getDatamatrix())[geZXAxis()], palette = palette, labels = getLabels(),
         show_labels = getShowLabels(), lines = getLines(), showlegend = showLegend()

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -211,7 +211,8 @@ scatterplot <- function(input, output, session, getDatamatrix, getThreedee = NUL
         x = xdata(), y = ydata(), z = zdata(), colorby = cb, plot_type = plotType(), title = getTitle(),
         xlab = colnames(getDatamatrix())[getXAxis()], ylab = colnames(getDatamatrix())[getYAxis()],
         zlab = colnames(getDatamatrix())[geZXAxis()], palette = palette, labels = getLabels(),
-        show_labels = getShowLabels(), lines = getLines(), showlegend = showLegend()
+        show_labels = getShowLabels(), lines = getLines(), showlegend =showLegend(), 
+        point_size = getPointSize()
       )
     })
   })

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -102,10 +102,10 @@ selectmatrixInput <- function(id, eselist, require_contrast_stats = FALSE) {
 #' selectSamples <- callModule(sampleselect, "selectmatrix", eselist)
 #'
 selectmatrix <- function(input, output, session, eselist, var_n = 50, var_max = NULL, select_assays = TRUE, select_samples = TRUE, select_genes = TRUE, provide_all_genes = FALSE,
-                         default_gene_select = NULL, require_contrast_stats = FALSE, rounding = 2, select_meta = TRUE) {
+                         default_gene_select = NULL, require_contrast_stats = FALSE, rounding = 2, select_meta = TRUE, allow_summarise = TRUE) {
   # Use the sampleselect and geneselect modules to generate reactive expressions that can be used to derive an expression matrix
 
-  unpack.list(callModule(sampleselect, "selectmatrix", eselist = eselist, getExperiment))
+  unpack.list(callModule(sampleselect, "selectmatrix", eselist = eselist, getExperiment, allow_summarise = allow_summarise))
   unpack.list(callModule(geneselect, "selectmatrix",
     eselist = eselist, getExperiment, var_n = var_n, var_max = varMax(), selectSamples = selectSamples,
     getAssay = getAssay, provide_all = provide_all_genes, default = default_gene_select
@@ -250,7 +250,7 @@ selectmatrix <- function(input, output, session, eselist, var_n = 50, var_max = 
       rows <- selectRows()
 
       selected_matrix <- assay_matrix[rows, samples, drop = FALSE]
-      if (getSampleSelect() == "group" && getSummaryType() != "none") {
+      if (allow_summarise && getSampleSelect() == "group" && getSummaryType() != "none") {
         selected_matrix <- summarizeMatrix(selected_matrix, selectColData()[[getSampleGroupVar()]], getSummaryType())
       }
 
@@ -278,7 +278,7 @@ selectmatrix <- function(input, output, session, eselist, var_n = 50, var_max = 
   # summarised if grouping variables were supplied!
 
   isSummarised <- reactive({
-    length(eselist@group_vars) > 0 && getSummaryType() != "none"
+    allow_summarise && length(eselist@group_vars) > 0 && getSummaryType() != "none"
   })
 
   # Extract the annotation from the SummarizedExperiment

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -92,6 +92,7 @@ selectmatrixInput <- function(id, eselist, require_contrast_stats = FALSE) {
 #'   used to hide experiments that don't have the necessary data.
 #' @param rounding Number of decimal places to show in results (Default 2)
 #' @param select_meta Boolean- add metadata controls?
+#' @param allow_summarise Boolean, show controls for matrix summarisation?
 #'
 #' @return output A list of reactive functions for fetching the derived matrix
 #'   and making a title based on its properties.

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -271,7 +271,7 @@ selectmatrix <- function(input, output, session, eselist, var_n = 50, var_max = 
   selectColData <- reactive({
     validate(need(length(selectSamples()) > 0, "Waiting for sample selection"))
     withProgress(message = "Extracting experiment metadata", value = 0, {
-      droplevels(data.frame(colData(getExperiment())[selectSamples(), , drop = FALSE]))
+      droplevels(data.frame(colData(getExperiment())[selectSamples(), , drop = FALSE], check.names = FALSE))
     })
   })
 

--- a/man/sampleselect.Rd
+++ b/man/sampleselect.Rd
@@ -4,7 +4,14 @@
 \alias{sampleselect}
 \title{The server function of the sampleselect module}
 \usage{
-sampleselect(input, output, session, eselist, getExperiment)
+sampleselect(
+  input,
+  output,
+  session,
+  eselist,
+  getExperiment,
+  allow_summarise = TRUE
+)
 }
 \arguments{
 \item{input}{Input object}
@@ -19,6 +26,8 @@ ExploratorySummarizedExperiment objects}
 \item{getExperiment}{Reactive expression that returns a
 \code{ExploratorySummarizedExperiment} with assays and metadata. Usually a
 result of a user selection}
+
+\item{allow_summarise}{Boolean, show controls for matrix summarisation?}
 }
 \value{
 output A list of reactive functions for interrogating the selected

--- a/man/selectmatrix.Rd
+++ b/man/selectmatrix.Rd
@@ -18,7 +18,8 @@ selectmatrix(
   default_gene_select = NULL,
   require_contrast_stats = FALSE,
   rounding = 2,
-  select_meta = TRUE
+  select_meta = TRUE,
+  allow_summarise = TRUE
 )
 }
 \arguments{
@@ -58,6 +59,8 @@ used to hide experiments that don't have the necessary data.}
 \item{rounding}{Number of decimal places to show in results (Default 2)}
 
 \item{select_meta}{Boolean- add metadata controls?}
+
+\item{allow_summarise}{Boolean, show controls for matrix summarisation?}
 }
 \value{
 output A list of reactive functions for fetching the derived matrix


### PR DESCRIPTION
In this PR:

- Remove internal assumptions on structure of contrasts, allowing for contrasts with the same variable and groups, but different blocking variables, for example.

Plus fixes for issues reported by @WackerO:

- colorBy error in loading plots (the loading plots don't require coloring)
- wire in currently disconnected point size controls
- remove generic matrix controls not relevant in metadata/ PCA plot and which were leading to errors (means, metadata selection)
- set `check.names = FALSE` in various places, to prevent mangling of space-containing sample covariates
- turn off erroring for warnings in CI so we don't get the constant issue surrounding the number of imports