### PR TITLE
Added na.omit to matrix reading in exploratory_plots.R

### DIFF
--- a/exec/exploratory_plots.R
+++ b/exec/exploratory_plots.R
@@ -154,11 +154,13 @@ assay_files <-
 # Expect that 'variance stabilised' expression profiles will already be logged
 
 assay_data <- lapply(assay_files, function(x) {
-  read_matrix(
-    x,
-    sample_metadata = sample_metadata,
-    feature_metadata = feature_metadata,
-    row.names = 1
+  na.omit(
+    read_matrix(
+      x,
+      sample_metadata = sample_metadata,
+      feature_metadata = feature_metadata,
+      row.names = 1
+    )
   )
 })
 


### PR DESCRIPTION
This PR adds `na.omit` to `exploratory_plots.R` to allow inputting matrices with NA values without producing an error