### PR TITLE
Refactor contrast parsing to support either "comparison + blocking_factors" or "formula + make_contrasts_str"

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -961,6 +961,11 @@ read_contrasts <-
       stringsAsFactors = FALSE
     )
 
+    # A contrast can be defined in two ways:
+    #
+    # 1 . Specifying a column in the sample sheet, and two values from that column which define two groups of samples to compare. Tools using a contrast defined in this way would need to generate a model and contrast using that information.
+    # 2. Specifying the formula and contrast string explicitly. Tools using those contrasts can then pass these directly to function of suites such as DESeq2. 
+
     if (!is.null(x$comparison)) {
       if (!is.null(x$formula) || !is.null(x$make_contrasts_str)) {
         stop(sprintf("Contrast id '%s' with 'comparison' must not have 'formula' or 'make_contrasts_str'.", x$id))

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -29,3 +29,57 @@ test_that("nlines works", {
   test_html <- "<input type='text' id='myid' value='foo' style='display: none;'>"
   expect_equal(as.character(hiddenInput("myid", "foo")), test_html)
 })
+
+# read_contrasts()
+
+test_that("read_contrasts parses YAML correctly", {
+  samples <- data.frame(
+    sample = c("Sample1", "Sample7", "Sample13", "Sample19", "Sample16"),
+    genotype = c("WT", "WT", "KO", "KO", "KO"),
+    treatment = c("Control", "Treated", "Control", "Treated", "Control"),
+    time = c(1, 1, 1, 1, 16),
+    batch = c("b1", "b1", "b1", "b1", "b3"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: treatment_mCherry_hND6_
+    comparison: [\"treatment\", \"Control\", \"Treated\"]
+  - id: treatment_mCherry_hND6_batch
+    comparison: [\"treatment\", \"Control\", \"Treated\"]
+    blocking_factors: [\"batch\"]
+  - id: treatment_plus_genotype
+    formula: \"~ treatment + genotype\"
+    make_contrasts_str: \"treatmentTreated\"
+  - id: interaction_genotype_treatment
+    formula: \"~ genotype * treatment\"
+    make_contrasts_str: \"genotypeWT.treatmentTreated\"
+  - id: full_model_with_interactions
+    formula: \"~ genotype * treatment * time\"
+    make_contrasts_str: \"genotypeWT.treatmentTreated.time\"
+"
+
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+
+  contrasts <- read_contrasts(yaml_file, samples)
+
+  # Test basic structure
+  expect_true(is.data.frame(contrasts))
+  expect_equal(nrow(contrasts), 5)
+  expect_true(all(c("id", "variable", "reference", "target", "blocking", "formula", "make_contrasts_str") %in% colnames(contrasts)))
+
+  # Test specific rows
+  expect_equal(contrasts$variable[1], "treatment")
+  expect_equal(contrasts$reference[1], "Control")
+  expect_equal(contrasts$target[1], "Treated")
+  expect_true(is.na(contrasts$make_contrasts_str[1]))
+
+  expect_equal(contrasts$blocking[2], "batch")
+  expect_equal(contrasts$formula[3], "~ treatment + genotype")
+  expect_equal(contrasts$make_contrasts_str[4], "genotypeWT.treatmentTreated")
+  expect_equal(contrasts$make_contrasts_str[5], "genotypeWT.treatmentTreated.time")
+
+  unlink(yaml_file)
+})


### PR DESCRIPTION
`validatefomcomponents` always required a required comparison (variable, reference, target) even when a formula and make_contrasts_str were supplied. This was because the internal TSV structure expected variable, reference, and target column. 

The changes introduced here aim to:
1. Remove automatic blocking inference from formula
2. The YAML contrast must specify blocking_factors if needed; otherwise blocking is NA.
3. variable, reference, and target are validated only when comparison is provided, not when formula is used.
4. Add a test case for YAML with testthat. 