### PR TITLE
Remove BioC versions

### DIFF
--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -218,14 +218,14 @@ if (opt$deploy_app) {
   print("Updating BioC packages as will be required for shinyapps.io deployment")
   
   library(BiocManager)
-  options(repos = BiocManager::repositories(version = '3.17'))
+  options(repos = BiocManager::repositories())
   ood <- data.frame(BiocManager::valid()$out_of_date)
   ood_packages <- ood[grep('bioconductor', ood$Repository), 'Package']
   
   dir.create('libs', showWarnings = FALSE) 
   .libPaths('libs')
   
-  BiocManager::install(ood_packages, version = "3.17", update = TRUE, ask = FALSE, lib = 'libs')
+  BiocManager::install(ood_packages, update = TRUE, ask = FALSE, lib = 'libs')
 }
 
 library(shinyngs)

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -218,14 +218,14 @@ if (opt$deploy_app) {
   print("Updating BioC packages as will be required for shinyapps.io deployment")
   
   library(BiocManager)
-  options(repos = BiocManager::repositories(version = '3.16'))
+  options(repos = BiocManager::repositories(version = '3.17'))
   ood <- data.frame(BiocManager::valid()$out_of_date)
   ood_packages <- ood[grep('bioconductor', ood$Repository), 'Package']
   
   dir.create('libs', showWarnings = FALSE) 
   .libPaths('libs')
   
-  BiocManager::install(ood_packages, version = "3.16", update = TRUE, ask = FALSE, lib = 'libs')
+  BiocManager::install(ood_packages, version = "3.17", update = TRUE, ask = FALSE, lib = 'libs')
 }
 
 library(shinyngs)


### PR DESCRIPTION
This PR fixes the following error:

```
Command error:
  [1] "Updating BioC packages as will be required for shinyapps.io deployment"
  Error: Bioconductor version '3.16' requires R version '4.2'; use `version = '3.17'`
    with R version 4.3; see https://bioconductor.org/install
  Execution halted
```