### PR TITLE
Support literal strings for `limma::makeContrasts`

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -958,7 +958,9 @@ read_contrasts <-
       formula <- NA
       string <- NA
       if (!is.null(x$formula)) {
-        terms <- trimws(unlist(strsplit(gsub("~", "", x$formula), "\\+")))
+        formula_obj <- as.formula(x$formula)
+        terms_obj <- terms(formula_obj)
+        terms <- attr(terms_obj, "term.labels")
         blocking_vars <- setdiff(terms, x$comparison[1])
         formula <- x$formula
         string <- x$string

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -956,10 +956,12 @@ read_contrasts <-
       # Extract blocking factors from 'formula' if available
       blocking <- NA
       formula <- NA
+      string <- NA
       if (!is.null(x$formula)) {
         terms <- trimws(unlist(strsplit(gsub("~", "", x$formula), "\\+")))
         blocking_vars <- setdiff(terms, x$comparison[1])
         formula <- x$formula
+        string <- x$string
         if (length(blocking_vars) > 0) blocking <- paste(blocking_vars, collapse = ";")
       } else if (!is.null(x$blocking_factors)) {
         blocking <- paste(x$blocking_factors, collapse = ";")
@@ -972,6 +974,7 @@ read_contrasts <-
         target = x$comparison[3],
         blocking = blocking,
         formula = formula,
+        string = string,
         stringsAsFactors = FALSE
       )
     }))

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -963,7 +963,7 @@ read_contrasts <-
         terms <- attr(terms_obj, "term.labels")
         blocking_vars <- setdiff(terms, x$comparison[1])
         formula <- x$formula
-        string <- x$string
+        string <- if (!is.null(x$string)) x$string else NA
         if (length(blocking_vars) > 0) blocking <- paste(blocking_vars, collapse = ";")
       } else if (!is.null(x$blocking_factors)) {
         blocking <- paste(x$blocking_factors, collapse = ";")

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -956,14 +956,14 @@ read_contrasts <-
       # Extract blocking factors from 'formula' if available
       blocking <- NA
       formula <- NA
-      string <- NA
+      make_contrasts_str <- NA
       if (!is.null(x$formula)) {
         formula_obj <- as.formula(x$formula)
         terms_obj <- terms(formula_obj)
         terms <- attr(terms_obj, "term.labels")
         blocking_vars <- setdiff(terms, x$comparison[1])
         formula <- x$formula
-        string <- if (!is.null(x$string)) x$string else NA
+        make_contrasts_str <- if (!is.null(x$make_contrasts_str)) x$make_contrasts_str else NA
         if (length(blocking_vars) > 0) blocking <- paste(blocking_vars, collapse = ";")
       } else if (!is.null(x$blocking_factors)) {
         blocking <- paste(x$blocking_factors, collapse = ";")
@@ -976,7 +976,7 @@ read_contrasts <-
         target = x$comparison[3],
         blocking = blocking,
         formula = formula,
-        string = string,
+        make_contrasts_str = make_contrasts_str,
         stringsAsFactors = FALSE
       )
     }))

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -963,7 +963,7 @@ read_contrasts <-
         terms <- attr(terms_obj, "term.labels")
         blocking_vars <- setdiff(terms, x$comparison[1])
         formula <- x$formula
-        make_contrasts_str <- if (!is.null(x$make_contrasts_str)) x$make_contrasts_str else NA
+        if (!is.null(x$make_contrasts_str)) make_contrasts_str <- x$make_contrasts_str
         if (length(blocking_vars) > 0) blocking <- paste(blocking_vars, collapse = ";")
       } else if (!is.null(x$blocking_factors)) {
         blocking <- paste(x$blocking_factors, collapse = ";")


### PR DESCRIPTION
Two changes are introduced here:
1. Support literal strings for `limma::makeContrasts`
2. Minor changes to how blocking variables are obtained with `setdiff` as the previous method would crash if the formula contained a 0. 