### PR TITLE
Add WebAssembly support workflow for shinylive compatibility

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,0 +1,26 @@
+name: Release WebAssembly Assets
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build R WebAssembly
+        uses: r-wasm/actions/build-rwasm@v2
+        with:
+          packages: |
+            shinyngs
+          cran: true
+          bioc: true
+          github: true
+          
+      - name: Release File System Image
+        uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
+        with:
+          release_tag: ${{ github.event.release.tag_name }}
+          image_name: shinyngs-wasm 

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -14,9 +14,7 @@ jobs:
         uses: r-wasm/actions/build-rwasm@v2
         with:
           packages: |
-            shinyngs
-          cran: true
-          bioc: true
+            github::pinin4fjords/shinyngs@${{ github.event.release.tag_name }}
           github: true
           
       - name: Release File System Image

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,24 +1,21 @@
-name: Release WebAssembly Assets
+# Workflow derived from https://github.com/r-wasm/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
 on:
   release:
-    types: [published]
+    # Must republish release to update assets
+    types: [ published ]
+
+name: Build and deploy wasm R package image
 
 jobs:
-  build-wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Build R WebAssembly
-        uses: r-wasm/actions/build-rwasm@v2
-        with:
-          packages: |
-            github::pinin4fjords/shinyngs@${{ github.event.release.tag_name }}
-          github: true
-          
-      - name: Release File System Image
-        uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
-        with:
-          release_tag: ${{ github.event.release.tag_name }}
-          image_name: shinyngs-wasm 
+  release-file-system-image:
+    uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
+    with:
+      packages: |
+        github::pinin4fjords/shinyngs@${{ github.event.release.tag_name }}
+      image_name: shinyngs-wasm
+    permissions:
+      # For publishing artifact files to the release
+      contents: write
+      # To download GitHub Packages within action 

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -14,7 +14,6 @@ jobs:
     with:
       packages: |
         github::pinin4fjords/shinyngs@${{ github.event.release.tag_name }}
-      image_name: shinyngs-wasm
     permissions:
       # For publishing artifact files to the release
       contents: write

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,24 +1,17 @@
 # Workflow derived from https://github.com/r-wasm/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-
 on:
   release:
     # Must republish release to update assets
     types: [ published ]
-
-permissions:
-  contents: write
-  repository-projects: read
 
 name: Build and deploy wasm R package image
 
 jobs:
   release-file-system-image:
     uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
-    with:
-      packages: |
-        github::pinin4fjords/shinyngs@${{ github.event.release.tag_name }}
     permissions:
       # For publishing artifact files to the release
       contents: write
-      # To download GitHub Packages within action 
+      # To download GitHub Packages within action
+      repository-projects: read

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -6,6 +6,10 @@ on:
     # Must republish release to update assets
     types: [ published ]
 
+permissions:
+  contents: write
+  repository-projects: read
+
 name: Build and deploy wasm R package image
 
 jobs:


### PR DESCRIPTION
# Add WebAssembly Support for shinylive

This PR adds WebAssembly support to the shinyngs package, enabling it to work with shinylive for browser-based execution.

## Changes
- Added `.github/workflows/release-wasm.yml` workflow that:
  - Builds the package and dependencies for WebAssembly
  - Creates a file system image containing the R package library
  - Attaches WebAssembly assets to GitHub releases

## Purpose
Currently, when using shinyngs with shinylive, the following error occurs:

```
rror in `get_github_wasm_assets()`:
! Can't find WebAssembly binary assets for github::pinin4fjords/shinyngs@v2.2.0
! Ensure WebAssembly binary assets are associated with the GitHub release "v2.2.0".
ℹ WebAssembly binary assets can be built on release using GitHub Actions: <https://github.com/r-wasm/actions>
ℹ Alternatively, install a CRAN version of this package to use the default Wasm binary repository.
Backtrace:
    ▆
 1. └─shinylive::export("/app", "/app/www")
 2.   └─shinylive:::download_wasm_packages(...)
 3.     └─base::lapply(...)
 4.       └─shinylive (local) FUN(X[[i]], ...)
 5.         └─shinylive:::prepare_wasm_metadata(pkg, prev_meta)
 6.           └─shinylive:::get_github_wasm_assets(desc)
 7.             └─cli::cli_abort(...)
 8.               └─rlang::abort(...)
Execution halted
```