### PR TITLE
Fix CI issues by pinning R version

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -28,6 +28,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: '4.4.0'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Transcritome Analysis Resource
 Tool](https://github.com/jminnier/STARTapp) (START), though it was
 probably developed at the same time as that work.
 
+
 # Examples
 
 ## Data structure

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Transcritome Analysis Resource
 Tool](https://github.com/jminnier/STARTapp) (START), though it was
 probably developed at the same time as that work.
 
-
 # Examples
 
 ## Data structure


### PR DESCRIPTION
Something to do with the object handling in R 4.5 is breaking things with the classes defined here. Pin the R back for now.