### PR TITLE
Add demo-app skill for spinning up test apps on local changes

### DIFF
--- a/.claude/skills/demo-app/SKILL.md
+++ b/.claude/skills/demo-app/SKILL.md
@@ -19,21 +19,29 @@ changes on top, then run the app against test data.
 ## 1. Build the environment once
 
 ```bash
-ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && \
-  /opt/homebrew/bin/micromamba create -n shinyngs-dev -c conda-forge -c bioconda r-shinyngs r-testthat -y
+micromamba create -n shinyngs-dev -c conda-forge -c bioconda r-shinyngs r-testthat -y
 ```
 
 This pulls the exact dependency set (Bioconductor packages, `shinyBS`,
 `shinyjs`, `d3heatmap`, `plotly`, etc.) as prebuilt binaries — building them
 from source directly is far slower and more failure-prone. Reuse this env
 across sessions; only rebuild if bioconda's pinned version drifts far from
-`DESCRIPTION`.
+`DESCRIPTION`. (`conda`/`mamba` work the same way if that's what you have
+installed.)
 
-Activate it for every command below:
+Activate it for every command below. `micromamba activate` needs shell hook
+initialization, which a fresh non-interactive shell (e.g. a tool-invoked
+command) won't have unless you set it up yourself, so the self-contained form
+is more reliable here:
 
 ```bash
-source ~/.local/bin/mm-activate shinyngs-dev
+eval "$(micromamba shell hook --shell bash)" && micromamba activate shinyngs-dev
 ```
+
+If environment creation fails in a confusing way on macOS, search for known
+micromamba/conda + Gatekeeper/codesign issues for your OS version before
+assuming it's this package's fault — these crop up periodically and the fix
+is OS-version-specific, not something to bake into this skill.
 
 ## 2. Install your local changes on top
 

--- a/.claude/skills/demo-app/SKILL.md
+++ b/.claude/skills/demo-app/SKILL.md
@@ -4,10 +4,12 @@ description: >-
   Spin up a shinyngs Shiny app on test data to demo or verify a code change.
   Use whenever asked to run the app, demo this change, show me the UI, spin up
   a test app, click through a module, or verify something in the browser for
-  this repo. Covers building a throwaway R env with all deps, installing local
-  changes on top, getting test data (zhangneurons or synthetic), launching a
-  full app vs a single module, and the pitfalls that waste time (stale ports,
-  Docker memory limits, wrapped validate() errors).
+  this repo — including comparing before/after, old vs new, or two branches
+  side by side, which this also handles by running both versions
+  simultaneously on separate ports. Covers building a throwaway R env with all
+  deps, installing local changes on top, getting test data (zhangneurons or
+  synthetic), launching a full app vs a single module, and the pitfalls that
+  waste time (stale ports, Docker memory limits, wrapped validate() errors).
 ---
 
 # Demoing shinyngs app changes
@@ -129,6 +131,45 @@ inputs are `selectize.js`-enhanced, so set values via
 
 Kill it when done: `lsof -ti tcp:PORT | xargs kill -9`.
 
+## 5. Comparing two versions side by side
+
+Sometimes the point isn't just to see the new behavior, but to see it next to
+the old one — before/after a fix, or one branch against another. R can't hold
+two versions of the same package's class definitions in one session, so this
+needs two separate R processes, each pointed at its own private copy of
+`shinyngs`, sharing everything else from the env in step 1. `compare-app.sh`
+does this:
+
+```bash
+scripts/compare-app.sh --help
+scripts/compare-app.sh develop . genesetanalysistable zhangneurons
+#                      ^old    ^new (this checkout, incl. uncommitted changes)
+```
+
+`OLD_REF`/`NEW_REF` are each either a git ref (branch/tag/commit) or an
+existing checkout/worktree path — pass `.` for "this checkout as it is right
+now." A ref that isn't currently checked out anywhere gets its own worktree
+(reusing one already on that ref rather than duplicating it, and created
+alongside the repo the same way any other worktree here would be); a ref
+that's already checked out somewhere (very often true for `NEW_REF`, since
+that's usually the branch you're already sitting in) is used directly, no
+worktree needed. Each version is installed into its own library directory
+under `/tmp/shinyngs-compare/` and launched via `run-app.sh` with
+`R_LIB_OVERRIDE` pointed at it, so neither touches the shared env or the
+other version.
+
+`MODULE` and `DATA` are shared between both sides deliberately — same
+module, same test data, different code, so any difference you see is
+attributable to the change. If the two versions disagree about the shape of
+that data (e.g. a slot or column was added since `OLD_REF`), build `DATA`
+with the *older* version's package so the comparison also exercises backward
+compatibility with it — usually the more informative direction, and it can
+turn up real bugs on its own, not just cosmetic differences.
+
+Clean up the worktrees this creates the same way as any other:
+`git worktree remove <path>` for ones you're done with, `git worktree prune`
+to sweep dangling references.
+
 ## Pitfalls that waste time
 
 - **Stale process silently holding the port.** A `runApp()` left over from an
