### PR TITLE
Fix installation through remotes/devtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
 Remotes:
     cran/d3heatmap,
     pinin4fjords/zhangneurons
+biocViews: Software
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Config/testthat/edition: 3


### PR DESCRIPTION
The devtools/remotes packages use the default repositories when using install_github.

The shinyngs package depends on limma and GSEABase, which are Bioconductor packages.

The devtools/remotes packages can add the corresponding bioconductor repositories to fetch those dependencies as well, but they need to know if the package has bioconductor dependencies.

How do they figure that out?

They check if there is a biocview assigned to the package:

https://github.com/r-lib/remotes/blob/828ba533af96fffbefeb0f9559329cc1da1242e8/R/deps.R#L137

https://github.com/r-lib/remotes/blob/828ba533af96fffbefeb0f9559329cc1da1242e8/install-github.R#L6095

This PR adds a generic biocviews to the description. It does not harm and it helps the remotes package to figure out that it has to add the bioconductor repositories.

Thanks for your work on this!