### PR TITLE
Add prettify to validate_indices

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -789,7 +789,7 @@ read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, s
     }
   }
 
-  matrix_data <- as.matrix(matrix_data[, rownames(sample_metadata)])
+  matrix_data <- na.omit(as.matrix(matrix_data[, rownames(sample_metadata)]))
   
   # Guess the log status
 

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -1271,6 +1271,7 @@ validate_indices <- function(assay_data, index_string) {
     indices <- as.integer(simpleSplit(index_string))
   } else {
     indices <- simpleSplit(index_string)
+    indices <- lapply(indices, prettifyVariablename)
   }
   
   invalid_indices <- indices[!indices %in% c(1:length(assay_data), names(assay_data))]

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -1271,7 +1271,7 @@ validate_indices <- function(assay_data, index_string) {
     indices <- as.integer(simpleSplit(index_string))
   } else {
     indices <- simpleSplit(index_string)
-    indices <- lapply(indices, prettifyVariablename)
+    indices <- unlist(lapply(indices, prettifyVariablename))
   }
   
   invalid_indices <- indices[!indices %in% c(1:length(assay_data), names(assay_data))]

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -1255,6 +1255,7 @@ cond_log2_transform_matrix <- function(matrix_data, should_log = NULL, threshold
 #'
 #' @param assay_data A list containing matrices as assay data.
 #' @param index_string A string that can be a comma-separated list of integers or assay names.
+#' @param prettify_names Boolean. Prettify element names?
 #'
 #' @return A vector of valid indices (either as integers or assay names).
 #'
@@ -1265,13 +1266,15 @@ cond_log2_transform_matrix <- function(matrix_data, should_log = NULL, threshold
 #'
 #' @export
 
-validate_indices <- function(assay_data, index_string) {
+validate_indices <- function(assay_data, index_string, prettify_names = TRUE) {
   
   if (is_valid_positive_integer_vector(index_string)) {
     indices <- as.integer(simpleSplit(index_string))
   } else {
     indices <- simpleSplit(index_string)
-    indices <- unlist(lapply(indices, prettifyVariablename))
+    if (prettify_names) {
+      indices <- unlist(lapply(indices, prettifyVariablename))
+    }
   }
   
   invalid_indices <- indices[!indices %in% c(1:length(assay_data), names(assay_data))]


### PR DESCRIPTION
ATM, a call to `prettifyVariablename` is missing in `validate_indices` while `stringsToNamedVector` contains a prettify. This leads to `exploratory_plots.R` throwing an `error Invalid` assays because it will e.g. compare the strings `raw` and `Raw`. This PR adds the prettify to fix this issue.