@@ -166,3 +207,10 @@ Kill it when done: `lsof -ti tcp:PORT | xargs kill -9`.
   suddenly shows nothing and a previously-working URL goes dead, the daemon
   is pointing at a different VM — rebuild the image there, or just run
   locally instead.
+
+- **In a comparison, `OLD_REF` failing to boot is often correct, not a
+  tooling bug.** An old ref can hit a real historical bug that was later
+  fixed — `compare-app.sh` still launches `NEW_REF` afterwards and reports
+  both statuses, rather than stopping at the first failure. Check the
+  printed log path before assuming the comparison scripts themselves are
+  broken.

--- a/.claude/skills/demo-app/SKILL.md
+++ b/.claude/skills/demo-app/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: demo-app
+description: >-
+  Spin up a shinyngs Shiny app on test data to demo or verify a code change.
+  Use whenever asked to run the app, demo this change, show me the UI, spin up
+  a test app, click through a module, or verify something in the browser for
+  this repo. Covers building a throwaway R env with all deps, installing local
+  changes on top, getting test data (zhangneurons or synthetic), launching a
+  full app vs a single module, and the pitfalls that waste time (stale ports,
+  Docker memory limits, wrapped validate() errors).
+---
+
+# Demoing shinyngs app changes
+
+shinyngs has a heavy Bioconductor dependency tree that's slow to build from
+source. The fast path is: get the deps from bioconda, install your local
+changes on top, then run the app against test data.
+
+## 1. Build the environment once
+
+```bash
+ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && \
+  /opt/homebrew/bin/micromamba create -n shinyngs-dev -c conda-forge -c bioconda r-shinyngs r-testthat -y
+```
+
+This pulls the exact dependency set (Bioconductor packages, `shinyBS`,
+`shinyjs`, `d3heatmap`, `plotly`, etc.) as prebuilt binaries — building them
+from source directly is far slower and more failure-prone. Reuse this env
+across sessions; only rebuild if bioconda's pinned version drifts far from
+`DESCRIPTION`.
+
+Activate it for every command below:
+
+```bash
+source ~/.local/bin/mm-activate shinyngs-dev
+```
+
+## 2. Install your local changes on top
+
+From the repo (or worktree) checkout:
+
+```bash
+R CMD INSTALL --no-docs --no-multiarch --no-byte-compile .
+```
+
+This overwrites the bioconda-installed `shinyngs` package with your working
+tree, keeping every dependency from step 1. Re-run this line after every edit
+you want reflected in a running app — it's fast (a few seconds, pure R, no
+compilation).
+
+Run the test suite the same way, so internal (`@noRd`) helpers resolve
+correctly against the installed package namespace:
+
+```bash
+Rscript -e 'suppressMessages({library(testthat); library(shinyngs)}); \
+  test_dir("tests/testthat", env = asNamespace("shinyngs"))'
+```
+
+## 3. Get test data
+
+Pick whichever is closest to what the change touches.
+
+**`zhangneurons` — a real, full-featured example dataset.** Best default for
+demoing anything in the main RNA-seq app, since it already has contrasts,
+differential stats, and gene set analyses (`roast` format) wired up.
+
+```bash
+git clone --depth 1 https://github.com/pinin4fjords/zhangneurons.git /tmp/zhangneurons
+R CMD INSTALL --no-docs /tmp/zhangneurons
+```
+
+Load it in an app script with:
+
+```r
+library(zhangneurons)
+data(zhangneurons, envir = environment())
+# `zhangneurons` is an ExploratorySummarizedExperimentList
+```
+
+It's also useful as a **backward-compatibility check**: it predates newer
+package features (e.g. slots added after it was last regenerated), so loading
+it exercises any "object built with an older package version" code path for
+free.
+
+**Synthetic data via the constructors — for a narrow, targeted case.** Build
+an `ExploratorySummarizedExperiment`/`List` directly in R when you need a
+specific edge case (a particular column format, a `NULL` entry in a nested
+list, a specific tool string) that real data won't reliably produce. See
+`R/ExploratorySummarizedExperiment-class.R` for the constructor signature.
+
+**`exec/make_app_from_files.R` — for exec/CLI changes.** Build flat CSV/TSV
+inputs (sample metadata, feature metadata, an expression matrix, a contrasts
+file, differential result files) and run the script directly; this is the
+only way to exercise CLI-flag logic end-to-end. Check `--help` for the full
+option list — it changes over time.
+
+## 4. Launch the app
+
+**Single module** — fastest, isolates exactly the screen you're demoing:
+
+```r
+library(shinyngs)
+esel <- readRDS("data.rds")  # or however you built it in step 3
+app <- prepareApp("genesetanalysistable", esel)  # module name, e.g. heatmap, pca, differentialtable
+shiny::runApp(shiny::shinyApp(app$ui, app$server), host = "127.0.0.1", port = 8110, launch.browser = FALSE)
+```
+
+**Full app** — for a click-through covering navigation, or when the change
+could have cross-module effects:
+
+```r
+library(shinyngs); library(shinyBS); library(shinyjs); library(markdown)
+esel <- readRDS("data.rds")
+app <- prepareApp("rnaseq", esel)
+shiny::runApp(shiny::shinyApp(app$ui, app$server), host = "127.0.0.1", port = 8110, launch.browser = FALSE)
+```
+
+Run this backgrounded and poll for readiness rather than guessing a sleep
+duration — startup time varies a lot with dataset size:
+
+```bash
+(Rscript -e "..." > /tmp/shinyngs.log 2>&1 &)
+for i in $(seq 1 30); do sleep 5; \
+  [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 http://127.0.0.1:8110)" = "200" ] && break; done
+grep -iE "listening|error|halt" /tmp/shinyngs.log | tail -5
+```
+
+Then either hand the user the URL to click through themselves, or drive it
+with Playwright (see the `webapp-testing` skill) — note that shinyngs' select
+inputs are `selectize.js`-enhanced, so set values via
+`element.selectize.setValue(val, false)`, not by setting `.value` directly.
+
+## Pitfalls that waste time
+
+- **Stale process silently holding the port.** A `runApp()` left over from an
+  earlier attempt (possibly hours old) can hold the port so a "restart"
+  silently connects you to the *old*, unfixed app. Before every launch:
+  ```bash
+  for pid in $(lsof -ti tcp:8110 2>/dev/null); do kill -9 $pid; done
+  ```
+  and confirm the fresh log actually contains `Listening on http://...`, not
+  `createTcpServer: address already in use`.
+
+- **`d3heatmap(matrix(1))` crashes app startup on old checkouts.** Fixed on
+  `develop` (`R/apps.R`, `dendrogram = "none"`), but if you're testing a
+  branch predating that fix, *every* app — not just heatmap screens — fails
+  at construction with `must have n >= 2 objects to cluster`. If a full app
+  won't boot at all, check this before assuming your own change broke it.
+
+- **A `validate()` message can get rewrapped into a red error.** If a reactive
+  passes an unevaluated call straight into another function's argument (e.g.
+  `linkMatrix(someReactive(), ...)`), R's lazy evaluation means the
+  `validate(need(...))` inside `someReactive()` doesn't fire until that
+  argument is touched deep inside the callee — surfacing as something like
+  `error in evaluating the argument 'x' in selecting a method for function
+  'colnames'` instead of a clean validation prompt. Force the reactive to a
+  local variable first. Use `options(shiny.fullstacktrace = TRUE)` to get the
+  real call stack when a message looks like this.
+
+- **Docker, if you use it instead of running locally, needs real memory.**
+  The full RNA-seq app plus a large gene-set collection can OOM-kill a
+  container silently (`Exited (137)`) if the Docker/colima VM has only ~2GB.
+  Running directly in the local micromamba env (steps 1-2) avoids this
+  entirely and is faster to iterate in; reach for Docker/`custom-studios-examples`
+  only when you specifically need to validate the production container image.
+
+- **Switching colima profiles orphans your built image.** If `docker ps`
+  suddenly shows nothing and a previously-working URL goes dead, the daemon
+  is pointing at a different VM — rebuild the image there, or just run
+  locally instead.

