### PR TITLE
Add installation instructions to the app.R script

### DIFF
--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -348,7 +348,7 @@ writeLines(
 )
 
 # If deployment has been indicated, try to do that. Needs SHINYAPPS_SECRET AND
-# SHINYAPPS_TOKEN to be set in the evironment
+# SHINYAPPS_TOKEN to be set in the environment
 
 if (opt$deploy_app) {
   library(rsconnect)

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -336,6 +336,8 @@ dir.create(opt$output_directory, showWarnings = FALSE)
 saveRDS(myesel, file = file.path(opt$output_directory, "data.rds"))
 writeLines(
   c(
+    '# install.packages(c("remotes", "BiocManager", "markdown"))',
+    '# remotes::install_github("pinin4fjords/shinyngs")',
     "library(shinyngs)",
     "library(markdown)",
     'esel <- readRDS("data.rds")',

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -336,8 +336,8 @@ dir.create(opt$output_directory, showWarnings = FALSE)
 saveRDS(myesel, file = file.path(opt$output_directory, "data.rds"))
 writeLines(
   c(
-    '# install.packages(c("remotes", "BiocManager", "markdown"))',
-    '# remotes::install_github("pinin4fjords/shinyngs")',
+    '# See installation instructions at:',
+    '# https://github.com/pinin4fjords/shinyngs?tab=readme-ov-file#installation',
     "library(shinyngs)",
     "library(markdown)",
     'esel <- readRDS("data.rds")',


### PR DESCRIPTION
If the output directory is given to a user who doesn't have shinyngs installed, having these instructions helps a lot.

This PR comes from the nf-core hackathon

@suzannejin
@susijo