### PR TITLE
Accept spaces in variables in metadata

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -827,7 +827,7 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
       read.delim(
         filename,
         sep = sep,
-        check.names = FALSE,
+        check.names = TRUE,
         header = TRUE,
         stringsAsFactors = stringsAsFactors
       )
@@ -845,6 +845,8 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
           filename
         )
       )
+    } else {
+      id_col <- make.names(id_col)
     }
 
     metadata <- metadata[match(unique(metadata[[id_col]]), metadata[[id_col]]), ]


### PR DESCRIPTION
The pipeline currently fails if one of the factor levels has spaces. This small change should allow spaces in variable names and make the Quarto report not fail.

Closes https://github.com/nf-core/differentialabundance/issues/682 in relation to [make_contrasts_str cannot deal with spaces in variable names](https://github.com/nf-core/differentialabundance/issues/670)