--- a/.claude/skills/demo-app/SKILL.md
+++ b/.claude/skills/demo-app/SKILL.md
@@ -166,9 +166,20 @@ with the *older* version's package so the comparison also exercises backward
 compatibility with it — usually the more informative direction, and it can
 turn up real bugs on its own, not just cosmetic differences.
 
-Clean up the worktrees this creates the same way as any other:
-`git worktree remove <path>` for ones you're done with, `git worktree prune`
-to sweep dangling references.
+When done, tear everything down in one command — both apps' processes are
+otherwise easy to forget since there are two of them, not one:
+
+```bash
+scripts/compare-app.sh --cleanup develop . 8110 8111
+```
+
+This kills both ports, deletes the temporary libraries, and removes any
+worktree it created for `OLD_REF`/`NEW_REF` — never a path you gave directly
+(like `.`), and never a worktree that already existed for other reasons; it
+only touches ones at this tool's own `<repo>-compare-<ref>` naming
+convention. Every normal (non-cleanup) run also prints the exact cleanup
+command to copy for that invocation, so you don't have to reconstruct it
+from memory.
 
 ## Pitfalls that waste time
 

--- a/.claude/skills/demo-app/SKILL.md
+++ b/.claude/skills/demo-app/SKILL.md
@@ -96,49 +96,39 @@ option list — it changes over time.
 
 ## 4. Launch the app
 
