### PR TITLE
Add validation for formula-based contrasts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     plotly (>= 4.3.4),
     plyr,
     RColorBrewer,
+    reformulas,
     reshape2,
     scatterplot3d,
     shiny,

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -885,6 +885,59 @@ checkListIsSubset <- function(test_list,
   TRUE
 }
 
+#' Remove random effects from a model formula
+#'
+#' @param formula_string Formula string that may contain random effects
+#'
+#' @return output Fixed-effects-only formula
+fixedEffectsFormula <- function(formula_string) {
+  reformulas::nobars(as.formula(formula_string))
+}
+
+#' Build a model matrix from the fixed-effects part of a formula
+#'
+#' @param formula_string Formula string that may contain random effects
+#' @param samples Data frame of sample information
+#'
+#' @return output Model matrix for the fixed-effects formula
+fixedEffectsModelMatrix <- function(formula_string, samples) {
+  model.matrix(fixedEffectsFormula(formula_string), data = samples)
+}
+
+#' Validate a formula-based contrast string against fixed-effect coefficients
+#'
+#' @param contrast_id Contrast identifier
+#' @param contrast_formula Formula string used for the contrast
+#' @param contrast_string Contrast string to validate
+#' @param samples Data frame of sample information
+#'
+#' @return output Returns TRUE if validation passes
+validateFormulaBasedContrast <- function(contrast_id,
+                                         contrast_formula,
+                                         contrast_string,
+                                         samples) {
+  model_coefficients <- make.names(
+    colnames(fixedEffectsModelMatrix(contrast_formula, samples)),
+    unique = TRUE
+  )
+
+  tryCatch(
+    limma::makeContrasts(contrasts = contrast_string, levels = model_coefficients),
+    error = function(e) {
+      stop(
+        paste0(
+          "Contrast id '", contrast_id, "' has invalid make_contrasts_str '", contrast_string,
+          "' for formula '", contrast_formula, "'. ",
+          "Available coefficient names for make_contrasts_str: ",
+          paste(model_coefficients, collapse = ", "),
+          "."
+        ),
+        call. = FALSE
+      )
+    }
+  )
+}
+
 
 #' Read and validate a contrasts file against sample metadata
 #'
