### PR TITLE
Density fixes

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -253,7 +253,7 @@ ggplotify <- function(plotmatrices, experiment, colorby = NULL, value_type = "ex
   allplotdata <- do.call(rbind, lapply(names(plotmatrices), function(pm) {
     if (value_type == "density") {
       plotdata <- do.call(rbind, lapply(colnames(plotmatrices[[pm]]), function(s) {
-        dens <- density(cond_log2_transform_matrix(plotmatrices[[pm]][, s], rmzeros = TRUE, should_log = should_log))  
+        dens <- density(cond_log2_transform_matrix(plotmatrices[[pm]][, s], rmzeros = TRUE, should_log = should_log), n = 100)
         data.frame(name = s, value = dens$x, density = dens$y)
       }))
     } else {

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -328,7 +328,7 @@ ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette
   }
 
   p <- ggplot(data = plotdata) +
-    geom_area(aes(x = value, y = density, fill = colorby, color = colorby), alpha = 0.4) +
+    geom_area(aes(x = value, y = density, fill = colorby, color = colorby, group = name), alpha = 0.4) +
     scale_fill_manual(name = prettifyVariablename(colorby), values = palette) +
     scale_color_manual(name = prettifyVariablename(colorby), values = palette) +
     ylab("Density") +

--- a/exec/exploratory_plots.R
+++ b/exec/exploratory_plots.R
@@ -157,6 +157,11 @@ assay_files <-
     prettify_names = TRUE
   )
 
+# Valid samples are those with values in the specified sample metadata field
+
+valid_samples <- Filter(function(x) !is.na(x) && x != '' && !is.null(x), sample_metadata[[opt$contrast_variable]])
+sample_metadata <- sample_metadata[sample_metadata[[opt$contrast_variable]] %in% valid_samples, ]
+
 # Expect that 'variance stabilised' expression profiles will already be logged
 
 assay_data <- lapply(assay_files, function(x) {


### PR DESCRIPTION
Making a couple of fixes here:

- In the exploratory plotting function, exclude any samples without a value in the key plotting variable.
- Reduce the granularity of the density calculation to try and improve performance.
- Don't mix samples in the density plot- we were getting spikiness due to conflated samples, which is clearly not desirable.