-**Single module** — fastest, isolates exactly the screen you're demoing:
-
-```r
-library(shinyngs)
-esel <- readRDS("data.rds")  # or however you built it in step 3
-app <- prepareApp("genesetanalysistable", esel)  # module name, e.g. heatmap, pca, differentialtable
-shiny::runApp(shiny::shinyApp(app$ui, app$server), host = "127.0.0.1", port = 8110, launch.browser = FALSE)
-```
-
-**Full app** — for a click-through covering navigation, or when the change
-could have cross-module effects:
-
-```r
-library(shinyngs); library(shinyBS); library(shinyjs); library(markdown)
-esel <- readRDS("data.rds")
-app <- prepareApp("rnaseq", esel)
-shiny::runApp(shiny::shinyApp(app$ui, app$server), host = "127.0.0.1", port = 8110, launch.browser = FALSE)
-```
-
-Run this backgrounded and poll for readiness rather than guessing a sleep
-duration — startup time varies a lot with dataset size:
+Use the bundled script for this — it kills anything already bound to the
+port, launches in the background, polls for readiness (startup time varies a
+lot with dataset size, so don't guess a sleep duration), and reports the log
+tail. This is the part that's identical every time and where manual attempts
+go wrong (see the first pitfall below), so it's worth using even for a quick
+check.
 
 ```bash
-(Rscript -e "..." > /tmp/shinyngs.log 2>&1 &)
-for i in $(seq 1 30); do sleep 5; \
-  [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 http://127.0.0.1:8110)" = "200" ] && break; done
-grep -iE "listening|error|halt" /tmp/shinyngs.log | tail -5
+scripts/run-app.sh --help   # read this first
+scripts/run-app.sh 8110 genesetanalysistable /tmp/data.rds   # single module — fastest, isolates one screen
+scripts/run-app.sh 8110 rnaseq zhangneurons                  # full app — click-through, cross-module changes
 ```
+
+`MODULE` is any shinyngs module name (`heatmap`, `pca`, `differentialtable`,
+...) or `rnaseq` for the full app. `DATA` is a path to an RDS file holding an
+`ExploratorySummarizedExperimentList` (however you built it in step 3), or
+the literal string `zhangneurons`.
 
 Then either hand the user the URL to click through themselves, or drive it
 with Playwright (see the `webapp-testing` skill) — note that shinyngs' select
 inputs are `selectize.js`-enhanced, so set values via
 `element.selectize.setValue(val, false)`, not by setting `.value` directly.
 
+Kill it when done: `lsof -ti tcp:PORT | xargs kill -9`.
+
 ## Pitfalls that waste time
 
 - **Stale process silently holding the port.** A `runApp()` left over from an
   earlier attempt (possibly hours old) can hold the port so a "restart"
-  silently connects you to the *old*, unfixed app. Before every launch:
-  ```bash
-  for pid in $(lsof -ti tcp:8110 2>/dev/null); do kill -9 $pid; done
-  ```
-  and confirm the fresh log actually contains `Listening on http://...`, not
+  silently connects you to the *old*, unfixed app — `scripts/run-app.sh`
+  kills anything on the target port before launching, specifically to avoid
+  this. If you launch manually instead, always do the same and confirm the
+  fresh log actually contains `Listening on http://...`, not
   `createTcpServer: address already in use`.
 
 - **`d3heatmap(matrix(1))` crashes app startup on old checkouts.** Fixed on

--- a/.claude/skills/demo-app/scripts/build-lib.sh
+++ b/.claude/skills/demo-app/scripts/build-lib.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage: build-lib.sh REF_OR_PATH LIB_DIR
+       build-lib.sh --resolve REF_OR_PATH
 
   REF_OR_PATH  Either an existing directory (a checkout/worktree to install
                as-is — pass "." or the current worktree's path for "my
@@ -21,41 +22,73 @@ duplicate (git worktree add errors if a branch is checked out twice), and
 otherwise creates one alongside the repo root, matching this project's usual
 worktree conventions.
 
+--resolve prints the checkout path that would be used for REF_OR_PATH,
+without creating a worktree or installing anything — used by
+compare-app.sh --cleanup to find (and only remove) worktrees it created,
+without side effects from just asking.
+
 Examples:
   build-lib.sh . /tmp/shinyngs-compare/new-lib          # this checkout, as-is
   build-lib.sh develop /tmp/shinyngs-compare/old-lib    # a branch/tag/commit
+  build-lib.sh --resolve develop
 USAGE
 }
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ "$#" -lt 2 ]; then
+# Prints the checkout path for REF_OR_PATH to stdout. If CREATE=true and no
+# worktree exists yet, creates one; if CREATE=false, only reports the path
+# a subsequent build would use, without touching the filesystem or git state.
+# All diagnostics go to stderr so stdout is just the path, safe to capture.
+resolve_src_dir() {
+  local ref_or_path="$1" create="$2"
+
+  if [ -d "$ref_or_path" ]; then
+    echo "==> Using existing checkout: $ref_or_path" >&2
+    echo "$ref_or_path"
+    return
+  fi
+
+  local repo_root safe_ref existing src_dir
+  repo_root="$(git rev-parse --show-toplevel)"
+  safe_ref="$(echo "$ref_or_path" | tr '/' '-')"
+  existing="$(git -C "$repo_root" worktree list --porcelain | awk -v ref="refs/heads/$ref_or_path" '
+    /^worktree /{wt=$2} /^branch /{if ($2==ref) print wt}')"
+
+  if [ -n "$existing" ]; then
+    echo "==> Reusing existing worktree for '$ref_or_path': $existing" >&2
+    echo "$existing"
+    return
+  fi
+
+  src_dir="$(dirname "$repo_root")/$(basename "$repo_root")-compare-${safe_ref}"
+  if [ -d "$src_dir" ]; then
+    echo "==> Reusing previously-built worktree: $src_dir" >&2
+  elif [ "$create" = true ]; then
+    echo "==> Creating worktree for '$ref_or_path': $src_dir" >&2
+    git -C "$repo_root" worktree add --detach "$src_dir" "$ref_or_path" >&2
+  fi
+  echo "$src_dir"
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   usage
-  exit "$([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && echo 0 || echo 1)"
+  exit 0
+fi
+
+if [ "${1:-}" = "--resolve" ]; then
+  [ "$#" -lt 2 ] && { usage; exit 1; }
+  resolve_src_dir "$2" false
+  exit 0
+fi
+
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
 fi
 
 REF_OR_PATH="$1"
 LIB_DIR="$2"
 
-if [ -d "$REF_OR_PATH" ]; then
-  SRC_DIR="$REF_OR_PATH"
-  echo "==> Using existing checkout: $SRC_DIR"
-else
-  REPO_ROOT="$(git rev-parse --show-toplevel)"
-  SAFE_REF="$(echo "$REF_OR_PATH" | tr '/' '-')"
-  EXISTING="$(git -C "$REPO_ROOT" worktree list --porcelain | awk -v ref="refs/heads/$REF_OR_PATH" '
-    /^worktree /{wt=$2} /^branch /{if ($2==ref) print wt}')"
-  if [ -n "$EXISTING" ]; then
-    SRC_DIR="$EXISTING"
-    echo "==> Reusing existing worktree for '$REF_OR_PATH': $SRC_DIR"
-  else
-    SRC_DIR="$(dirname "$REPO_ROOT")/$(basename "$REPO_ROOT")-compare-${SAFE_REF}"
-    if [ -d "$SRC_DIR" ]; then
-      echo "==> Reusing previously-built worktree: $SRC_DIR"
-    else
-      echo "==> Creating worktree for '$REF_OR_PATH': $SRC_DIR"
-      git -C "$REPO_ROOT" worktree add --detach "$SRC_DIR" "$REF_OR_PATH"
-    fi
-  fi
-fi
+SRC_DIR="$(resolve_src_dir "$REF_OR_PATH" true)"
 
 mkdir -p "$LIB_DIR"
 echo "==> Installing $SRC_DIR into $LIB_DIR"

--- a/.claude/skills/demo-app/scripts/build-lib.sh
+++ b/.claude/skills/demo-app/scripts/build-lib.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Install a specific version of shinyngs into its own R library directory,
+# leaving the shared env's library untouched. Used by compare-app.sh to build
+# an "old" and a "new" version side by side; see SKILL.md for the workflow.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: build-lib.sh REF_OR_PATH LIB_DIR
+
+  REF_OR_PATH  Either an existing directory (a checkout/worktree to install
+               as-is — pass "." or the current worktree's path for "my
+               in-progress changes"), or a git ref (branch/tag/commit) to
+               check out into a worktree first.
+  LIB_DIR      Directory to install the package into (created if needed).
+               Point R_LIB_OVERRIDE at this when launching the app.
+
+When REF_OR_PATH is a ref, run this from inside any checkout of the repo.
+Reuses an existing worktree already on that ref instead of creating a
+duplicate (git worktree add errors if a branch is checked out twice), and
+otherwise creates one alongside the repo root, matching this project's usual
+worktree conventions.
+
+Examples:
+  build-lib.sh . /tmp/shinyngs-compare/new-lib          # this checkout, as-is
+  build-lib.sh develop /tmp/shinyngs-compare/old-lib    # a branch/tag/commit
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ "$#" -lt 2 ]; then
+  usage
+  exit "$([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && echo 0 || echo 1)"
+fi
+
+REF_OR_PATH="$1"
+LIB_DIR="$2"
+
+if [ -d "$REF_OR_PATH" ]; then
+  SRC_DIR="$REF_OR_PATH"
+  echo "==> Using existing checkout: $SRC_DIR"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  SAFE_REF="$(echo "$REF_OR_PATH" | tr '/' '-')"
+  EXISTING="$(git -C "$REPO_ROOT" worktree list --porcelain | awk -v ref="refs/heads/$REF_OR_PATH" '
+    /^worktree /{wt=$2} /^branch /{if ($2==ref) print wt}')"
+  if [ -n "$EXISTING" ]; then
+    SRC_DIR="$EXISTING"
+    echo "==> Reusing existing worktree for '$REF_OR_PATH': $SRC_DIR"
+  else
+    SRC_DIR="$(dirname "$REPO_ROOT")/$(basename "$REPO_ROOT")-compare-${SAFE_REF}"
+    if [ -d "$SRC_DIR" ]; then
+      echo "==> Reusing previously-built worktree: $SRC_DIR"
+    else
+      echo "==> Creating worktree for '$REF_OR_PATH': $SRC_DIR"
+      git -C "$REPO_ROOT" worktree add --detach "$SRC_DIR" "$REF_OR_PATH"
+    fi
+  fi
+fi
+
+mkdir -p "$LIB_DIR"
+echo "==> Installing $SRC_DIR into $LIB_DIR"
+R CMD INSTALL --no-docs --no-multiarch --no-byte-compile --library="$LIB_DIR" "$SRC_DIR"

--- a/.claude/skills/demo-app/scripts/compare-app.sh
+++ b/.claude/skills/demo-app/scripts/compare-app.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Launch two versions of a shinyngs app side by side — e.g. the base branch
+# and your feature branch — against the same test data, for visual/behavioral
+# comparison. See SKILL.md for the full workflow.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: compare-app.sh OLD_REF NEW_REF MODULE DATA [OLD_PORT] [NEW_PORT]
+
+  OLD_REF   "Before" version: a git ref (branch/tag/commit), or an existing
+            checkout/worktree path.
+  NEW_REF   "After" version: same options. Pass "." for your current
+            checkout's working tree (including uncommitted changes).
+  MODULE    shinyngs module name, or "rnaseq" for the full app — same for
+            both sides, so the comparison is apples-to-apples.
+  DATA      Path to an RDS file, or "zhangneurons" — same for both sides.
+            If OLD_REF and NEW_REF disagree on the object's shape (e.g. a
+            slot added since OLD_REF), build DATA with the OLDER version so
+            the comparison also covers backward compatibility, which is
+            usually the more informative direction.
+  OLD_PORT  Port for the old version (default 8110)
+  NEW_PORT  Port for the new version (default 8111)
+
+Builds each version into its own R library (via build-lib.sh) so they don't
+touch the shared env or each other, then launches each with run-app.sh on
+its own port. Two separate R processes — required, since one R session can't
+hold two versions of the same package's class definitions at once.
+
+Example:
+  compare-app.sh develop . genesetanalysistable zhangneurons
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ "$#" -lt 4 ]; then
+  usage
+  exit "$([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && echo 0 || echo 1)"
+fi
+
+OLD_REF="$1"
+NEW_REF="$2"
+MODULE="$3"
+DATA="$4"
+OLD_PORT="${5:-8110}"
+NEW_PORT="${6:-8111}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="${COMPARE_WORKDIR:-/tmp/shinyngs-compare}"
+
+echo "=== Building old version ($OLD_REF) ==="
+"$SCRIPT_DIR/build-lib.sh" "$OLD_REF" "$WORKDIR/old-lib"
+
+echo "=== Building new version ($NEW_REF) ==="
+"$SCRIPT_DIR/build-lib.sh" "$NEW_REF" "$WORKDIR/new-lib"
+
+echo "=== Launching old version on port $OLD_PORT ==="
+old_status=0
+R_LIB_OVERRIDE="$WORKDIR/old-lib" "$SCRIPT_DIR/run-app.sh" "$OLD_PORT" "$MODULE" "$DATA" || old_status=$?
+
+echo "=== Launching new version on port $NEW_PORT ==="
+new_status=0
+R_LIB_OVERRIDE="$WORKDIR/new-lib" "$SCRIPT_DIR/run-app.sh" "$NEW_PORT" "$MODULE" "$DATA" || new_status=$?
+
+echo "=== Summary ==="
+echo "  old ($OLD_REF): http://127.0.0.1:${OLD_PORT} $([ "$old_status" -eq 0 ] && echo READY || echo FAILED)"
+echo "  new ($NEW_REF): http://127.0.0.1:${NEW_PORT} $([ "$new_status" -eq 0 ] && echo READY || echo FAILED)"
+
+[ "$old_status" -eq 0 ] && [ "$new_status" -eq 0 ]