@@ -922,48 +975,6 @@ read_contrasts <-
           target_column = "target",
           blocking_column = "blocking",
           convert_to_list = FALSE) {
-
-  fixed_effects_formula <- function(formula_string) {
-    fixed_formula <- gsub("\\([^()]*\\|[^()]*\\)", "", formula_string)
-    fixed_formula <- gsub("\\s+", " ", fixed_formula)
-    fixed_formula <- gsub("\\+\\s*\\+", "+", fixed_formula)
-    fixed_formula <- gsub("~\\s*\\+", "~", fixed_formula)
-    fixed_formula <- gsub("\\+\\s*$", "", fixed_formula)
-    fixed_formula <- trimws(fixed_formula)
-
-    if (identical(fixed_formula, "~") || identical(fixed_formula, "")) {
-      fixed_formula <- "~ 1"
-    }
-
-    fixed_formula
-  }
-
-  validate_formula_based_contrast <- function(contrast_id,
-                                              contrast_formula,
-                                              contrast_string,
-                                              samples) {
-    contrast_formula <- fixed_effects_formula(contrast_formula)
-    model_coefficients <- make.names(
-      colnames(model.matrix(as.formula(contrast_formula), data = samples)),
-      unique = TRUE
-    )
-
-    tryCatch(
-      limma::makeContrasts(contrasts = contrast_string, levels = model_coefficients),
-      error = function(e) {
-        stop(
-          paste0(
-            "Contrast id '", contrast_id, "' has invalid make_contrasts_str '", contrast_string,
-            "' for formula '", contrast_formula, "'. ",
-            "Available coefficient names derived from the formula: ",
-            paste(model_coefficients, collapse = ", "),
-            "."
-          ),
-          call. = FALSE
-        )
-      }
-    )
-  }
 
   # Read the contrasts depending on the file format (CSV or YAML)
   if (grepl("\\.csv$", filename)) {
@@ -1066,35 +1077,42 @@ read_contrasts <-
 
     # Extract design matrix columns from contrasts: the variable column plus any blocking factors.
     # For formula-based contrasts, extract variables from the formula itself.
-    formula_vars <- character(0)
     if ("formula" %in% colnames(contrasts) && !is.na(contrasts$formula[i])) {
-      formula_vars <- all.vars(as.formula(fixed_effects_formula(contrasts$formula[i])))
-    }
+      design_cols <- unique(all.vars(as.formula(contrasts$formula[i])))
+      success <- checkListIsSubset(design_cols, colnames(samples), "formula variables", "sample metadata")
+      design_matrix <- samples[, design_cols, drop = FALSE]
 
-    design_cols <- unique(na.omit(c(contrasts[[variable_column]][i], blocking_vars, formula_vars)))
-    design_matrix <- samples[, design_cols, drop = FALSE]
-    
-    # Ensure there are no NA values in the design matrix.
-    if (any(is.na(design_matrix))) {
-      stop("NA values found in one or more design matrix columns.")
-    }
-    
-    # Check that the design matrix is full rank.
-    mm <- model.matrix(~ . - 1, data = design_matrix)
-    if (qr(mm)$rank < ncol(mm)) {
-      stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
-    }
-    
-    if ("formula" %in% colnames(contrasts) &&
-        "make_contrasts_str" %in% colnames(contrasts) &&
-        !is.na(contrasts$formula[i]) &&
-        !is.na(contrasts$make_contrasts_str[i])) {
-      validate_formula_based_contrast(
+      # Ensure there are no NA values in the design matrix.
+      if (any(is.na(design_matrix))) {
+        stop("NA values found in one or more design matrix columns.")
+      }
+
+      # Check that the design matrix is full rank.
+      mm <- fixedEffectsModelMatrix(contrasts$formula[i], samples)
+      if (qr(mm)$rank < ncol(mm)) {
+        stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
+      }
+
+      validateFormulaBasedContrast(
         contrast_id = contrasts[i, "id"],
         contrast_formula = contrasts$formula[i],
         contrast_string = contrasts$make_contrasts_str[i],
         samples = samples
       )
+    } else {
+      design_cols <- unique(na.omit(c(contrasts[[variable_column]][i], blocking_vars)))
+      design_matrix <- samples[, design_cols, drop = FALSE]
+
+      # Ensure there are no NA values in the design matrix.
+      if (any(is.na(design_matrix))) {
+        stop("NA values found in one or more design matrix columns.")
+      }
+
+      # Check that the design matrix is full rank.
+      mm <- model.matrix(~ . - 1, data = design_matrix)
+      if (qr(mm)$rank < ncol(mm)) {
+        stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
+      }
     }
 
     # Warn about continuous covariates in the design matrix columns.
@@ -1523,4 +1541,3 @@ cond_log2_transform_assays <- function(assay_data, log2_assays, threshold = 30, 
 
   return(assay_data)
 }
-

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -909,17 +909,19 @@ fixedEffectsModelMatrix <- function(formula_string, samples) {
 #' @param contrast_id Contrast identifier
 #' @param contrast_formula Formula string used for the contrast
 #' @param contrast_string Contrast string to validate
+#' @param model_matrix Optional precomputed model matrix for the fixed-effects formula
 #' @param samples Data frame of sample information
 #'
 #' @return output Returns TRUE if validation passes
 validateFormulaBasedContrast <- function(contrast_id,
                                          contrast_formula,
                                          contrast_string,
+                                         model_matrix = NULL,
                                          samples) {
-  model_coefficients <- make.names(
-    colnames(fixedEffectsModelMatrix(contrast_formula, samples)),
-    unique = TRUE
-  )
+  if (is.null(model_matrix)) {
+    model_matrix <- fixedEffectsModelMatrix(contrast_formula, samples)
+  }
+  model_coefficients <- make.names(colnames(model_matrix), unique = TRUE)
 
   tryCatch(
     limma::makeContrasts(contrasts = contrast_string, levels = model_coefficients),
@@ -1118,6 +1120,7 @@ read_contrasts <-
           contrast_id = contrasts[i, "id"],
           contrast_formula = contrasts$formula[i],
           contrast_string = contrasts$make_contrasts_str[i],
+          model_matrix = mm,
           samples = contrast_samples
         )
       } else {

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -1011,6 +1011,8 @@ read_contrasts <-
       id = x$id,
       variable = NA, reference = NA, target = NA,
       blocking = NA,
+      exclude_samples_col = NA,
+      exclude_samples_values = NA,
       formula = NA,
       make_contrasts_str = NA,
       stringsAsFactors = FALSE
@@ -1053,6 +1055,15 @@ read_contrasts <-
       stop(sprintf("Contrast id '%s' must provide either 'comparison' or 'formula' + 'make_contrasts_str'.", x$id))
     }
 
+    if (!is.null(x$exclude_samples_col) || !is.null(x$exclude_samples_values)) {
+      if (is.null(x$exclude_samples_col) || is.null(x$exclude_samples_values)) {
+        stop(sprintf("Contrast id '%s' must provide both 'exclude_samples_col' and 'exclude_samples_values'.", x$id))
+      }
+
+      row$exclude_samples_col <- x$exclude_samples_col
+      row$exclude_samples_values <- paste(x$exclude_samples_values, collapse = ";")
+    }
+
     row
   }))
     if (any(duplicated(contrasts$id))) {
@@ -1073,10 +1084,17 @@ read_contrasts <-
   if (length(blocking) > 0) {
     success <- checkListIsSubset(blocking, colnames(samples), "blocking variables", "sample metadata")
   }
+  if ("exclude_samples_col" %in% colnames(contrasts)) {
+    exclude_cols <- na.omit(contrasts$exclude_samples_col)
+    if (length(exclude_cols) > 0) {
+      success <- checkListIsSubset(exclude_cols, colnames(samples), "exclude sample columns", "sample metadata")
+    }
+  }
 
   # Ensure reference and target are valid for their variable
   for (i in 1:nrow(contrasts)) {
     blocking_vars <- simpleSplit(contrasts[[blocking_column]][i], ";")
+    design_cols <- character(0)
 
     # Extract design matrix columns from contrasts: the variable column plus any blocking factors.
     # For formula-based contrasts, extract variables from the formula itself.
@@ -1094,18 +1112,7 @@ read_contrasts <-
       if ("formula" %in% colnames(contrasts) && !is.na(contrasts$formula[i])) {
         design_cols <- unique(all.vars(as.formula(contrasts$formula[i])))
         success <- checkListIsSubset(design_cols, colnames(samples), "formula variables", "sample metadata")
-        design_matrix <- contrast_samples[, design_cols, drop = FALSE]
-
-        # Ensure there are no NA values in the design matrix.
-        if (any(is.na(design_matrix))) {
-          stop("NA values found in one or more design matrix columns.")
-        }
-
-        # Check that the design matrix is full rank.
         mm <- fixedEffectsModelMatrix(contrasts$formula[i], contrast_samples)
-        if (qr(mm)$rank < ncol(mm)) {
-          stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
-        }
 
         validateFormulaBasedContrast(
           contrast_id = contrasts[i, "id"],
@@ -1115,18 +1122,19 @@ read_contrasts <-
         )
       } else {
         design_cols <- unique(na.omit(c(contrasts[[variable_column]][i], blocking_vars)))
-        design_matrix <- contrast_samples[, design_cols, drop = FALSE]
+        mm <- model.matrix(~ . - 1, data = contrast_samples[, design_cols, drop = FALSE])
+      }
 
-        # Ensure there are no NA values in the design matrix.
-        if (any(is.na(design_matrix))) {
-          stop("NA values found in one or more design matrix columns.")
-        }
+      design_matrix <- contrast_samples[, design_cols, drop = FALSE]
 
-        # Check that the design matrix is full rank.
-        mm <- model.matrix(~ . - 1, data = design_matrix)
-        if (qr(mm)$rank < ncol(mm)) {
-          stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
-        }
+      # Ensure there are no NA values in the design matrix.
+      if (any(is.na(design_matrix))) {
+        stop("NA values found in one or more design matrix columns.")
+      }
+
+      # Check that the design matrix is full rank.
+      if (qr(mm)$rank < ncol(mm)) {
+        stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
       }
 
       # Warn about continuous covariates in the design matrix columns.

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -827,7 +827,7 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
       read.delim(
         filename,
         sep = sep,
-        check.names = FALSE,
+        check.names = TRUE,
         header = TRUE,
         stringsAsFactors = stringsAsFactors
       )
@@ -845,6 +845,8 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
           filename
         )
       )
+    } else {
+      id_col <- make.names(id_col)
     }
 
     metadata <- metadata[match(unique(metadata[[id_col]]), metadata[[id_col]]), ]

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -925,6 +925,48 @@ read_contrasts <-
           blocking_column = "blocking",
           convert_to_list = FALSE) {
 
+  fixed_effects_formula <- function(formula_string) {
+    fixed_formula <- gsub("\\([^()]*\\|[^()]*\\)", "", formula_string)
+    fixed_formula <- gsub("\\s+", " ", fixed_formula)
+    fixed_formula <- gsub("\\+\\s*\\+", "+", fixed_formula)
+    fixed_formula <- gsub("~\\s*\\+", "~", fixed_formula)
+    fixed_formula <- gsub("\\+\\s*$", "", fixed_formula)
+    fixed_formula <- trimws(fixed_formula)
+
+    if (identical(fixed_formula, "~") || identical(fixed_formula, "")) {
+      fixed_formula <- "~ 1"
+    }
+
+    fixed_formula
+  }
+
+  validate_formula_based_contrast <- function(contrast_id,
+                                              contrast_formula,
+                                              contrast_string,
+                                              samples) {
+    contrast_formula <- fixed_effects_formula(contrast_formula)
+    model_coefficients <- make.names(
+      colnames(model.matrix(as.formula(contrast_formula), data = samples)),
+      unique = TRUE
+    )
+
+    tryCatch(
+      limma::makeContrasts(contrasts = contrast_string, levels = model_coefficients),
+      error = function(e) {
+        stop(
+          paste0(
+            "Contrast id '", contrast_id, "' has invalid make_contrasts_str '", contrast_string,
+            "' for formula '", contrast_formula, "'. ",
+            "Available coefficient names derived from the formula: ",
+            paste(model_coefficients, collapse = ", "),
+            "."
+          ),
+          call. = FALSE
+        )
+      }
+    )
+  }
+
   # Read the contrasts depending on the file format (CSV or YAML)
   if (grepl("\\.csv$", filename)) {
     contrasts <- read_metadata(filename)
@@ -1028,7 +1070,7 @@ read_contrasts <-
     # For formula-based contrasts, extract variables from the formula itself.
     formula_vars <- character(0)
     if ("formula" %in% colnames(contrasts) && !is.na(contrasts$formula[i])) {
-      formula_vars <- all.vars(as.formula(contrasts$formula[i]))
+      formula_vars <- all.vars(as.formula(fixed_effects_formula(contrasts$formula[i])))
     }
 
     design_cols <- unique(na.omit(c(contrasts[[variable_column]][i], blocking_vars, formula_vars)))
@@ -1045,6 +1087,18 @@ read_contrasts <-
       stop(paste("Design matrix is not full rank.", "Model matrix columns:", paste(colnames(mm), collapse = ", "), "\n"))
     }
     
+    if ("formula" %in% colnames(contrasts) &&
+        "make_contrasts_str" %in% colnames(contrasts) &&
+        !is.na(contrasts$formula[i]) &&
+        !is.na(contrasts$make_contrasts_str[i])) {
+      validate_formula_based_contrast(
+        contrast_id = contrasts[i, "id"],
+        contrast_formula = contrasts$formula[i],
+        contrast_string = contrasts$make_contrasts_str[i],
+        samples = samples
+      )
+    }
+
     # Warn about continuous covariates in the design matrix columns.
     for (col in design_cols) {
       if (is.numeric(samples[[col]])) {

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -827,7 +827,7 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
       read.delim(
         filename,
         sep = sep,
-        check.names = TRUE,
+        check.names = FALSE,
         header = TRUE,
         stringsAsFactors = stringsAsFactors
       )
@@ -845,8 +845,6 @@ read_metadata <- function(filename, id_col = NULL, sep = NULL, stringsAsFactors 
           filename
         )
       )
-    } else {
-      id_col <- make.names(id_col)
     }
 
     metadata <- metadata[match(unique(metadata[[id_col]]), metadata[[id_col]]), ]

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -126,3 +126,33 @@ contrasts:
 
   unlink(yaml_file)
 })
