### PR TITLE
Don't filter out NA values in matrix

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -801,7 +801,7 @@ read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, s
     }
   }
 
-  na.omit(as.matrix(matrix_data[, rownames(sample_metadata)]))
+  as.matrix(matrix_data[, rownames(sample_metadata)])
 }
 
 #' Read a metadata file


### PR DESCRIPTION
As reported in https://github.com/nf-core/differentialabundance/issues/695:

> ## Description of the bug
> I'm running the pipeline with the generic_matrix profile (see https://github.com/nf-core/differentialabundance/pull/692).
> My data is normally distributed, and contains some NA values.
> Filtering is set to
> ```
> filtering_min_abundance: false
> filtering_min_samples_not_na: 10
> ```
> however, features with any NA are removed, even if there are at least 10 valid observations. What's even weirder is that this already happens in the VALIDATOR process and not in CUSTOM_MATRIXFILTER.

--> This change would allow the filtering of NA values to be handled in the `CUSTOM_MATRIXFILTER` module