--- a/.claude/skills/demo-app/scripts/compare-app.sh
+++ b/.claude/skills/demo-app/scripts/compare-app.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage: compare-app.sh OLD_REF NEW_REF MODULE DATA [OLD_PORT] [NEW_PORT]
+       compare-app.sh --cleanup OLD_REF NEW_REF [OLD_PORT] [NEW_PORT]
 
   OLD_REF   "Before" version: a git ref (branch/tag/commit), or an existing
             checkout/worktree path.
@@ -27,14 +28,63 @@ touch the shared env or each other, then launches each with run-app.sh on
 its own port. Two separate R processes — required, since one R session can't
 hold two versions of the same package's class definitions at once.
 
-Example:
+--cleanup kills both apps, deletes the temporary libraries, and removes any
+worktree it created for OLD_REF/NEW_REF (never one you passed as an existing
+path, and never one that already existed for other reasons — only ones at
+this tool's own "<repo>-compare-<ref>" naming convention). Pass it the same
+OLD_REF/NEW_REF/ports you launched with, dropping MODULE/DATA (irrelevant to
+cleanup).
+
+Examples:
   compare-app.sh develop . genesetanalysistable zhangneurons
+  compare-app.sh --cleanup develop .
 USAGE
 }
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ "$#" -lt 4 ]; then
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   usage
-  exit "$([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && echo 0 || echo 1)"
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="${COMPARE_WORKDIR:-/tmp/shinyngs-compare}"
+
+if [ "${1:-}" = "--cleanup" ]; then
+  [ "$#" -lt 3 ] && { usage; exit 1; }
+  OLD_REF="$2"
+  NEW_REF="$3"
+  OLD_PORT="${4:-8110}"
+  NEW_PORT="${5:-8111}"
+
+  echo "=== Killing apps on ports $OLD_PORT and $NEW_PORT ==="
+  for port in "$OLD_PORT" "$NEW_PORT"; do
+    for pid in $(lsof -ti tcp:"$port" 2>/dev/null || true); do
+      kill -9 "$pid" 2>/dev/null || true
+    done
+  done
+
+  echo "=== Removing $WORKDIR ==="
+  rm -rf "$WORKDIR"
+
+  for ref in "$OLD_REF" "$NEW_REF"; do
+    if [ -d "$ref" ]; then
+      echo "==> '$ref' is a path you gave directly, not a worktree we made — leaving it"
+      continue
+    fi
+    path="$("$SCRIPT_DIR/build-lib.sh" --resolve "$ref" 2>/dev/null)"
+    if git worktree list --porcelain 2>/dev/null | grep -qx "worktree $path"; then
+      echo "==> Removing worktree for '$ref': $path"
+      git worktree remove "$path" 2>&1 || echo "    (left in place — see message above, e.g. uncommitted changes)"
+    fi
+  done
+
+  echo "=== Cleanup done ==="
+  exit 0
+fi
+
+if [ "$#" -lt 4 ]; then
+  usage
+  exit 1
 fi
 
 OLD_REF="$1"