+
+test_that("read_contrasts reports a descriptive error for realistic invalid formula contrast strings", {
+  samples <- data.frame(
+    sample = c("Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6", "Sample7", "Sample8"),
+    genotype = c("WT", "WT", "WT", "WT", "KO", "KO", "KO", "KO"),
+    treatment = c("Control", "Control", "Treated", "Treated", "Control", "Control", "Treated", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: invalid_formula_contrast
+    formula: \"~ genotype * treatment\"
+    make_contrasts_str: \"genotypeWT:treatmentTreated\"
+"
+
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+
+  expect_error(
+    read_contrasts(yaml_file, samples),
+    paste(
+      "Contrast id 'invalid_formula_contrast' has invalid make_contrasts_str 'genotypeWT:treatmentTreated'",
+      "for formula '~ genotype \\* treatment'. Available coefficient names for make_contrasts_str:",
+      "Intercept, genotypeWT, treatmentTreated, genotypeWT.treatmentTreated\\."
+    )
+  )
+
+  unlink(yaml_file)
+})

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -150,7 +150,7 @@ contrasts:
     paste(
       "Contrast id 'invalid_formula_contrast' has invalid make_contrasts_str 'genotypeWT.treatmenttreated'",
       "for formula '~ genotype \\* treatment'. Available coefficient names for make_contrasts_str:",
-      "Intercept, genotypeWT, treatmentTreated, genotypeWT.treatmentTreated\\."
+      "X\\.Intercept\\., genotypeWT, treatmentTreated, genotypeWT\\.treatmentTreated\\."
     )
   )
 

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -34,11 +34,11 @@ test_that("nlines works", {
 
 test_that("read_contrasts parses YAML correctly", {
   samples <- data.frame(
-    sample = c("Sample1", "Sample7", "Sample13", "Sample19", "Sample16"),
-    genotype = c("WT", "WT", "KO", "KO", "KO"),
-    treatment = c("Control", "Treated", "Control", "Treated", "Control"),
-    time = c(1, 1, 1, 1, 16),
-    batch = c("b1", "b1", "b1", "b1", "b3"),
+    sample = c("Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6", "Sample7", "Sample8"),
+    genotype = c("WT", "WT", "WT", "WT", "KO", "KO", "KO", "KO"),
+    treatment = c("Control", "Control", "Treated", "Treated", "Control", "Control", "Treated", "Treated"),
+    time = c(1, 16, 1, 16, 1, 16, 1, 16),
+    batch = c("b1", "b2", "b1", "b2", "b1", "b2", "b1", "b2"),
     stringsAsFactors = FALSE
   )
 
@@ -88,11 +88,11 @@ contrasts:
 
 test_that("read_contrasts parses YAML correctly using only formula based contrasts", {
   samples <- data.frame(
-    sample = c("Sample1", "Sample7", "Sample13", "Sample19", "Sample16"),
-    genotype = c("WT", "WT", "KO", "KO", "KO"),
-    treatment = c("Control", "Treated", "Control", "Treated", "Control"),
-    time = c(1, 1, 1, 1, 16),
-    batch = c("b1", "b1", "b1", "b1", "b3"),
+    sample = c("Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6", "Sample7", "Sample8"),
+    genotype = c("WT", "WT", "WT", "WT", "KO", "KO", "KO", "KO"),
+    treatment = c("Control", "Control", "Treated", "Treated", "Control", "Control", "Treated", "Treated"),
+    time = c(1, 16, 1, 16, 1, 16, 1, 16),
+    batch = c("b1", "b2", "b1", "b2", "b1", "b2", "b1", "b2"),
     stringsAsFactors = FALSE
   )
 

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -139,7 +139,7 @@ test_that("read_contrasts reports a descriptive error for realistic invalid form
 contrasts:
   - id: invalid_formula_contrast
     formula: \"~ genotype * treatment\"
-    make_contrasts_str: \"genotypeWT:treatmentTreated\"
+    make_contrasts_str: \"genotypeWT.treatmenttreated\"
 "
 
   yaml_file <- tempfile(fileext = ".yaml")
@@ -148,7 +148,7 @@ contrasts:
   expect_error(
     read_contrasts(yaml_file, samples),
     paste(
-      "Contrast id 'invalid_formula_contrast' has invalid make_contrasts_str 'genotypeWT:treatmentTreated'",
+      "Contrast id 'invalid_formula_contrast' has invalid make_contrasts_str 'genotypeWT.treatmenttreated'",
       "for formula '~ genotype \\* treatment'. Available coefficient names for make_contrasts_str:",
       "Intercept, genotypeWT, treatmentTreated, genotypeWT.treatmentTreated\\."
     )


### PR DESCRIPTION
As discussed in https://github.com/nf-core/differentialabundance/issues/670:
> It would be great to detect issues in the contrasts early, i.e. in the VALIDATOR, and with a clear error message (stating which coefficient names are available). At least for DREAM, I have to wait >30 min to get an error otherwise.

This PR adds a validation for formula-based contrasts, checking against the model matrix to ensure early on that the `make_contrasts_str` is valid.