### PR TITLE
Preload htmlwidget deps in prepareApp to fix reverse-proxy races

### DIFF
--- a/R/apps.R
+++ b/R/apps.R
@@ -111,7 +111,32 @@ prepareApp <- function(type, eselist, ui_only = FALSE, ...) {
     app <- simpleApp(eselist, type, ui_only = ui_only, ...)
   }
 
+  # Preload htmlwidget JS/CSS as <script>/<link> tags in the initial HTML so
+  # plugins like jQuery DataTables are attached at page-load. Otherwise
+  # htmlwidgets 1.6.4's shinyBinding.renderValue calls the synchronous
+  # Shiny.renderDependencies() and immediately runs bindingDef.renderValue
+  # (e.g. $().DataTable). The plugin <script> is appended to <head> but not
+  # awaited. Locally that's a <1ms race; behind a reverse proxy (Seqera
+  # Studios, Shiny Server behind nginx, etc.) it consistently loses, surfacing
+  # as "$table.DataTable is not a function" and empty plots/tables.
+  app$ui <- htmltools::attachDependencies(
+    app$ui,
+    htmlwidget_preload_deps(),
+    append = TRUE
+  )
+
   app
+}
+
+# Dependencies for every htmlwidget type used anywhere in shinyngs, so they
+# load as blocking <script>/<link> tags in the initial HTML rather than lazily
+# via WebSocket-delivered dep messages. See prepareApp() for rationale.
+htmlwidget_preload_deps <- function() {
+  htmltools::resolveDependencies(c(
+    htmltools::findDependencies(DT::datatable(data.frame(a = 1))),
+    htmltools::findDependencies(plotly::plot_ly(x = 1, y = 1)),
+    htmltools::findDependencies(d3heatmap::d3heatmap(matrix(1)))
+  ))
 }
 
 #' Produce a simple app with controls and layout for a single module, in a


### PR DESCRIPTION
## Summary

`prepareApp()` now attaches DT, plotly and d3heatmap htmlwidget dependencies to the returned UI, so their plugin JS/CSS are rendered as blocking `<script>`/`<link>` tags in the initial page HTML rather than lazy-injected at widget render time.

## Why

htmlwidgets 1.6.4's `shinyBinding.renderValue` at `htmlwidgets/www/htmlwidgets.js:514-517` calls the **synchronous** `Shiny.renderDependencies(data.deps)` and immediately invokes `bindingDef.renderValue`. `renderDependencies` appends plugin `<script>` tags (e.g. `jquery.dataTables.min.js`, `plotly-latest.min.js`) to `<head>` but does not wait for them. The binding then runs `$table.DataTable(...)`, `Plotly.newPlot(...)` etc, which need the plugins already attached.

On localhost the fetches take <1ms and the binding always wins the race. Behind a reverse proxy with non-trivial latency (Seqera Studios' `connect-client` relay, Shiny Server behind nginx, rstudio-connect, etc.) the binding consistently **loses**, and every datatable and plotly output in a shinyngs app fails with errors like:

```
TypeError: $table.DataTable is not a function
    at Object.renderValue (datatables.js:348)
```

## How

Preload the set of dependencies that cover every htmlwidget used anywhere in shinyngs (DT, plotly, d3heatmap and their transitive deps — jquery, dt-core, crosstalk, plotly-main, typedarray, d3, etc.). `htmltools::attachDependencies(..., append = TRUE)` puts them in the UI, so Shiny renders them as standard blocking `<link>`/`<script>` tags in `<head>` at initial page load. By the time any widget output message arrives over the WebSocket, the plugins are already attached to `jQuery` / `window`.

## Test plan

- [x] Verified on a Seqera Studios Shiny Studio deployment of a shinyngs RNA-seq app where the race reliably fired; with this patch, all DataTables and plotly plots render correctly.
- [ ] Sanity-check there is no regression locally on a standard Shiny app run (widget deps should still resolve/de-dupe cleanly via `htmltools::resolveDependencies`).
- [ ] Confirm the patch covers every htmlwidget type used across the package (grep suggests DT, plotly, d3heatmap; please flag if I missed any).

## Alternatives considered

- Upstream fix in rstudio/htmlwidgets to make `shinyBinding.renderValue` async and await `Shiny.renderDependenciesAsync`. That is the correct long-term fix and is still worth filing, but it requires a release cycle and propagation through CRAN/bioconda; this change works today on any shinyngs install.
- Monkey-patching `htmlwidgets.js` from `prepareApp()` via `tags$script(...)`. Rejected as fragile (version-sensitive, relies on load order).