@@ -43,9 +93,6 @@ MODULE="$3"
 DATA="$4"
 OLD_PORT="${5:-8110}"
 NEW_PORT="${6:-8111}"
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKDIR="${COMPARE_WORKDIR:-/tmp/shinyngs-compare}"
 
 echo "=== Building old version ($OLD_REF) ==="
 "$SCRIPT_DIR/build-lib.sh" "$OLD_REF" "$WORKDIR/old-lib"
@@ -64,5 +111,6 @@ R_LIB_OVERRIDE="$WORKDIR/new-lib" "$SCRIPT_DIR/run-app.sh" "$NEW_PORT" "$MODULE"
 echo "=== Summary ==="
 echo "  old ($OLD_REF): http://127.0.0.1:${OLD_PORT} $([ "$old_status" -eq 0 ] && echo READY || echo FAILED)"
 echo "  new ($NEW_REF): http://127.0.0.1:${NEW_PORT} $([ "$new_status" -eq 0 ] && echo READY || echo FAILED)"
+echo "  Clean up with: $(basename "$0") --cleanup \"$OLD_REF\" \"$NEW_REF\" $OLD_PORT $NEW_PORT"
 
 [ "$old_status" -eq 0 ] && [ "$new_status" -eq 0 ]

--- a/.claude/skills/demo-app/scripts/run-app.sh
+++ b/.claude/skills/demo-app/scripts/run-app.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Launch a shinyngs app for demoing/verifying a local change, deterministically:
+# kill anything already bound to the port, launch in the background, poll for
+# readiness, and report the log tail. See SKILL.md for the surrounding workflow
+# (env setup, installing local changes, choosing test data).
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-app.sh PORT MODULE DATA
+
+  PORT    Localhost port to bind (e.g. 8110)
+  MODULE  shinyngs module name (e.g. genesetanalysistable, heatmap, pca),
+          or "rnaseq" for the full app
+  DATA    Path to an RDS file holding an ExploratorySummarizedExperimentList,
+          or the literal string "zhangneurons" to load the installed
+          zhangneurons test package via data(zhangneurons)
+
+Environment overrides:
+  TIMEOUT_SECS   Max seconds to wait for readiness (default 150)
+  POLL_INTERVAL  Seconds between readiness checks (default 5)
+
+Requires the target R env active (SKILL.md step 1) and the local shinyngs
+package already installed into it (step 2). Prints the log tail and exits 0
+once the app responds 200, or exits 1 after TIMEOUT_SECS with the log tail
+for diagnosis.
+
+Examples:
+  run-app.sh 8110 genesetanalysistable zhangneurons
+  run-app.sh 8110 rnaseq /tmp/my-test-object.rds
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ "$#" -lt 3 ]; then
+  usage
+  exit "$([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && echo 0 || echo 1)"
+fi
+
+PORT="$1"
+MODULE="$2"
+DATA="$3"
+LOG="$(mktemp -t "shinyngs-app-${PORT}-XXXXXX").log"
+TIMEOUT_SECS="${TIMEOUT_SECS:-150}"
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+
+echo "==> Killing any process already bound to port $PORT"
+for pid in $(lsof -ti tcp:"$PORT" 2>/dev/null || true); do
+  kill -9 "$pid" 2>/dev/null || true
+done
+sleep 1
+
+if [ "$DATA" = "zhangneurons" ]; then
+  load_expr='suppressMessages(library(zhangneurons)); data(zhangneurons, envir = environment()); esel <- zhangneurons'
+else
+  if [ ! -f "$DATA" ]; then
+    echo "==> DATA file not found: $DATA" >&2
+    exit 1
+  fi
+  load_expr="esel <- readRDS(\"$DATA\")"
+fi
+
+r_expr="suppressMessages({library(shinyngs); library(shinyBS); library(shinyjs); library(markdown)}); ${load_expr}; app <- prepareApp(\"${MODULE}\", esel); shiny::runApp(shiny::shinyApp(app\$ui, app\$server), host = \"127.0.0.1\", port = ${PORT}, launch.browser = FALSE)"
+
+echo "==> Launching module '$MODULE' on port $PORT (log: $LOG)"
+(Rscript -e "$r_expr" >"$LOG" 2>&1 &)
+
+echo "==> Waiting up to ${TIMEOUT_SECS}s for readiness"
+elapsed=0
+ready=false
+while [ "$elapsed" -lt "$TIMEOUT_SECS" ]; do
+  sleep "$POLL_INTERVAL"
+  elapsed=$((elapsed + POLL_INTERVAL))
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 "http://127.0.0.1:$PORT" || echo 000)
+  if [ "$code" = "200" ]; then
+    ready=true
+    break
+  fi
+done
+
+echo "==> Log tail:"
+grep -iE "listening|error|halt|execution" "$LOG" | tail -10 || true
+
+if [ "$ready" = true ]; then
+  echo "==> READY after ~${elapsed}s: http://127.0.0.1:${PORT}"
+  exit 0
+else
+  echo "==> NOT READY after ${TIMEOUT_SECS}s — check $LOG"
+  exit 1
+fi

--- a/.claude/skills/demo-app/scripts/run-app.sh
+++ b/.claude/skills/demo-app/scripts/run-app.sh
@@ -17,8 +17,12 @@ Usage: run-app.sh PORT MODULE DATA
           zhangneurons test package via data(zhangneurons)
 
 Environment overrides:
-  TIMEOUT_SECS   Max seconds to wait for readiness (default 150)
-  POLL_INTERVAL  Seconds between readiness checks (default 5)
+  TIMEOUT_SECS    Max seconds to wait for readiness (default 150)
+  POLL_INTERVAL   Seconds between readiness checks (default 5)
+  R_LIB_OVERRIDE  A library directory to search for the shinyngs package
+                  before the env's own library. Used by compare-app.sh to run
+                  two package versions side by side without touching the
+                  shared env; leave unset for normal single-version use.
 
 Requires the target R env active (SKILL.md step 1) and the local shinyngs
 package already installed into it (step 2). Prints the log tail and exits 0
@@ -59,9 +63,14 @@ else
   load_expr="esel <- readRDS(\"$DATA\")"
 fi
 
-r_expr="suppressMessages({library(shinyngs); library(shinyBS); library(shinyjs); library(markdown)}); ${load_expr}; app <- prepareApp(\"${MODULE}\", esel); shiny::runApp(shiny::shinyApp(app\$ui, app\$server), host = \"127.0.0.1\", port = ${PORT}, launch.browser = FALSE)"
+lib_expr=""
+if [ -n "${R_LIB_OVERRIDE:-}" ]; then
+  lib_expr=".libPaths(c(\"${R_LIB_OVERRIDE}\", .libPaths())); "
+fi
 
-echo "==> Launching module '$MODULE' on port $PORT (log: $LOG)"
+r_expr="${lib_expr}suppressMessages({library(shinyngs); library(shinyBS); library(shinyjs); library(markdown)}); ${load_expr}; app <- prepareApp(\"${MODULE}\", esel); shiny::runApp(shiny::shinyApp(app\$ui, app\$server), host = \"127.0.0.1\", port = ${PORT}, launch.browser = FALSE)"
+
+echo "==> Launching module '$MODULE' on port $PORT (log: $LOG)${R_LIB_OVERRIDE:+, shinyngs from $R_LIB_OVERRIDE}"
 (Rscript -e "$r_expr" >"$LOG" 2>&1 &)
 
 echo "==> Waiting up to ${TIMEOUT_SECS}s for readiness"

--- a/.claude/skills/demo-app/scripts/run-app.sh
+++ b/.claude/skills/demo-app/scripts/run-app.sh
@@ -39,7 +39,7 @@ fi
 PORT="$1"
 MODULE="$2"
 DATA="$3"
-LOG="$(mktemp -t "shinyngs-app-${PORT}-XXXXXX").log"
+LOG="/tmp/shinyngs-app-${PORT}.log"
 TIMEOUT_SECS="${TIMEOUT_SECS:-150}"
 POLL_INTERVAL="${POLL_INTERVAL:-5}"
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/demo-app/SKILL.md`, a Claude Code skill documenting how to spin up a shinyngs app on test data to demo or verify a code change
- Covers building a throwaway R env from bioconda `r-shinyngs` plus `R CMD INSTALL` on top for fast local-change iteration, test data options (`zhangneurons`, synthetic constructor-built data, `exec/make_app_from_files.R`), launching a single module vs the full app, and pitfalls worth knowing about (stale ports holding an old app, the historical `d3heatmap` 1x1-matrix startup crash, `validate()` messages getting rewrapped into red errors, Docker memory limits)

## Test plan
- [x] Frontmatter parses as valid YAML
- [x] Module names referenced (`genesetanalysistable`, `heatmap`, `pca`, `differentialtable`) verified to exist in `R/`
- Documentation-only change; no code paths affected