### PR TITLE
Migrate all Shiny modules from callModule() to moduleServer()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     reformulas,
     reshape2,
     scatterplot3d,
-    shiny,
+    shiny (>= 1.5.0),
     shinyBS,
     shinyjs,
     shinythemes,

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -1522,7 +1522,11 @@ cond_log2_transform_matrix <- function(matrix_data, should_transform = NULL, thr
 
   # Determine if transformation is needed
   if (is.null(should_transform)) {
-    should_transform <- (max(matrix_data, na.rm = TRUE) > threshold) || (reverse && max(matrix_data, na.rm = TRUE) <= threshold)
+    if (reverse) {
+      should_transform <- max(matrix_data, na.rm = TRUE) <= threshold
+    } else {
+      should_transform <- max(matrix_data, na.rm = TRUE) > threshold
+    }
   }
 
   # Apply transformation based on conditions

--- a/R/apps.R
+++ b/R/apps.R
@@ -105,7 +105,7 @@ prepareApp <- function(type, eselist, ui_only = FALSE, ...) {
     inputFunc <- get(paste0(type, "Input"))
 
     app <- list(ui = inputFunc(type, eselist), server = function(input, output, session) {
-      callModule(get(type), type, eselist)
+      get(type)(type, eselist)
     })
   } else {
     app <- simpleApp(eselist, type, ui_only = ui_only, ...)
@@ -177,7 +177,7 @@ simpleApp <- function(eselist, module = NULL, ui_only = FALSE, ...) {
       }
     } else {
       server <- function(input, output, session) {
-        callModule(get(module), module, eselist, ...)
+        get(module)(module, eselist, ...)
       }
     }
     list(ui = ui, server = server)

--- a/R/assaydatatable.R
+++ b/R/assaydatatable.R
@@ -64,21 +64,19 @@ assaydatatableOutput <- function(id) {
 
 #' The server function of the assaydatatable module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example). Essentially this just passes the results of \code{colData()}
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 #' applied to the specified SummarizedExperiment object to the
 #' \code{simpletable} module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(assaydatatable, "assaydatatable", eselist)
+#' assaydatatable("assaydatatable", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
@@ -86,20 +84,22 @@ assaydatatableOutput <- function(id) {
 #' app <- prepareApp("assaydatatable", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-assaydatatable <- function(input, output, session, eselist) {
-  # Render the output area - and provide an input-dependent title
+assaydatatable <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Render the output area - and provide an input-dependent title
 
-  output$assaydatatable <- renderUI({
-    ns <- session$ns
+    output$assaydatatable <- renderUI({
+      ns <- session$ns
 
-    simpletableOutput(ns("assaydatatable"), tabletitle = paste("Assay data", getAssay(), sep = ": "))
+      simpletableOutput(ns("assaydatatable"), tabletitle = paste("Assay data", getAssay(), sep = ": "))
+    })
+
+    # Call the selectmatrix module and unpack the reactives it sends back
+
+    unpack.list(selectmatrix("expression", eselist, var_n = 1000, select_genes = TRUE, provide_all_genes = TRUE))
+
+    # Pass the matrix to the simpletable module for display
+
+    simpletable("assaydatatable", downloadMatrix = selectLabelledMatrix, displayMatrix = selectLabelledLinkedMatrix, filename = getAssay(), rownames = FALSE)
   })
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  unpack.list(callModule(selectmatrix, "expression", eselist, var_n = 1000, select_genes = TRUE, provide_all_genes = TRUE))
-
-  # Pass the matrix to the simpletable module for display
-
-  callModule(simpletable, "assaydatatable", downloadMatrix = selectLabelledMatrix, displayMatrix = selectLabelledLinkedMatrix, filename = getAssay(), rownames = FALSE)
 }

--- a/R/barplot.R
+++ b/R/barplot.R
@@ -37,42 +37,42 @@ barplotOutput <- function(id, height = "400") {
 #'
 #' Display grouped, stacked or overlaid bars for a matrix
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param getPlotmatrix Reactive supplying a matrix to plot
 #' @param getYLabel Reactive supplying the Y axis label
 #' @param barmode Bar mode: 'stack', 'group' or 'overlay'
 
-barplot <- function(input, output, session, getPlotmatrix, getYLabel, barmode = "stack") {
-  # If we're doing an overlay plot, let's re-order the rows such that we've a better chance of seeing each group
+barplot <- function(id, getPlotmatrix, getYLabel, barmode = "stack") {
+  moduleServer(id, function(input, output, session) {
+    # If we're doing an overlay plot, let's re-order the rows such that we've a better chance of seeing each group
 
-  formatPlotMatrix <- reactive({
-    pm <- getPlotmatrix()
+    formatPlotMatrix <- reactive({
+      pm <- getPlotmatrix()
 
-    validate(need(input$barMode, "Waiting for bar mode"))
+      validate(need(input$barMode, "Waiting for bar mode"))
 
-    if (input$barMode == "overlay") {
-      pm <- pm[order(rowMeans(pm), decreasing = TRUE), ]
-    }
-    pm
-  })
+      if (input$barMode == "overlay") {
+        pm <- pm[order(rowMeans(pm), decreasing = TRUE), ]
+      }
+      pm
+    })
 
-  # Render the plot
+    # Render the plot
 
-  output$barPlot <- renderPlotly({
-    fpm <- formatPlotMatrix()
-    plotdata <- reshape2::melt(fpm)
+    output$barPlot <- renderPlotly({
+      fpm <- formatPlotMatrix()
+      plotdata <- reshape2::melt(fpm)
 
-    # Prevent interpretation of row names as numbers
+      # Prevent interpretation of row names as numbers
 
-    plotdata$Var2 <- as.character(plotdata$Var2)
-    plotdata %>%
-      plot_ly(x = ~Var2, y = ~value, color = ~Var1, type = "bar") %>%
-      layout(
-        margin = list(b = 100), barmode = input$barMode, xaxis = list(title = " "),
-        yaxis = list(title = getYLabel())
-      ) %>%
-      config(showLink = TRUE)
+      plotdata$Var2 <- as.character(plotdata$Var2)
+      plotdata %>%
+        plot_ly(x = ~Var2, y = ~value, color = ~Var1, type = "bar") %>%
+        layout(
+          margin = list(b = 100), barmode = input$barMode, xaxis = list(title = " "),
+          yaxis = list(title = getYLabel())
+        ) %>%
+        config(showLink = TRUE)
+    })
   })
 }

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -91,19 +91,17 @@ boxplotOutput <- function(id) {
 #' boxplot produced using \code{ggplot2}. For higher sample numbers, the default is
 #' a line-based alternative using \code{plotly}.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(boxplot, "boxplot", eselist)
+#' boxplot("boxplot", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
@@ -111,55 +109,57 @@ boxplotOutput <- function(id) {
 #' app <- prepareApp("boxplot", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-boxplot <- function(input, output, session, eselist) {
-  # Get the expression matrix - no need for a gene selection
+boxplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Get the expression matrix - no need for a gene selection
 
-  unpack.list(callModule(selectmatrix, "sampleBoxplot", eselist, select_genes = FALSE))
-  unpack.list(callModule(groupby, "boxplot", eselist = eselist, group_label = "Color by", selectColData = selectColData))
+    unpack.list(selectmatrix("sampleBoxplot", eselist, select_genes = FALSE))
+    unpack.list(groupby("boxplot", eselist = eselist, group_label = "Color by", selectColData = selectColData))
 
-  # Render the plot
+    # Render the plot
 
-  output$quartilesPlot <- renderUI({
-    ns <- session$ns
-    if (input$plotType == "boxes") {
-      plotOutput(ns("sampleBoxplot"))
-    } else if (input$plotType == "density") {
-      plotlyOutput(ns("densityPlotly"), height = "600px")
-    } else {
-      plotlyOutput(ns("quartilesPlotly"), height = "600px")
-    }
+    output$quartilesPlot <- renderUI({
+      ns <- session$ns
+      if (input$plotType == "boxes") {
+        plotOutput(ns("sampleBoxplot"))
+      } else if (input$plotType == "density") {
+        plotlyOutput(ns("densityPlotly"), height = "600px")
+      } else {
+        plotlyOutput(ns("quartilesPlotly"), height = "600px")
+      }
+    })
+
+    output$quartilesPlotly <- renderPlotly({
+      selected_matrix <- selectMatrix()
+      ese <- getExperiment()
+      plotly_quartiles(selectMatrix(), idToLabel(rownames(selected_matrix), ese), getAssayMeasure(), whisker_distance = input$whiskerDistance)
+    })
+
+    output$densityPlotly <- renderPlotly({
+      plotly_densityplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), palette = getPalette())
+    })
+
+    output$sampleBoxplot <- renderPlot(
+      {
+        withProgress(message = "Making sample boxplot", value = 0, {
+          p <- ggplot_boxplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), whisker_distance = input$whiskerDistance, palette = getPalette())
+          print(p)
+        })
+      },
+      height = 600
+    )
+
+    # Provide the plot for download
+
+    plotSampleBoxplot <- reactive({
+      p <- ggplot_boxplot(selectMatrix(), selectColData(), colorBy())
+      print(p)
+    })
+
+    # Call to plotdownload module
+
+    plotdownload("boxplot", makePlot = plotSampleBoxplot, filename = "boxplot.png", plotHeight = 600, plotWidth = 800)
   })
-
-  output$quartilesPlotly <- renderPlotly({
-    selected_matrix <- selectMatrix()
-    ese <- getExperiment()
-    plotly_quartiles(selectMatrix(), idToLabel(rownames(selected_matrix), ese), getAssayMeasure(), whisker_distance = input$whiskerDistance)
-  })
-
-  output$densityPlotly <- renderPlotly({
-    plotly_densityplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), palette = getPalette())
-  })
-
-  output$sampleBoxplot <- renderPlot(
-    {
-      withProgress(message = "Making sample boxplot", value = 0, {
-        p <- ggplot_boxplot(selectMatrix(), selectColData(), getGroupby(), expressiontype = getAssayMeasure(), whisker_distance = input$whiskerDistance, palette = getPalette())
-        print(p)
-      })
-    },
-    height = 600
-  )
-
-  # Provide the plot for download
-
-  plotSampleBoxplot <- reactive({
-    p <- ggplot_boxplot(selectMatrix(), selectColData(), colorBy())
-    print(p)
-  })
-
-  # Call to plotdownload module
-
-  callModule(plotdownload, "boxplot", makePlot = plotSampleBoxplot, filename = "boxplot.png", plotHeight = 600, plotWidth = 800)
 }
 
 #' Make a boxplot with coloring by experimental variable
@@ -195,7 +195,7 @@ boxplot <- function(input, output, session, eselist) {
 #' data(airway, package = "airway")
 #' ggplot_boxplot(assays(airway)[[1]], data.frame(colData(airway)), colorby = "dex")
 #'
-ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", whisker_distance = 1.5, base_size = 11, palette_name = 'Set1', annotate_samples = FALSE, should_transform = NULL) {
+ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", whisker_distance = 1.5, base_size = 11, palette_name = "Set1", annotate_samples = FALSE, should_transform = NULL) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, annotate_samples, should_transform = should_transform)
 
   if (!is.null(colorby)) {
@@ -215,10 +215,10 @@ ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = N
 
   if (is.list(plotmatrices) && length(plotmatrices) > 1) {
     n_col <- ifelse(sum(unlist(lapply(plotmatrices, ncol))) < 20, length(plotmatrices), 1)
-    p <- p + facet_wrap(~ type, ncol = n_col)
+    p <- p + facet_wrap(~type, ncol = n_col)
   }
 
-  p <- p + theme_bw(base_size=base_size) + theme(
+  p <- p + theme_bw(base_size = base_size) + theme(
     axis.text.x = element_text(angle = 90, hjust = 1, size = rel(1.5)), axis.title.x = element_blank(), legend.position = "bottom",
     axis.text.y = element_text(size = rel(1.5)), legend.text = element_text(size = rel(1.2)), title = element_text(size = rel(1.3)),
     strip.text.x = element_text(size = 10)
@@ -252,7 +252,7 @@ ggplot_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = N
 #'
 #' @keywords keywords
 
-plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, expressiontype = "expression", palette_name = 'Set1', annotate_samples = FALSE, should_transform = NULL) {
+plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, expressiontype = "expression", palette_name = "Set1", annotate_samples = FALSE, should_transform = NULL) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, annotate_samples = annotate_samples, should_transform = should_transform)
 
   ncats <- length(unique(plotdata$colorby))
@@ -320,7 +320,7 @@ plotly_boxplot <- function(plotmatrices, experiment, colorby, palette = NULL, ex
 #'
 #' @return output A \code{ggplot} output
 
-ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", base_size = 16, palette_name = 'Set1', annotate_samples = FALSE, should_transform = NULL) {
+ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", base_size = 16, palette_name = "Set1", annotate_samples = FALSE, should_transform = NULL) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, value_type = "density", annotate_samples = annotate_samples, should_transform = should_transform)
   if (is.null(palette)) {
     ncats <- length(unique(plotdata$colorby))
@@ -370,7 +370,7 @@ ggplot_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette
 #'
 #' @return output A \code{plotly} output
 
-plotly_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", palette_name = 'Set1', annotate_samples = FALSE, should_transform = NULL) {
+plotly_densityplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", palette_name = "Set1", annotate_samples = FALSE, should_transform = NULL) {
   plotdata <- ggplotify(plotmatrices, experiment, colorby, value_type = "density", annotate_samples = annotate_samples, should_transform = should_transform)
   if (is.null(palette)) {
     ncats <- length(unique(plotdata$colorby))

--- a/R/chipseq.R
+++ b/R/chipseq.R
@@ -148,86 +148,86 @@ chipseqInput <- function(id, eselist) {
 #' The server function of the chipseq module. Currently a near-clone of the
 #' RNA-seq module, with ChIP-seq optimisations planned.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(chipseq, "chipseq", eselist)
+#' chipseq("chipseq", eselist)
 #'
-chipseq <- function(input, output, session, eselist) {
-  # Add internal links to the tables with gene labels
+chipseq <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Add internal links to the tables with gene labels
 
-  for (esen in names(eselist)) {
-    ese <- eselist[[esen]]
+    for (esen in names(eselist)) {
+      ese <- eselist[[esen]]
 
-    if (length(ese@labelfield) > 0) {
-      eselist@url_roots[[ese@labelfield]] <- "?gene="
-      eselist@url_roots$significant_genes <- "?gene="
-      eselist@url_roots$gene_set_id <- "?geneset="
-    }
-  }
-
-  # Now a lot of boring calls to all the modules to activate the UI parts
-
-  callModule(experimenttable, "experimenttable", eselist)
-  callModule(rowmetatable, "rowmetatable", eselist)
-  callModule(heatmap, "heatmap-clustering", eselist, type = "samples")
-  callModule(heatmap, "heatmap-expression", eselist, type = "expression")
-  callModule(heatmap, "heatmap-pca", eselist, type = "pca")
-  callModule(pca, "pca", eselist)
-  callModule(boxplot, "boxplot", eselist)
-  callModule(dendro, "dendro", eselist)
-  callModule(assaydatatable, "expression", eselist)
-
-  # Calls for the various optional tables
-
-  if (any(unlist(lapply(eselist, function(ese) {
-    length(ese@read_reports) > 0
-  })))) {
-    callModule(readreports, "readrep", eselist)
-  }
-
-  if (length(eselist@contrasts) > 0) {
-    callModule(differentialtable, "differential", eselist)
-    callModule(volcanoplot, "volcano", eselist)
-    callModule(foldchangeplot, "foldchange", eselist)
-    callModule(maplot, "ma", eselist)
-    callModule(genesetanalysistable, "genesetanalysis", eselist)
-    updateBarcodeGeneset <- callModule(genesetbarcodeplot, "chipseq", eselist)
-    if (length(eselist@contrasts) > 1) {
-      callModule(upset, "upset", eselist)
-    }
-  }
-
-  updateGeneLabel <- callModule(gene, "gene", eselist)
-
-  # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
-  # accordingly
-
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-
-    if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
-      return()
-    }
-
-    url_observe <- observe({
-      if ("gene" %in% names(query)) {
-        updateNavbarPage(session, "chipseq", "geneinfo")
-        updateGeneLabel()
-      } else if ("geneset" %in% names(query)) {
-        updateNavbarPage(session, "chipseq", "genesetbarcode")
-        updateBarcodeGeneset()
+      if (length(ese@labelfield) > 0) {
+        eselist@url_roots[[ese@labelfield]] <- "?gene="
+        eselist@url_roots$significant_genes <- "?gene="
+        eselist@url_roots$gene_set_id <- "?geneset="
       }
-      url_observe$suspend()
+    }
+
+    # Now a lot of boring calls to all the modules to activate the UI parts
+
+    experimenttable("experimenttable", eselist)
+    rowmetatable("rowmetatable", eselist)
+    heatmap("heatmap-clustering", eselist, type = "samples")
+    heatmap("heatmap-expression", eselist, type = "expression")
+    heatmap("heatmap-pca", eselist, type = "pca")
+    pca("pca", eselist)
+    boxplot("boxplot", eselist)
+    dendro("dendro", eselist)
+    assaydatatable("expression", eselist)
+
+    # Calls for the various optional tables
+
+    if (any(unlist(lapply(eselist, function(ese) {
+      length(ese@read_reports) > 0
+    })))) {
+      readreports("readrep", eselist)
+    }
+
+    if (length(eselist@contrasts) > 0) {
+      differentialtable("differential", eselist)
+      volcanoplot("volcano", eselist)
+      foldchangeplot("foldchange", eselist)
+      maplot("ma", eselist)
+      genesetanalysistable("genesetanalysis", eselist)
+      updateBarcodeGeneset <- genesetbarcodeplot("chipseq", eselist)
+      if (length(eselist@contrasts) > 1) {
+        upset("upset", eselist)
+      }
+    }
+
+    updateGeneLabel <- gene("gene", eselist)
+
+    # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
+    # accordingly
+
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+
+      if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
+        return()
+      }
+
+      url_observe <- observe({
+        if ("gene" %in% names(query)) {
+          updateNavbarPage(session, "chipseq", "geneinfo")
+          updateGeneLabel()
+        } else if ("geneset" %in% names(query)) {
+          updateNavbarPage(session, "chipseq", "genesetbarcode")
+          updateBarcodeGeneset()
+        }
+        url_observe$suspend()
+      })
     })
   })
 }

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -90,244 +90,241 @@ clusteringOutput <- function(id) {
 #' defining the input matrix users can decide how the clusters are drawn and how
 #' many clusters should be generated.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(clustering, "myid", eselist)
+#' clustering("myid", eselist)
 #'
-clustering <- function(input, output, session, eselist) {
-  # Call the selectmatrix module to get the expression matrix - no need for a gene selection
+clustering <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Call the selectmatrix module to get the expression matrix - no need for a gene selection
 
-  unpack.list(callModule(selectmatrix, "clustering", eselist, select_genes = TRUE, var_n = 1000, provide_all_genes = TRUE, default_gene_select = "variance"))
+    unpack.list(selectmatrix("clustering", eselist, select_genes = TRUE, var_n = 1000, provide_all_genes = TRUE, default_gene_select = "variance"))
 
-  getPalette <- callModule(colormaker, "clustering", getNumberCategories = getClusterNumber)
+    getPalette <- colormaker("clustering", getNumberCategories = getClusterNumber)
 
-  ############################################################################# Form accessors
+    ############################################################################# Form accessors
 
-  # The number of clusters
+    # The number of clusters
 
-  getClusterNumber <- reactive({
-    validate(need(!is.null(input$cluster_number), "waiting for cluster number"))
-    as.numeric(input$cluster_number)
-  })
-
-  # How limits of error bars etc should be defined
-
-  getLimits <- reactive({
-    validate(need(!is.null(input$limits), "Waiting for limits"))
-    limits <- input$limits
-
-    average_type <- getAverageType()
-    if (average_type == "median") {
-      limits <- paste0("median.", limits)
-    }
-    limits
-  })
-
-  # Use mean or median?
-
-  getAverageType <- reactive({
-    validate(need(!is.null(input$average_type), "Waiting for average type"))
-    input$average_type
-  })
-
-  # How to display clusters
-
-  getClusterDisplay <- reactive({
-    validate(need(!is.null(input$cluster_display), "waiting for cluster display"))
-    input$cluster_display
-  })
-
-  ############################################################################# Display things
-
-  errorBarsSubtitle <- reactive({
-    limits <- getLimits()
-    limit_types <- c(sd = "standard deviation", se = "standard error", ci = "95% Confidence interval")
-    cluster_display <- getClusterDisplay()
-    average_type <- getAverageType()
-
-    subtitle <- ""
-    if (cluster_display != "sample_lines") {
-      subtitle <- paste0("(Limits show ", limit_types[limits], "s of the ", getAverageType(), ")")
-    }
-    subtitle
-  })
-
-  # Create title reflecting how the input matrix for clustering was generated
-
-  output$geneClusteringTitle <- renderUI({
-    list(h3(paste("Feature-wise clustering for feature set:", matrixTitle())), h4(errorBarsSubtitle()))
-  })
-
-  # A common set of colors however the clusters are plotted
-
-  # getClusterColors <- reactive({ number_of_clusters <- getClusterNumber() makeColorScale(as.numeric(number_of_clusters), 'Dark2') })
-
-  ############################################################################# Clustering
-
-  # Make a scaled version of the input matrix suitable for clustering and visualisation
-
-  scaleMatrix <- reactive({
-    inmatrix <- selectMatrix()
-    data.frame(t(scale(t(inmatrix))), check.names = FALSE)
-  })
-
-  # Do the actual clustering. Assign genes/rows to clusters.
-
-  makeClusters <- reactive({
-    scaled_inmatrix <- scaleMatrix()
-    cluster_number <- getClusterNumber()
-    withProgress(message = "Calculating clusters with clara()", value = 0, {
-      cluster::clara(scaled_inmatrix, cluster_number, samples = 50)
+    getClusterNumber <- reactive({
+      validate(need(!is.null(input$cluster_number), "waiting for cluster number"))
+      as.numeric(input$cluster_number)
     })
-  })
 
-  # Get the matrix of values for each cluster
+    # How limits of error bars etc should be defined
 
-  getMatricesByCluster <- reactive({
-    scaled_inmatrix <- scaleMatrix()
-    clusters <- makeClusters()
-    split(scaled_inmatrix, clusters$clustering[match(rownames(scaled_inmatrix), names(clusters$clustering))])
-  })
+    getLimits <- reactive({
+      validate(need(!is.null(input$limits), "Waiting for limits"))
+      limits <- input$limits
 
-  # A reactive to define what summary stats are used
+      average_type <- getAverageType()
+      if (average_type == "median") {
+        limits <- paste0("median.", limits)
+      }
+      limits
+    })
 
-  addMedians <- reactive({
-    average_type <- getAverageType()
-    average_type == "median"
-  })
+    # Use mean or median?
 
-  # Generate summary statistics from the matrix for each cluster. This is what's actually plotted if cluster display is set to something other than 'sample
-  # lines'.  Uses summarySE() to derive mean, median, standard error, standard deviation and 95% confidence intervals.
+    getAverageType <- reactive({
+      validate(need(!is.null(input$average_type), "Waiting for average type"))
+      input$average_type
+    })
 
-  getSummarisedMatricesByCluster <- reactive({
-    matrices_by_cluster <- getMatricesByCluster()
-    add_medians <- addMedians()
+    # How to display clusters
 
-    withProgress(message = "Calculating summary statistics for the clusters", value = 0, {
-      lapply(matrices_by_cluster, function(mbc) {
-        summarySE(reshape2::melt(as.matrix(mbc)), measurevar = "value", groupvars = "Var2", add_medians = add_medians)
+    getClusterDisplay <- reactive({
+      validate(need(!is.null(input$cluster_display), "waiting for cluster display"))
+      input$cluster_display
+    })
+
+    ############################################################################# Display things
+
+    errorBarsSubtitle <- reactive({
+      limits <- getLimits()
+      limit_types <- c(sd = "standard deviation", se = "standard error", ci = "95% Confidence interval")
+      cluster_display <- getClusterDisplay()
+      average_type <- getAverageType()
+
+      subtitle <- ""
+      if (cluster_display != "sample_lines") {
+        subtitle <- paste0("(Limits show ", limit_types[limits], "s of the ", getAverageType(), ")")
+      }
+      subtitle
+    })
+
+    # Create title reflecting how the input matrix for clustering was generated
+
+    output$geneClusteringTitle <- renderUI({
+      list(h3(paste("Feature-wise clustering for feature set:", matrixTitle())), h4(errorBarsSubtitle()))
+    })
+
+    # A common set of colors however the clusters are plotted
+
+    # getClusterColors <- reactive({ number_of_clusters <- getClusterNumber() makeColorScale(as.numeric(number_of_clusters), 'Dark2') })
+
+    ############################################################################# Clustering
+
+    # Make a scaled version of the input matrix suitable for clustering and visualisation
+
+    scaleMatrix <- reactive({
+      inmatrix <- selectMatrix()
+      data.frame(t(scale(t(inmatrix))), check.names = FALSE)
+    })
+
+    # Do the actual clustering. Assign genes/rows to clusters.
+
+    makeClusters <- reactive({
+      scaled_inmatrix <- scaleMatrix()
+      cluster_number <- getClusterNumber()
+      withProgress(message = "Calculating clusters with clara()", value = 0, {
+        cluster::clara(scaled_inmatrix, cluster_number, samples = 50)
       })
     })
-  })
 
-  # The business end of the cluster plotting. Use the above parameters and processing to produce one plot object for each cluster of matrix rows.
+    # Get the matrix of values for each cluster
 
-  makeClusterPlots <- reactive({
-    matrices_by_cluster <- getMatricesByCluster()
-    summarised_matrices_by_cluster <- getSummarisedMatricesByCluster()
-    cluster_colors <- getPalette()
-    limits <- getLimits()
-    average_type <- getAverageType()
-    cluster_display <- getClusterDisplay()
-
-    if (cluster_display == "sample_lines") {
-      plots <- lapply(names(matrices_by_cluster), function(c) {
-        cluster_color <- cluster_colors[as.numeric(c)]
-
-        x <- matrices_by_cluster[[c]]
-        if (nrow(x) > 100) {
-          x <- x[sample(1:nrow(x), 100), ]
-        }
-        x <- reshape2::melt(as.matrix(x))
-        x %>%
-          group_by(Var1) %>%
-          plot_ly(x = ~Var2, y = ~value, type = "scatter", mode = "lines", text = ~Var1, name = paste("Cluster", c), line = list(color = cluster_color))
-      })
-    } else if (cluster_display == "error_bars") {
-      plots <- lapply(names(summarised_matrices_by_cluster), function(c) {
-        cluster_color <- cluster_colors[as.numeric(c)]
-        x <- summarised_matrices_by_cluster[[c]]
-        plot_ly(x, x = ~Var2, y = ~ x[, average_type], name = paste("Cluster", c)) %>% add_lines(error_y = ~ list(
-          name = paste("Cluster", c), color = cluster_color,
-          type = "array", array = x[, limits]
-        ), line = list(color = cluster_color))
-      })
-    } else {
-      plots <- lapply(names(matrices_by_cluster), function(c) {
-        cluster_color <- cluster_colors[as.numeric(c)]
-        x <- summarised_matrices_by_cluster[[c]]
-
-        x$lower <- x[, average_type] - x[, limits]
-        x$upper <- x[, average_type] + x[, limits]
-
-        plot_ly(x, name = paste("Cluster", c)) %>%
-          add_trace(
-            x = ~Var2, y = x[, average_type], type = "scatter", mode = "lines", line = list(color = cluster_color),
-            showlegend = TRUE
-          ) %>%
-          add_trace(
-            x = ~Var2, y = ~upper, type = "scatter", mode = "lines", line = list(color = "transparent"), showlegend = FALSE,
-            name = paste(average_type, toupper(limits), sep = " + ")
-          ) %>%
-          add_trace(
-            x = ~Var2, y = ~lower, type = "scatter", mode = "lines", fill = "tonexty",
-            fillcolor = "rgba(0,100,80,0.2)", line = list(color = "transparent"), showlegend = FALSE, name = paste(average_type, toupper(limits), sep = " - ")
-          )
-      })
-    }
-
-    experiment <- selectColData()
-
-    lapply(plots, function(p) {
-      p %>% layout(
-        xaxis = list(categoryarray = rownames(experiment), categoryorder = "array", title = ""), yaxis = list(title = "scaled<br />expression"),
-        margin = list(b = 150)
-      )
-    })
-  })
-
-  # Take individual cluster plots and display them together using subplot.
-
-  output$geneClusteringPlot <- renderPlotly({
-    withProgress(message = "Plotting cluster profiles", value = 0, {
+    getMatricesByCluster <- reactive({
       scaled_inmatrix <- scaleMatrix()
       clusters <- makeClusters()
-
-      withProgress(message = "Making a plot for each cluster", value = 0, {
-        plots <- makeClusterPlots()
-      })
-      do.call(function(...) subplot(..., titleX = TRUE, titleY = TRUE, shareY = TRUE, shareX = TRUE, nrows = ceiling(length(plots) / 3)), plots) %>% config(showLink = TRUE)
+      split(scaled_inmatrix, clusters$clustering[match(rownames(scaled_inmatrix), names(clusters$clustering))])
     })
+
+    # A reactive to define what summary stats are used
+
+    addMedians <- reactive({
+      average_type <- getAverageType()
+      average_type == "median"
+    })
+
+    # Generate summary statistics from the matrix for each cluster. This is what's actually plotted if cluster display is set to something other than 'sample
+    # lines'.  Uses summarySE() to derive mean, median, standard error, standard deviation and 95% confidence intervals.
+
+    getSummarisedMatricesByCluster <- reactive({
+      matrices_by_cluster <- getMatricesByCluster()
+      add_medians <- addMedians()
+
+      withProgress(message = "Calculating summary statistics for the clusters", value = 0, {
+        lapply(matrices_by_cluster, function(mbc) {
+          summarySE(reshape2::melt(as.matrix(mbc)), measurevar = "value", groupvars = "Var2", add_medians = add_medians)
+        })
+      })
+    })
+
+    # The business end of the cluster plotting. Use the above parameters and processing to produce one plot object for each cluster of matrix rows.
+
+    makeClusterPlots <- reactive({
+      matrices_by_cluster <- getMatricesByCluster()
+      summarised_matrices_by_cluster <- getSummarisedMatricesByCluster()
+      cluster_colors <- getPalette()
+      limits <- getLimits()
+      average_type <- getAverageType()
+      cluster_display <- getClusterDisplay()
+
+      if (cluster_display == "sample_lines") {
+        plots <- lapply(names(matrices_by_cluster), function(c) {
+          cluster_color <- cluster_colors[as.numeric(c)]
+
+          x <- matrices_by_cluster[[c]]
+          if (nrow(x) > 100) {
+            x <- x[sample(1:nrow(x), 100), ]
+          }
+          x <- reshape2::melt(as.matrix(x))
+          x %>%
+            group_by(Var1) %>%
+            plot_ly(x = ~Var2, y = ~value, type = "scatter", mode = "lines", text = ~Var1, name = paste("Cluster", c), line = list(color = cluster_color))
+        })
+      } else if (cluster_display == "error_bars") {
+        plots <- lapply(names(summarised_matrices_by_cluster), function(c) {
+          cluster_color <- cluster_colors[as.numeric(c)]
+          x <- summarised_matrices_by_cluster[[c]]
+          plot_ly(x, x = ~Var2, y = ~ x[, average_type], name = paste("Cluster", c)) %>% add_lines(error_y = ~ list(
+            name = paste("Cluster", c), color = cluster_color,
+            type = "array", array = x[, limits]
+          ), line = list(color = cluster_color))
+        })
+      } else {
+        plots <- lapply(names(matrices_by_cluster), function(c) {
+          cluster_color <- cluster_colors[as.numeric(c)]
+          x <- summarised_matrices_by_cluster[[c]]
+
+          x$lower <- x[, average_type] - x[, limits]
+          x$upper <- x[, average_type] + x[, limits]
+
+          plot_ly(x, name = paste("Cluster", c)) %>%
+            add_trace(
+              x = ~Var2, y = x[, average_type], type = "scatter", mode = "lines", line = list(color = cluster_color),
+              showlegend = TRUE
+            ) %>%
+            add_trace(
+              x = ~Var2, y = ~upper, type = "scatter", mode = "lines", line = list(color = "transparent"), showlegend = FALSE,
+              name = paste(average_type, toupper(limits), sep = " + ")
+            ) %>%
+            add_trace(
+              x = ~Var2, y = ~lower, type = "scatter", mode = "lines", fill = "tonexty",
+              fillcolor = "rgba(0,100,80,0.2)", line = list(color = "transparent"), showlegend = FALSE, name = paste(average_type, toupper(limits), sep = " - ")
+            )
+        })
+      }
+
+      experiment <- selectColData()
+
+      lapply(plots, function(p) {
+        p %>% layout(
+          xaxis = list(categoryarray = rownames(experiment), categoryorder = "array", title = ""), yaxis = list(title = "scaled<br />expression"),
+          margin = list(b = 150)
+        )
+      })
+    })
+
+    # Take individual cluster plots and display them together using subplot.
+
+    output$geneClusteringPlot <- renderPlotly({
+      withProgress(message = "Plotting cluster profiles", value = 0, {
+        scaled_inmatrix <- scaleMatrix()
+        clusters <- makeClusters()
+
+        withProgress(message = "Making a plot for each cluster", value = 0, {
+          plots <- makeClusterPlots()
+        })
+        do.call(function(...) subplot(..., titleX = TRUE, titleY = TRUE, shareY = TRUE, shareX = TRUE, nrows = ceiling(length(plots) / 3)), plots) %>% config(showLink = TRUE)
+      })
+    })
+
+    ############################################################################# Functions for making the table of values with cluster numbers
+
+    makeMatrixWithClusters <- reactive({
+      inmatrix <- selectMatrix()
+      clusters <- makeClusters()
+      ese <- getExperiment()
+      mf <- getMetafields()
+
+      inmatrix <- data.frame(inmatrix, check.names = FALSE)
+
+      inmatrix$cluster <- clusters$clustering[match(rownames(inmatrix), names(clusters$clustering))]
+      inmatrix <- inmatrix[, c("cluster", colnames(inmatrix)[colnames(inmatrix) != "cluster"])]
+      labelMatrix(inmatrix, ese, metafields = mf)
+    })
+
+    # Add links to the table
+
+    makeLinkedMatrixWithClusters <- reactive({
+      mwc <- makeMatrixWithClusters()
+      linkMatrix(mwc, eselist@url_roots)
+    })
+
+    # Render the table and provide for download, using the simpletable module.
+
+    simpletable("geneClusteringTable", downloadMatrix = makeMatrixWithClusters, displayMatrix = makeLinkedMatrixWithClusters, filter = "top", filename = "clustered_matrix", rownames = FALSE)
   })
-
-  ############################################################################# Functions for making the table of values with cluster numbers
-
-  makeMatrixWithClusters <- reactive({
-    inmatrix <- selectMatrix()
-    clusters <- makeClusters()
-    ese <- getExperiment()
-    mf <- getMetafields()
-
-    inmatrix <- data.frame(inmatrix, check.names = FALSE)
-
-    inmatrix$cluster <- clusters$clustering[match(rownames(inmatrix), names(clusters$clustering))]
-    inmatrix <- inmatrix[, c("cluster", colnames(inmatrix)[colnames(inmatrix) != "cluster"])]
-    labelMatrix(inmatrix, ese, metafields = mf)
-  })
-
-  # Add links to the table
-
-  makeLinkedMatrixWithClusters <- reactive({
-    mwc <- makeMatrixWithClusters()
-    linkMatrix(mwc, eselist@url_roots)
-  })
-
-  # Render the table and provide for download, using the simpletable module.
-
-  callModule(simpletable, "geneClusteringTable",
-    downloadMatrix = makeMatrixWithClusters, displayMatrix = makeLinkedMatrixWithClusters, filter = "top", filename = "clustered_matrix",
-    rownames = FALSE
-  )
 }
 
 #' Summarise an input matrix
@@ -440,35 +437,35 @@ madScore <- function(matrix, sample_sheet = NULL, groupby = NULL, outlier_thresh
 
   group_sizes <- table(sample_sheet[[groupby]])
   mad_valid_groups <- group_sizes[group_sizes > 2]
-  
-  if (length(mad_valid_groups) == 0){
-    print("WARNING: low replication, skipping outlier detection ...")  
+
+  if (length(mad_valid_groups) == 0) {
+    print("WARNING: low replication, skipping outlier detection ...")
     NULL
-  }else{
+  } else {
     mad_valid_samples <- which(sample_sheet[[groupby]] %in% names(mad_valid_groups))
 
     matrix <- matrix[, mad_valid_samples]
     sample_sheet <- sample_sheet[mad_valid_samples, ]
-    
+
     if (is.null(groupby)) {
       matrices <- list(all = matrix)
     } else {
       matrices <- lapply(split(rownames(sample_sheet), sample_sheet[[groupby]]), function(x) matrix[, x])
     }
-    
+
     # The following intentionally verbose to highlight logic
-    
+
     mads <- do.call(rbind, lapply(names(matrices), function(g) {
       corrs <- cor(matrices[[g]])
       corrs_involving <- unlist(lapply(1:ncol(corrs), function(x) mean(corrs[x, -x])))
       corrs_not_involving <- unlist(lapply(1:ncol(corrs), function(x) mean(corrs[-x, -x][upper.tri(corrs[-x, -x])])))
-      
+
       correlation_difference <- structure(corrs_involving - corrs_not_involving, names = colnames(corrs))
       median_correlation_differences <- median(correlation_difference)
       median_absolute_deviation <- median(abs(correlation_difference - median_correlation_differences))
       data.frame(group = g, mad = (correlation_difference - median_correlation_differences) / (median_absolute_deviation * 1.4826))
     }))
-    
+
     mads$outlier <- mads$mad < outlier_threshold
     mads
   }

--- a/R/colormaker.R
+++ b/R/colormaker.R
@@ -30,12 +30,10 @@ colormakerInput <- function(id) {
 #' and provides that palette given a reactive which supplied the required
 #' number of colors.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param getNumberCategories A reactive supplying the number of categories
 #' that require a color.
 #'
@@ -45,19 +43,21 @@ colormakerInput <- function(id) {
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(colormaker, "myid", getNumberCategories)
+#' colormaker("myid", getNumberCategories)
 #'
-colormaker <- function(input, output, session, getNumberCategories) {
-  getPaletteName <- reactive({
-    validate(need(!is.null(input$palette_name), "Waiting for palette"))
-    input$palette_name
-  })
+colormaker <- function(id, getNumberCategories) {
+  moduleServer(id, function(input, output, session) {
+    getPaletteName <- reactive({
+      validate(need(!is.null(input$palette_name), "Waiting for palette"))
+      input$palette_name
+    })
 
-  reactive({
-    palette <- getPaletteName()
-    n_colors <- getNumberCategories()
+    reactive({
+      palette <- getPaletteName()
+      n_colors <- getNumberCategories()
 
-    makeColorScale(n_colors, palette)
+      makeColorScale(n_colors, palette)
+    })
   })
 }
 

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -85,12 +85,10 @@ contrastsOutput <- function(id) {
 #' differential expression panels. In particular it provides the ability for
 #' users to add filters to progressively refine a query.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param selectmatrix_reactives The list of reactive expressions returned by
@@ -108,696 +106,697 @@ contrastsOutput <- function(id) {
 #' @import data.table
 #'
 #' @examples
-#' callModule(contrasts, "differential", getExperiment = getExperiment, selectMatrix = selectMatrix, getAssay = getAssay, multiple = TRUE)
+#' contrasts("differential", getExperiment = getExperiment, selectMatrix = selectMatrix, getAssay = getAssay, multiple = TRUE)
 #'
-contrasts <- function(input, output, session, eselist, selectmatrix_reactives = list(), multiple = FALSE, select_all_contrasts = FALSE, show_controls = TRUE,
-                      default_foldchange = 2, default_pval = 0.05, default_qval = 0.1) {
-  ns <- session$ns
+contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = FALSE, select_all_contrasts = FALSE, show_controls = TRUE, default_foldchange = 2, default_pval = 0.05, default_qval = 0.1) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
-  unpack.list(selectmatrix_reactives)
+    unpack.list(selectmatrix_reactives)
 
-  getSummaryType <- callModule(summarisematrix, "contrasts")
+    getSummaryType <- summarisematrix("contrasts")
 
-  ########################################################################### Rendering the contrast control filter sets
+    ########################################################################### Rendering the contrast control filter sets
 
-  inserted <- c() # Stores the list of inserted filter sets
-  filterset_values <- list() # Stores the list of values in the filter set
-  makeReactiveBinding("filterset_values") # Make the stored values reactive
+    inserted <- c() # Stores the list of inserted filter sets
+    filterset_values <- list() # Stores the list of values in the filter set
+    makeReactiveBinding("filterset_values") # Make the stored values reactive
 
-  filter_observers <- list()
+    filter_observers <- list()
 
-  # This observer adds a set of filters on the first page load and when the assocaited button is clicked.
+    # This observer adds a set of filters on the first page load and when the assocaited button is clicked.
 
-  observeEvent(
-    {
-      selectMatrix()
-      input$insertBtn
-    },
-    {
-      ese <- getExperiment()
-      contrasts <- getAllContrasts()
-      contrast_numbers <- getAllContrastsNumbers()
-      assay <- getAssay()
-      coldata <- selectColData()
+    observeEvent(
+      {
+        selectMatrix()
+        input$insertBtn
+      },
+      {
+        ese <- getExperiment()
+        contrasts <- getAllContrasts()
+        contrast_numbers <- getAllContrastsNumbers()
+        assay <- getAssay()
+        coldata <- selectColData()
 
-      # Restrict contrasts to those valid for the input matrix
+        # Restrict contrasts to those valid for the input matrix
 
-      valid_contrasts <- unlist(lapply(contrasts, function(cont) {
-        all(c(cont['Group.1'], cont['Group.2']) %in% coldata[[cont['Variable']]])
-      }))
-      contrasts <- contrasts[valid_contrasts]
-      contrast_numbers <- contrast_numbers[valid_contrasts]
+        valid_contrasts <- unlist(lapply(contrasts, function(cont) {
+          all(c(cont["Group.1"], cont["Group.2"]) %in% coldata[[cont["Variable"]]])
+        }))
+        contrasts <- contrasts[valid_contrasts]
+        contrast_numbers <- contrast_numbers[valid_contrasts]
 
-      # btn keeps track of how many filter sets have been added
+        # btn keeps track of how many filter sets have been added
 
-      btn <- length(inserted)
+        btn <- length(inserted)
 
-      # Call makeContrastFilterSet() to generate a set of filters, and add to the UI with insertUI()
+        # Call makeContrastFilterSet() to generate a set of filters, and add to the UI with insertUI()
 
-      insertUI(selector = paste0("#", ns("contrasts-placeholder")), where = "beforeEnd", ui = makeContrastFilterSet(ns, ese, assay, contrasts, contrast_numbers,
-        multiple = multiple, show_controls = show_controls, default_foldchange = default_foldchange, default_pval = default_pval, default_qval = default_qval,
-        filter_rows = getFilterRows(), index = btn, select_all_contrasts = select_all_contrasts
-      ))
+        insertUI(selector = paste0("#", ns("contrasts-placeholder")), where = "beforeEnd", ui = makeContrastFilterSet(ns, ese, assay, contrasts, contrast_numbers,
+          multiple = multiple, show_controls = show_controls, default_foldchange = default_foldchange, default_pval = default_pval, default_qval = default_qval,
+          filter_rows = getFilterRows(), index = btn, select_all_contrasts = select_all_contrasts
+        ))
 
-      # Record the ID of the added filter set
+        # Record the ID of the added filter set
 
-      inserted <<- c(inserted, paste0("contrast", btn))
+        inserted <<- c(inserted, paste0("contrast", btn))
 
-      # Now add observers for each new element generated by makeControlFilterSet(). When they fire, these observers will add the filter values to the reactive
-      # filterset_values. When this is referenced (by e.g. getFoldChange()), the dependency chain is established such that outputs are refreshed when the
-      # dynamically added fields are altered.
+        # Now add observers for each new element generated by makeControlFilterSet(). When they fire, these observers will add the filter values to the reactive
+        # filterset_values. When this is referenced (by e.g. getFoldChange()), the dependency chain is established such that outputs are refreshed when the
+        # dynamically added fields are altered.
 
-      filterId <- paste0("filter", btn)
+        filterId <- paste0("filter", btn)
 
-      filter_observers[[filterId]] <<- lapply(c("contrasts", "fold_change", "q_value", "p_value", "fold_change_card", "q_value_card", "p_value_card"), function(field) {
-        filter_field_id <- paste0(field, btn)
-        observeEvent(input[[filter_field_id]],
-          {
-            req(input[[filter_field_id]])
-            if (is.null(filterset_values[[filterId]])) {
-              filterset_values[[filterId]] <<- list()
-            }
+        filter_observers[[filterId]] <<- lapply(c("contrasts", "fold_change", "q_value", "p_value", "fold_change_card", "q_value_card", "p_value_card"), function(field) {
+          filter_field_id <- paste0(field, btn)
+          observeEvent(input[[filter_field_id]],
+            {
+              req(input[[filter_field_id]])
+              if (is.null(filterset_values[[filterId]])) {
+                filterset_values[[filterId]] <<- list()
+              }
 
-            if (length(input[[filter_field_id]]) == 1 && input[[filter_field_id]] == "NULL") {
-              filterset_values[[filterId]][[field]] <<- NULL
-            } else {
-              filterset_values[[filterId]][[field]] <<- input[[filter_field_id]]
-            }
+              if (length(input[[filter_field_id]]) == 1 && input[[filter_field_id]] == "NULL") {
+                filterset_values[[filterId]][[field]] <<- NULL
+              } else {
+                filterset_values[[filterId]][[field]] <<- input[[filter_field_id]]
+              }
 
-            # filterset_values[[filterId]][[paste0(field, 'card')]] <<- input[[paste0(filter_field_id, 'card')]]
-          },
-          ignoreNULL = FALSE
-        )
-      })
-    },
-    ignoreNULL = FALSE,
-    priority = 1
-  )
-
-  # This observer removes a filter set when the 'remove' button is clicked.  This removes both the UI element and its stored values in filterset_values
-
-  observeEvent(input$removeBtn, {
-    if (length(inserted) > 1) {
-      removeUI(selector = paste0("#", inserted[length(inserted)]))
-      inserted <<- inserted[-length(inserted)]
-      filterset_values[[length(filterset_values)]] <<- NULL
-    }
-  })
-
-  # When a new assay is selected, or when the input matrix is otherwise changed, we need to rebuild the inputs
-
-  observeEvent(selectMatrix(),
-    {
-      if (length(inserted) > 0) {
-        lapply(names(filterset_values), function(filterId) {
-          lapply(names(filterset_values[[filterId]]), function(field) {
-            filterset_values[[filterId]][[field]] <<- NULL
-          })
-          filterset_values[[filterId]] <<- NULL
+              # filterset_values[[filterId]][[paste0(field, 'card')]] <<- input[[paste0(filter_field_id, 'card')]]
+            },
+            ignoreNULL = FALSE
+          )
         })
-        removeUI(selector = ".shinyngs-contrast", multiple = TRUE, immediate = TRUE)
-        inserted <<- c()
+      },
+      ignoreNULL = FALSE,
+      priority = 1
+    )
+
+    # This observer removes a filter set when the 'remove' button is clicked.  This removes both the UI element and its stored values in filterset_values
+
+    observeEvent(input$removeBtn, {
+      if (length(inserted) > 1) {
+        removeUI(selector = paste0("#", inserted[length(inserted)]))
+        inserted <<- inserted[-length(inserted)]
+        filterset_values[[length(filterset_values)]] <<- NULL
       }
-    },
-    priority = 2
-  )
+    })
 
-  # The combine_operator field is only necessary with more than one filter set
+    # When a new assay is selected, or when the input matrix is otherwise changed, we need to rebuild the inputs
 
-  output$combine_operator <- renderUI({
-    scn <- getSelectedContrastNumbers()
-    if (length(scn) > 1) {
-      inlineField(selectInput(ns("combine_operator"), NULL, c(and = "intersect", or = "union")), label = "Combine using", 6)
-    } else {
-      hiddenInput(ns("combine_operator"), "intersect")
-    }
-  })
+    observeEvent(selectMatrix(),
+      {
+        if (length(inserted) > 0) {
+          lapply(names(filterset_values), function(filterId) {
+            lapply(names(filterset_values[[filterId]]), function(field) {
+              filterset_values[[filterId]][[field]] <<- NULL
+            })
+            filterset_values[[filterId]] <<- NULL
+          })
+          removeUI(selector = ".shinyngs-contrast", multiple = TRUE, immediate = TRUE)
+          inserted <<- c()
+        }
+      },
+      priority = 2
+    )
 
-  ########################################################################### Accessors for form values
+    # The combine_operator field is only necessary with more than one filter set
 
-  # Get current value of field which determines if the table should be filtered at all.
+    output$combine_operator <- renderUI({
+      scn <- getSelectedContrastNumbers()
+      if (length(scn) > 1) {
+        inlineField(selectInput(ns("combine_operator"), NULL, c(and = "intersect", or = "union")), label = "Combine using", 6)
+      } else {
+        hiddenInput(ns("combine_operator"), "intersect")
+      }
+    })
 
-  getFilterRows <- reactive({
-    req(! is.null(input$filterRows))
-    as.logical(input$filterRows)
-  })
+    ########################################################################### Accessors for form values
 
-  # Get the indices of the currently selected contrasts for each filter set by querying filterset_values.
+    # Get current value of field which determines if the table should be filtered at all.
 
-  getSelectedContrastNumbers <- reactive({
-    req(length(filterset_values) > 0)
-    lapply(filterset_values, function(x) x$contrasts)
-  })
+    getFilterRows <- reactive({
+      req(!is.null(input$filterRows))
+      as.logical(input$filterRows)
+    })
 
-  # Fetch the values from all the fold change filters
+    # Get the indices of the currently selected contrasts for each filter set by querying filterset_values.
 
-  getFoldChange <- reactive({
-    req(length(filterset_values) > 0)
-    unlist(lapply(filterset_values, function(x) x$fold_change))
-  })
+    getSelectedContrastNumbers <- reactive({
+      req(length(filterset_values) > 0)
+      lapply(filterset_values, function(x) x$contrasts)
+    })
 
-  # Fetch the values from all the fold change cardinality filters
+    # Fetch the values from all the fold change filters
 
-  getFoldChangeCard <- reactive({
-    req(length(filterset_values) > 0)
-    card <- unlist(lapply(filterset_values, function(x) x$fold_change_card))
-    if (fcsAvailable()) {
-      req(length(card) > 0)
-    }
-    card
-  })
+    getFoldChange <- reactive({
+      req(length(filterset_values) > 0)
+      unlist(lapply(filterset_values, function(x) x$fold_change))
+    })
 
-  # Get current value of the q value filter
+    # Fetch the values from all the fold change cardinality filters
 
-  getQval <- reactive({
-    req(length(filterset_values) > 0)
-    unlist(lapply(filterset_values, function(x) x$q_value))
-  })
+    getFoldChangeCard <- reactive({
+      req(length(filterset_values) > 0)
+      card <- unlist(lapply(filterset_values, function(x) x$fold_change_card))
+      if (fcsAvailable()) {
+        req(length(card) > 0)
+      }
+      card
+    })
 
-  # Get current value of the q value cardinality filter
+    # Get current value of the q value filter
 
-  getQvalCard <- reactive({
-    req(length(filterset_values) > 0)
-    card <- unlist(lapply(filterset_values, function(x) x$q_value_card))
-    if (qvalsAvailable()) {
-      req(length(card) > 0)
-    }
-    card
-  })
+    getQval <- reactive({
+      req(length(filterset_values) > 0)
+      unlist(lapply(filterset_values, function(x) x$q_value))
+    })
 
-  # Get current value of the p value filter
+    # Get current value of the q value cardinality filter
 
-  getPval <- reactive({
-    req(length(filterset_values) > 0)
-    unlist(lapply(filterset_values, function(x) x$p_value))
-  })
+    getQvalCard <- reactive({
+      req(length(filterset_values) > 0)
+      card <- unlist(lapply(filterset_values, function(x) x$q_value_card))
+      if (qvalsAvailable()) {
+        req(length(card) > 0)
+      }
+      card
+    })
 
-  # Get current value of the p value cardinality filter
+    # Get current value of the p value filter
 
-  getPvalCard <- reactive({
-    req(length(filterset_values) > 0)
-    card <- unlist(lapply(filterset_values, function(x) x$p_value_card))
-    if (pvalsAvailable()) {
-      req(length(card) > 0)
-    }
-    card
-  })
+    getPval <- reactive({
+      req(length(filterset_values) > 0)
+      unlist(lapply(filterset_values, function(x) x$p_value))
+    })
 
-  # Get method for combining filters
+    # Get current value of the p value cardinality filter
 
-  getFilterSetCombinationOperator <- reactive({
-    req(input$combine_operator)
-    input$combine_operator
-  })
+    getPvalCard <- reactive({
+      req(length(filterset_values) > 0)
+      card <- unlist(lapply(filterset_values, function(x) x$p_value_card))
+      if (pvalsAvailable()) {
+        req(length(card) > 0)
+      }
+      card
+    })
 
-  # Use presence of combine operator as a flag for use of dynamic contrasts, i.e. the possibility of multiple filter sets
+    # Get method for combining filters
 
-  isDynamic <- reactive({
-    !is.null(input$dynamic)
-  })
+    getFilterSetCombinationOperator <- reactive({
+      req(input$combine_operator)
+      input$combine_operator
+    })
 
-  ########################################################################### Generate summaries and contrast stats for all contrasts and all rows.  Then the data is handy for subsetting by other functions.  NOTE: this uses ALL
-  ########################################################################### rows in the input ExploratorySummarizedExperiment.  The rows in the matrix returned by selectMatrix() will but a subset, but any modifications to the
-  ########################################################################### rows used will not necessitate a re-calculation of these basic stats.
+    # Use presence of combine operator as a flag for use of dynamic contrasts, i.e. the possibility of multiple filter sets
 
-  # Generate the summary statistic (probably mean) for column groups as defined by the possible contrasts. Other functions can then pick from this output and
-  # calculate fold changes etc.
+    isDynamic <- reactive({
+      !is.null(input$dynamic)
+    })
 
-  getSummaries <- reactive({
-    if (!is.null(getSummaryType())) {
-      ese <- getExperiment()
+    ########################################################################### Generate summaries and contrast stats for all contrasts and all rows.  Then the data is handy for subsetting by other functions.  NOTE: this uses ALL
+    ########################################################################### rows in the input ExploratorySummarizedExperiment.  The rows in the matrix returned by selectMatrix() will but a subset, but any modifications to the
+    ########################################################################### rows used will not necessitate a re-calculation of these basic stats.
+
+    # Generate the summary statistic (probably mean) for column groups as defined by the possible contrasts. Other functions can then pick from this output and
+    # calculate fold changes etc.
+
+    getSummaries <- reactive({
+      if (!is.null(getSummaryType())) {
+        ese <- getExperiment()
+        contrasts <- getAllContrasts()
+        matrix <- getAssayMatrix()
+        coldata <- data.frame(colData(ese), check.names = FALSE)
+
+        validate(need(nrow(matrix) > 0, "Waiting for input matrix"))
+
+        contrast_variables <- unique(unlist(lapply(contrasts, function(x) x["Variable"])))
+        names(contrast_variables) <- contrast_variables
+
+        withProgress(message = paste("Calculating summaries by", getSummaryType()), value = 0, {
+          summaries <- lapply(contrast_variables, function(cv) summarizeMatrix(matrix, coldata[[cv]], getSummaryType()))
+        })
+
+        summaries
+      }
+    })
+
+    # Get all the contrasts the user specified in their StructuredExperiment- if any
+
+    getAllContrasts <- reactive({
+      if (length(eselist@contrasts) > 0) {
+        contrasts <- eselist@contrasts
+
+        contrasts <- lapply(contrasts, function(cont) {
+          if (is.null(names(cont))) {
+            names(cont) <- c("Variable", "Group.1", "Group.2")
+          }
+          cont
+        })
+
+        names(contrasts) <- as.character(1:length(contrasts))
+        contrasts
+      } else {
+        NULL
+      }
+    })
+
+    # Get a named vector of integers for contrasts, to be used in field etc
+
+    getAllContrastsNumbers <- reactive({
       contrasts <- getAllContrasts()
-      matrix <- getAssayMatrix()
-      coldata <- data.frame(colData(ese), check.names = FALSE)
+      contrast_names <- makeContrastNames()
 
-      validate(need(nrow(matrix) > 0, "Waiting for input matrix"))
-
-      contrast_variables <- unique(unlist(lapply(contrasts, function(x) x['Variable'])))
-      names(contrast_variables) <- contrast_variables
-
-      withProgress(message = paste("Calculating summaries by", getSummaryType()), value = 0, {
-        summaries <- lapply(contrast_variables, function(cv) summarizeMatrix(matrix, coldata[[cv]], getSummaryType()))
-      })
-
-      summaries
-    }
-  })
-
-  # Get all the contrasts the user specified in their StructuredExperiment- if any
-
-  getAllContrasts <- reactive({
-    if (length(eselist@contrasts) > 0) {
-      contrasts <- eselist@contrasts
-      
-      contrasts <- lapply(contrasts, function(cont){
-        if (is.null(names(cont))){
-            names(cont) <- c('Variable', 'Group.1', 'Group.2')
-        }
-        cont
-      })
-    
-      names(contrasts) <- as.character(1:length(contrasts))
-      contrasts
-    } else {
-      NULL
-    }
-  })
-
-  # Get a named vector of integers for contrasts, to be used in field etc
-
-  getAllContrastsNumbers <- reactive({
-    contrasts <- getAllContrasts()
-    contrast_names <- makeContrastNames()
-
-    if (!is.null(contrasts)) {
-      structure(names(contrasts), names = contrast_names)
-    } else {
-      NULL
-    }
-  })
-
-  # Get list describing, for each contrast, the samples on each side
-
-  getContrastSamples <- reactive({
-    ese <- getExperiment()
-    coldata <- selectColData()
-    contrasts <- getAllContrasts()
-
-    lapply(contrasts, function(c) {
-      list(colnames(ese)[coldata[c['Variable']] == c['Group.1']], colnames(ese)[coldata[c['Variable']] == c['Group.2']])
+      if (!is.null(contrasts)) {
+        structure(names(contrasts), names = contrast_names)
+      } else {
+        NULL
+      }
     })
-  })
 
-  # Main function for returning the table of contrast information. Means, fold changes calculated on the fly, p/q values must be supplied in a 'contrast_stats' slot
-  # of the ExploratorySummarizedExperiment. Make a summary table for every contrast. This data can then be re-used when processing filter sets.
+    # Get list describing, for each contrast, the samples on each side
 
-  contrastsTables <- reactive({
-    matrix <- selectMatrix()
+    getContrastSamples <- reactive({
+      ese <- getExperiment()
+      coldata <- selectColData()
+      contrasts <- getAllContrasts()
 
-    ese <- getExperiment()
-    summaries <- getSummaries()
-    contrasts <- getAllContrasts()
-    assay <- getAssay()
-
-    # There can be a mismatch between the conrasts and summaries as we adjust the input matrix. Wait for updates to finish before making the table.
-
-    # validate(need(all(unlist(lapply(selected_contrasts, function(x) all(x[-1] %in% colnames(summaries[[x[1]]]))))), 'Matching summaries and contrasts'))
-
-    withProgress(message = "Calculating contrast tables", value = 0, {
-      contrast_tables <- lapply(names(contrasts), function(c) {
-        cont <- contrasts[[c]]
-
-        smry1 <- summaries[[cont['Variable']]][, cont['Group.1']]
-        smry2 <- summaries[[cont['Variable']]][, cont['Group.2']]
-
-        ct <- data.frame(cont['Variable'], cont['Group.1'], cont['Group.2'], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
-        names(ct) <- c("Variable", "Condition 1", "Condition 2", "Average 1", "Average 2")
-
-        # Use pre-computed fold changes where provided.
-
-        if (fcsAvailable()) {
-          fcs <- ese@contrast_stats[[assay]]$fold_changes
-          ct[["Fold change"]] <- round(fcs[match(rownames(ct), rownames(fcs)), as.numeric(c)], 2)
-        } else {
-          ct[["Fold change"]] <- round(foldChange(smry1, smry2), 2)
-        }
-
-        if (pvalsAvailable()) {
-          pvals <- ese@contrast_stats[[assay]]$pvals
-          ct[["p value"]] <- signif(pvals[match(rownames(ct), rownames(pvals)), as.numeric(c)], 5)
-        }
-
-        if (qvalsAvailable()) {
-          qvals <- ese@contrast_stats[[assay]]$qvals
-          ct[["q value"]] <- signif(qvals[match(rownames(ct), rownames(qvals)), as.numeric(c)], 5)
-        }
-
-        ct
+      lapply(contrasts, function(c) {
+        list(colnames(ese)[coldata[c["Variable"]] == c["Group.1"]], colnames(ese)[coldata[c["Variable"]] == c["Group.2"]])
       })
     })
 
-    names(contrast_tables) <- getAllContrastsNumbers()
-    contrast_tables
-  })
+    # Main function for returning the table of contrast information. Means, fold changes calculated on the fly, p/q values must be supplied in a 'contrast_stats' slot
+    # of the ExploratorySummarizedExperiment. Make a summary table for every contrast. This data can then be re-used when processing filter sets.
 
-  # Test for the presence of pre-computed fold changes (e.g. from modelling)
+    contrastsTables <- reactive({
+      matrix <- selectMatrix()
 
-  fcsAvailable <- reactive({
-    assay <- getAssay()
-    ese <- getExperiment()
+      ese <- getExperiment()
+      summaries <- getSummaries()
+      contrasts <- getAllContrasts()
+      assay <- getAssay()
 
-    length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "fold_changes" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$fold_changes)
-  })
+      # There can be a mismatch between the conrasts and summaries as we adjust the input matrix. Wait for updates to finish before making the table.
 
-  # Test for the presence of p values in the input object
+      # validate(need(all(unlist(lapply(selected_contrasts, function(x) all(x[-1] %in% colnames(summaries[[x[1]]]))))), 'Matching summaries and contrasts'))
 
-  pvalsAvailable <- reactive({
-    assay <- getAssay()
-    ese <- getExperiment()
+      withProgress(message = "Calculating contrast tables", value = 0, {
+        contrast_tables <- lapply(names(contrasts), function(c) {
+          cont <- contrasts[[c]]
 
-    length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "pvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$pvals)
-  })
+          smry1 <- summaries[[cont["Variable"]]][, cont["Group.1"]]
+          smry2 <- summaries[[cont["Variable"]]][, cont["Group.2"]]
 
-  # Test for the presence of q values in the input object
+          ct <- data.frame(cont["Variable"], cont["Group.1"], cont["Group.2"], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
+          names(ct) <- c("Variable", "Condition 1", "Condition 2", "Average 1", "Average 2")
 
-  qvalsAvailable <- reactive({
-    assay <- getAssay()
-    ese <- getExperiment()
+          # Use pre-computed fold changes where provided.
 
-    length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "qvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$qvals)
-  })
+          if (fcsAvailable()) {
+            fcs <- ese@contrast_stats[[assay]]$fold_changes
+            ct[["Fold change"]] <- round(fcs[match(rownames(ct), rownames(fcs)), as.numeric(c)], 2)
+          } else {
+            ct[["Fold change"]] <- round(foldChange(smry1, smry2), 2)
+          }
 
-  ########################################################################### Subsetting using the rows in the input matrix. This does NOT involve the filters from this module, but simply subsets the base data to the rows pertinent
-  ########################################################################### to the input matrix.
+          if (pvalsAvailable()) {
+            pvals <- ese@contrast_stats[[assay]]$pvals
+            ct[["p value"]] <- signif(pvals[match(rownames(ct), rownames(pvals)), as.numeric(c)], 5)
+          }
 
-  # Get contrasts tables with rows reflecting the input matrix
+          if (qvalsAvailable()) {
+            qvals <- ese@contrast_stats[[assay]]$qvals
+            ct[["q value"]] <- signif(qvals[match(rownames(ct), rownames(qvals)), as.numeric(c)], 5)
+          }
 
-  contrastsTablesToMatchMatrix <- reactive({
-    contrast_tables <- contrastsTables()
-    matrix <- selectMatrix()
+          ct
+        })
+      })
 
-    lapply(contrast_tables, function(ct) {
-      ct[rownames(matrix), ]
+      names(contrast_tables) <- getAllContrastsNumbers()
+      contrast_tables
     })
-  })
 
-  ########################################################################### Contrast naming
+    # Test for the presence of pre-computed fold changes (e.g. from modelling)
 
-  # Make names for the contrasts
+    fcsAvailable <- reactive({
+      assay <- getAssay()
+      ese <- getExperiment()
 
-  makeContrastNames <- reactive({
-    contrasts <- getAllContrasts()
+      length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "fold_changes" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$fold_changes)
+    })
 
-    lapply(contrasts, function(x){
-        x <- x[! names(x) %in% 'id']
-        contrast_name <- paste(prettifyVariablename(x['Variable']), paste(x['Group.2'], x['Group.1'], sep = " vs "), sep = ": ")
-        extras <- setdiff(names(x), c('Variable', 'Group.1', 'Group.2'))
-        if (length(extras) > 0 ){
-          suffix <- paste0('(', paste(paste(extras, x[extras], sep = ':'), collapse = ','), ')')
+    # Test for the presence of p values in the input object
+
+    pvalsAvailable <- reactive({
+      assay <- getAssay()
+      ese <- getExperiment()
+
+      length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "pvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$pvals)
+    })
+
+    # Test for the presence of q values in the input object
+
+    qvalsAvailable <- reactive({
+      assay <- getAssay()
+      ese <- getExperiment()
+
+      length(ese@contrast_stats) > 0 && assay %in% names(ese@contrast_stats) && "qvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$qvals)
+    })
+
+    ########################################################################### Subsetting using the rows in the input matrix. This does NOT involve the filters from this module, but simply subsets the base data to the rows pertinent
+    ########################################################################### to the input matrix.
+
+    # Get contrasts tables with rows reflecting the input matrix
+
+    contrastsTablesToMatchMatrix <- reactive({
+      contrast_tables <- contrastsTables()
+      matrix <- selectMatrix()
+
+      lapply(contrast_tables, function(ct) {
+        ct[rownames(matrix), ]
+      })
+    })
+
+    ########################################################################### Contrast naming
+
+    # Make names for the contrasts
+
+    makeContrastNames <- reactive({
+      contrasts <- getAllContrasts()
+
+      lapply(contrasts, function(x) {
+        x <- x[!names(x) %in% "id"]
+        contrast_name <- paste(prettifyVariablename(x["Variable"]), paste(x["Group.2"], x["Group.1"], sep = " vs "), sep = ": ")
+        extras <- setdiff(names(x), c("Variable", "Group.1", "Group.2"))
+        if (length(extras) > 0) {
+          suffix <- paste0("(", paste(paste(extras, x[extras], sep = ":"), collapse = ","), ")")
           contrast_name <- paste(contrast_name, suffix)
         }
         contrast_name
       })
-  })
-
-  # Make safe set of names to be used where spaces etc not allowed
-
-  makeSafeContrastNames <- reactive({
-    contrasts <- getAllContrasts()
-    names <- lapply(contrasts, function(x) paste(ucfirst(prettifyVariablename(x['Variable'])), paste(ucfirst(x['Group.2']), ucfirst(x['Group.1']), sep = "_vs_"), sep = "."))
-    names <- lapply(names, function(name) {
-      name <- sub("\\+", "_POS_", name)
-      name <- sub("\\-", "_NEG_", name)
     })
-    names
-  })
 
-  ########################################################################### Subset contrast-related variables according to filters
+    # Make safe set of names to be used where spaces etc not allowed
 
-  # Get the actual contrasts to which the numbers from the interface pertain
-
-  getSelectedContrasts <- reactive({
-    scn <- getSelectedContrastNumbers()
-    all_contrasts <- getAllContrasts()
-
-    lapply(scn, function(s) {
-      all_contrasts[s]
+    makeSafeContrastNames <- reactive({
+      contrasts <- getAllContrasts()
+      names <- lapply(contrasts, function(x) paste(ucfirst(prettifyVariablename(x["Variable"])), paste(ucfirst(x["Group.2"]), ucfirst(x["Group.1"]), sep = "_vs_"), sep = "."))
+      names <- lapply(names, function(name) {
+        name <- sub("\\+", "_POS_", name)
+        name <- sub("\\-", "_NEG_", name)
+      })
+      names
     })
-  })
 
-  # Get the name of the currently selected contrast
+    ########################################################################### Subset contrast-related variables according to filters
 
-  getSelectedContrastNames <- reactive({
-    contrast_names <- makeContrastNames()
-    lapply(getSelectedContrastNumbers(), function(x) contrast_names[x])
-  })
+    # Get the actual contrasts to which the numbers from the interface pertain
 
-  # The same, but with safe names that won't get mangled by plotting etc
+    getSelectedContrasts <- reactive({
+      scn <- getSelectedContrastNumbers()
+      all_contrasts <- getAllContrasts()
 
-  getSafeSelectedContrastNames <- reactive({
-    contrast_names <- makeSafeContrastNames()
-
-    lapply(getSelectedContrastNumbers(), function(scns) {
-      contrast_names[scns]
-    })
-  })
-
-  # Get samples for currently selected contrast
-
-  getSelectedContrastSamples <- reactive({
-    contrast_samples <- getContrastSamples()
-    selected_contrasts <- getSelectedContrastNumbers()
-    contrast_samples[[selected_contrasts]]
-  })
-
-  ########################################################################### Process data in response to contrasts filters
-
-  # If we're only looking at a single contrast filter with a single contrast (e.g. for a fold change plot etc), then we can simplify.
-
-  singleContrast <- reactive({
-    selected_contrasts <- getSelectedContrastNumbers()
-    length(selected_contrasts) == 1 && length(selected_contrasts[[1]]) == 1
-  })
-
-  # Filter contrasts tables down to the contrasts of interest
-
-  selectedContrastsTables <- reactive({
-    selected_contrasts <- getSelectedContrastNumbers()
-    contrast_tables <- contrastsTablesToMatchMatrix()
-
-    req(selected_contrasts, contrast_tables)
-
-    # Selected contrasts is a list, one for each filter set. Each one can have multiple contrasts
-
-    withProgress(message = "Filtering to specified features", value = 0, {
-      lapply(selected_contrasts, function(scs_set) {
-        lapply(scs_set, function(s) {
-          ct <- contrast_tables[[s]]
-          if (singleContrast()) {
-            simplifyContrastTable(ct)
-          } else {
-            ct
-          }
-        })
+      lapply(scn, function(s) {
+        all_contrasts[s]
       })
     })
-  })
 
-  # Apply user filters to results of contrastsTables(). Called on first page load and on subsequent clicks of 'Apply'.
+    # Get the name of the currently selected contrast
 
-  filteredContrastsTables <- reactive({
-    selected_contrasts_tables <- selectedContrastsTables()
-    req(length(selected_contrasts_tables) > 0)
+    getSelectedContrastNames <- reactive({
+      contrast_names <- makeContrastNames()
+      lapply(getSelectedContrastNumbers(), function(x) contrast_names[x])
+    })
 
-    if (getFilterRows()) {
-      ese <- getExperiment()
-      assay <- getAssay()
+    # The same, but with safe names that won't get mangled by plotting etc
 
-      fold_change <- getFoldChange()
-      fold_change_card <- getFoldChangeCard()
-      p_value <- getPval()
-      p_value_card <- getPvalCard()
-      q_value <- getQval()
-      q_value_card <- getQvalCard()
+    getSafeSelectedContrastNames <- reactive({
+      contrast_names <- makeSafeContrastNames()
 
-      withProgress(message = "Applying filters", value = 0, {
-        fcts <- lapply(1:length(selected_contrasts_tables), function(i) {
-          sct <- selected_contrasts_tables[[i]]
+      lapply(getSelectedContrastNumbers(), function(scns) {
+        contrast_names[scns]
+      })
+    })
 
-          lapply(sct, function(s) {
-            filter <- evaluateCardinalFilter(s[["Fold change"]], fold_change_card[i], fold_change[i])
+    # Get samples for currently selected contrast
 
-            if (pvalsAvailable()) {
-              filter <- filter & evaluateCardinalFilter(s[["p value"]], p_value_card[i], p_value[i])
+    getSelectedContrastSamples <- reactive({
+      contrast_samples <- getContrastSamples()
+      selected_contrasts <- getSelectedContrastNumbers()
+      contrast_samples[[selected_contrasts]]
+    })
+
+    ########################################################################### Process data in response to contrasts filters
+
+    # If we're only looking at a single contrast filter with a single contrast (e.g. for a fold change plot etc), then we can simplify.
+
+    singleContrast <- reactive({
+      selected_contrasts <- getSelectedContrastNumbers()
+      length(selected_contrasts) == 1 && length(selected_contrasts[[1]]) == 1
+    })
+
+    # Filter contrasts tables down to the contrasts of interest
+
+    selectedContrastsTables <- reactive({
+      selected_contrasts <- getSelectedContrastNumbers()
+      contrast_tables <- contrastsTablesToMatchMatrix()
+
+      req(selected_contrasts, contrast_tables)
+
+      # Selected contrasts is a list, one for each filter set. Each one can have multiple contrasts
+
+      withProgress(message = "Filtering to specified features", value = 0, {
+        lapply(selected_contrasts, function(scs_set) {
+          lapply(scs_set, function(s) {
+            ct <- contrast_tables[[s]]
+            if (singleContrast()) {
+              simplifyContrastTable(ct)
+            } else {
+              ct
             }
-
-            if (qvalsAvailable()) {
-              filter <- filter & evaluateCardinalFilter(s[["q value"]], q_value_card[i], q_value[i])
-            }
-
-            s[filter, , drop = FALSE]
           })
         })
       })
-    } else {
-      fcts <- selected_contrasts_tables
-    }
-    fcts
-  })
-
-  # Find the list of features that result from combining all the filters
-
-  selectFilterFinalFeatures <- reactive({
-    filtered_contrasts_tables <- filteredContrastsTables()
-    validate(need(length(filtered_contrasts_tables) > 0, "Waiting for filtered contrasts tables"))
-
-    lapply(filtered_contrasts_tables, function(fcts) {
-      Reduce(intersect, lapply(fcts, function(fct) {
-        rownames(fct)
-      }))
     })
-  })
 
-  selectFinalFeatures <- reactive({
-    filter_final_features <- selectFilterFinalFeatures()
+    # Apply user filters to results of contrastsTables(). Called on first page load and on subsequent clicks of 'Apply'.
 
-    withProgress(message = "Selecting final feature set", value = 0, {
+    filteredContrastsTables <- reactive({
+      selected_contrasts_tables <- selectedContrastsTables()
+      req(length(selected_contrasts_tables) > 0)
+
+      if (getFilterRows()) {
+        ese <- getExperiment()
+        assay <- getAssay()
+
+        fold_change <- getFoldChange()
+        fold_change_card <- getFoldChangeCard()
+        p_value <- getPval()
+        p_value_card <- getPvalCard()
+        q_value <- getQval()
+        q_value_card <- getQvalCard()
+
+        withProgress(message = "Applying filters", value = 0, {
+          fcts <- lapply(1:length(selected_contrasts_tables), function(i) {
+            sct <- selected_contrasts_tables[[i]]
+
+            lapply(sct, function(s) {
+              filter <- evaluateCardinalFilter(s[["Fold change"]], fold_change_card[i], fold_change[i])
+
+              if (pvalsAvailable()) {
+                filter <- filter & evaluateCardinalFilter(s[["p value"]], p_value_card[i], p_value[i])
+              }
+
+              if (qvalsAvailable()) {
+                filter <- filter & evaluateCardinalFilter(s[["q value"]], q_value_card[i], q_value[i])
+              }
+
+              s[filter, , drop = FALSE]
+            })
+          })
+        })
+      } else {
+        fcts <- selected_contrasts_tables
+      }
+      fcts
+    })
+
+    # Find the list of features that result from combining all the filters
+
+    selectFilterFinalFeatures <- reactive({
+      filtered_contrasts_tables <- filteredContrastsTables()
+      validate(need(length(filtered_contrasts_tables) > 0, "Waiting for filtered contrasts tables"))
+
+      lapply(filtered_contrasts_tables, function(fcts) {
+        Reduce(intersect, lapply(fcts, function(fct) {
+          rownames(fct)
+        }))
+      })
+    })
+
+    selectFinalFeatures <- reactive({
+      filter_final_features <- selectFilterFinalFeatures()
+
+      withProgress(message = "Selecting final feature set", value = 0, {
         comb_op <- getFilterSetCombinationOperator()
         Reduce(get(comb_op), filter_final_features)
-    })
-  })
-
-  # The output of filteredContrastsTables() are significant results for each filter set, and each contrast within those.
-
-  labelledContrastsTable <- reactive({
-    ese <- getExperiment()
-    sff <- selectFinalFeatures()
-
-    filtered_contrast_tables <- filteredContrastsTables()
-
-    metafields <- c()
-    if (!is.null(getMetafields)) {
-      metafields <- getMetafields()
-    }
-
-    withProgress(message = "Making labelled table", value = 0, {
-      final_contrasts_table <- unique(rbindlist(lapply(filtered_contrast_tables, function(fcts) {
-        rbindlist(lapply(fcts, function(fct) {
-          labelMatrix(fct[sff, , drop = FALSE], ese = ese, metafields = metafields)
-        }))
-      })))
-    })
-  })
-
-  # Use labelledContrastsTable to get the labelled matrix and add some links.
-
-  linkedLabelledContrastsTable <- reactive({
-    lct <- labelledContrastsTable()
-    if (length(eselist@url_roots) > 0) {
-      lct <- linkMatrix(lct, eselist@url_roots)
-    } 
-    lct
-  })
-
-  # A summary table of differential expression
-
-  makeDifferentialSetSummary <- reactive({
-    fcts <- filteredContrastsTables()
-    selected_contrasts <- getSelectedContrasts()
-    queries <- getQueryStrings()
-    eid <- getExperimentId()
-
-    summaries <- lapply(1:length(fcts), function(i) {
-      summary <- data.frame(cbind(query = queries[i], do.call(rbind, selected_contrasts[[i]])))
-      colnames(summary) <- c("Query", "Variable", "group 1", "group 2")
-      summary[[paste0("Differential ", eid, "s (up)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] > 0)))
-      summary[[paste0("Differential ", eid, "s (down)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] < 0)))
-      summary[[paste0("Differential ", eid, "s (total)")]] <- unlist(lapply(fcts[[i]], nrow))
-
-      summary
+      })
     })
 
-    if (length(summaries) == 1) {
-      summaries[[1]][, -1]
-    } else {
-      rbindlist(summaries)
-    }
-  })
+    # The output of filteredContrastsTables() are significant results for each filter set, and each contrast within those.
 
-  getQueryStrings <- reactive({
-    contrast_names <- makeContrastNames()
-
-    # Get the current filters, getting the name for the contrast(s)
-
-    fvs <- lapply(filterset_values, function(fv) {
-      fv$contrasts <- paste(contrast_names[fv$contrasts], collapse = ", ")
-      fv
-    })
-
-    unlist(lapply(fvs, function(x) {
-      paste("<p>", paste(unlist(lapply(grep("card", names(x[-1]), invert = TRUE, value = TRUE), function(y) {
-        paste(y, x[[paste0(y, "_card")]], x[[y]])
-      })), collapse = " AND "), "in <i>", x[[1]], "</i></p>")
-    }))
-  })
-
-  makeQuerySummary <- reactive({
-    filters <- getQueryStrings()
-
-    # Get the list of features resulting from each filter
-
-    filter_final_features <- selectFilterFinalFeatures()
-
-    # Make a table of the number of features resulting from each filter
-
-    query_summary <- data.frame(filter = filters, features = unlist(lapply(filter_final_features, length)), stringsAsFactors = FALSE)
-
-    exp_id <- getExperimentId()
-    colnames(query_summary)[2] <- paste0(exp_id, "s")
-
-    # Convert to labels
-
-    labelfield <- getLabelField()
-    if (!is.null(labelfield)) {
+    labelledContrastsTable <- reactive({
       ese <- getExperiment()
-      filter_final_labels <- lapply(filter_final_features, function(x) convertIds(x, ese, labelfield))
+      sff <- selectFinalFeatures()
 
-      query_summary[[paste0(labelfield, "s")]] <- unlist(lapply(filter_final_labels, function(x) length(unique(x))))
-    }
+      filtered_contrast_tables <- filteredContrastsTables()
 
-    query_summary
-  })
+      metafields <- c()
+      if (!is.null(getMetafields)) {
+        metafields <- getMetafields()
+      }
 
-  ########################################################################### Tell the user something about the query and its results
+      withProgress(message = "Making labelled table", value = 0, {
+        final_contrasts_table <- unique(rbindlist(lapply(filtered_contrast_tables, function(fcts) {
+          rbindlist(lapply(fcts, function(fct) {
+            labelMatrix(fct[sff, , drop = FALSE], ese = ese, metafields = metafields)
+          }))
+        })))
+      })
+    })
 
-  output$summary <- renderUI({
-    query_summary <- makeQuerySummary()
-    comb_op <- getFilterSetCombinationOperator()
-    operator <- ifelse(comb_op == "intersect", "AND", "OR")
-    query_summary[-1, 1] <- paste0("<p><b>", operator, "</b></p>", query_summary[-1, 1])
+    # Use labelledContrastsTable to get the labelled matrix and add some links.
 
-    if (ncol(query_summary) == 2) {
-      column_widths <- c(8, 4)
-    } else {
-      column_widths <- c(6, 3, 3)
-    }
+    linkedLabelledContrastsTable <- reactive({
+      lct <- labelledContrastsTable()
+      if (length(eselist@url_roots) > 0) {
+        lct <- linkMatrix(lct, eselist@url_roots)
+      }
+      lct
+    })
 
-    makeFluidRow <- function(row) {
-      do.call(fluidRow, lapply(1:length(row), function(r) {
-        column(column_widths[r], HTML(row[r]))
+    # A summary table of differential expression
+
+    makeDifferentialSetSummary <- reactive({
+      fcts <- filteredContrastsTables()
+      selected_contrasts <- getSelectedContrasts()
+      queries <- getQueryStrings()
+      eid <- getExperimentId()
+
+      summaries <- lapply(1:length(fcts), function(i) {
+        summary <- data.frame(cbind(query = queries[i], do.call(rbind, selected_contrasts[[i]])))
+        colnames(summary) <- c("Query", "Variable", "group 1", "group 2")
+        summary[[paste0("Differential ", eid, "s (up)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] > 0)))
+        summary[[paste0("Differential ", eid, "s (down)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] < 0)))
+        summary[[paste0("Differential ", eid, "s (total)")]] <- unlist(lapply(fcts[[i]], nrow))
+
+        summary
+      })
+
+      if (length(summaries) == 1) {
+        summaries[[1]][, -1]
+      } else {
+        rbindlist(summaries)
+      }
+    })
+
+    getQueryStrings <- reactive({
+      contrast_names <- makeContrastNames()
+
+      # Get the current filters, getting the name for the contrast(s)
+
+      fvs <- lapply(filterset_values, function(fv) {
+        fv$contrasts <- paste(contrast_names[fv$contrasts], collapse = ", ")
+        fv
+      })
+
+      unlist(lapply(fvs, function(x) {
+        paste("<p>", paste(unlist(lapply(grep("card", names(x[-1]), invert = TRUE, value = TRUE), function(y) {
+          paste(y, x[[paste0(y, "_card")]], x[[y]])
+        })), collapse = " AND "), "in <i>", x[[1]], "</i></p>")
       }))
-    }
+    })
 
-    summary_bits <- list(h4("Query Summary"), makeFluidRow(prettifyVariablename(colnames(query_summary))), br(), apply(query_summary, 1, makeFluidRow))
+    makeQuerySummary <- reactive({
+      filters <- getQueryStrings()
 
-    if (nrow(query_summary) > 1) {
-      sff_in <- selectFinalFeatures()
-      sff <- unique(sff_in)
-      ese <- getExperiment()
+      # Get the list of features resulting from each filter
 
-      summary_row <- c(comb_op, length(sff))
+      filter_final_features <- selectFilterFinalFeatures()
+
+      # Make a table of the number of features resulting from each filter
+
+      query_summary <- data.frame(filter = filters, features = unlist(lapply(filter_final_features, length)), stringsAsFactors = FALSE)
+
+      exp_id <- getExperimentId()
+      colnames(query_summary)[2] <- paste0(exp_id, "s")
+
+      # Convert to labels
 
       labelfield <- getLabelField()
       if (!is.null(labelfield)) {
-        labels <- convertIds(ids = sff, ese, labelfield)
-        summary_row <- c(summary_row, length(unique(labels[!is.na(labels)])))
+        ese <- getExperiment()
+        filter_final_labels <- lapply(filter_final_features, function(x) convertIds(x, ese, labelfield))
+
+        query_summary[[paste0(labelfield, "s")]] <- unlist(lapply(filter_final_labels, function(x) length(unique(x))))
       }
 
-      summary_bits <- c(summary_bits, list(hr(), makeFluidRow(summary_row)))
-    }
+      query_summary
+    })
 
-    list(tags$br(), do.call(wellPanel, summary_bits))
+    ########################################################################### Tell the user something about the query and its results
+
+    output$summary <- renderUI({
+      query_summary <- makeQuerySummary()
+      comb_op <- getFilterSetCombinationOperator()
+      operator <- ifelse(comb_op == "intersect", "AND", "OR")
+      query_summary[-1, 1] <- paste0("<p><b>", operator, "</b></p>", query_summary[-1, 1])
+
+      if (ncol(query_summary) == 2) {
+        column_widths <- c(8, 4)
+      } else {
+        column_widths <- c(6, 3, 3)
+      }
+
+      makeFluidRow <- function(row) {
+        do.call(fluidRow, lapply(1:length(row), function(r) {
+          column(column_widths[r], HTML(row[r]))
+        }))
+      }
+
+      summary_bits <- list(h4("Query Summary"), makeFluidRow(prettifyVariablename(colnames(query_summary))), br(), apply(query_summary, 1, makeFluidRow))
+
+      if (nrow(query_summary) > 1) {
+        sff_in <- selectFinalFeatures()
+        sff <- unique(sff_in)
+        ese <- getExperiment()
+
+        summary_row <- c(comb_op, length(sff))
+
+        labelfield <- getLabelField()
+        if (!is.null(labelfield)) {
+          labels <- convertIds(ids = sff, ese, labelfield)
+          summary_row <- c(summary_row, length(unique(labels[!is.na(labels)])))
+        }
+
+        summary_bits <- c(summary_bits, list(hr(), makeFluidRow(summary_row)))
+      }
+
+      list(tags$br(), do.call(wellPanel, summary_bits))
+    })
+
+    ########################################################################### Return the reactive that allow other modules to interact with this one
+
+    list(
+      getFoldChange = getFoldChange, getFoldChangeCard = getFoldChangeCard, getQval = getQval, getQvalCard = getQvalCard, getPval = getPval, getPvalCard = getPvalCard,
+      getAllContrasts = getAllContrasts, getSelectedContrasts = getSelectedContrasts, getSelectedContrastNumbers = getSelectedContrastNumbers, getSelectedContrastNames = getSelectedContrastNames,
+      getSafeSelectedContrastNames = getSafeSelectedContrastNames, getContrastSamples = getContrastSamples, getSelectedContrastSamples = getSelectedContrastSamples,
+      contrastsTables = contrastsTables, filteredContrastsTables = filteredContrastsTables, labelledContrastsTable = labelledContrastsTable, linkedLabelledContrastsTable = linkedLabelledContrastsTable,
+      makeDifferentialSetSummary = makeDifferentialSetSummary, getQueryStrings = getQueryStrings, selectedContrastsTables = selectedContrastsTables
+    )
   })
-
-  ########################################################################### Return the reactive that allow other modules to interact with this one
-
-  list(
-    getFoldChange = getFoldChange, getFoldChangeCard = getFoldChangeCard, getQval = getQval, getQvalCard = getQvalCard, getPval = getPval, getPvalCard = getPvalCard,
-    getAllContrasts = getAllContrasts, getSelectedContrasts = getSelectedContrasts, getSelectedContrastNumbers = getSelectedContrastNumbers, getSelectedContrastNames = getSelectedContrastNames,
-    getSafeSelectedContrastNames = getSafeSelectedContrastNames, getContrastSamples = getContrastSamples, getSelectedContrastSamples = getSelectedContrastSamples,
-    contrastsTables = contrastsTables, filteredContrastsTables = filteredContrastsTables, labelledContrastsTable = labelledContrastsTable, linkedLabelledContrastsTable = linkedLabelledContrastsTable,
-    makeDifferentialSetSummary = makeDifferentialSetSummary, getQueryStrings = getQueryStrings, selectedContrastsTables = selectedContrastsTables
-  )
 }
 
 #' Calculate fold change between two vectors

--- a/R/dendro.R
+++ b/R/dendro.R
@@ -73,58 +73,58 @@ dendroOutput <- function(id) {
 #' provided by the \code{selectmatrix} module, as well distance matrix
 #' generation and clustering method.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(dendro, "myid", eselist)
+#' dendro("myid", eselist)
 #'
-dendro <- function(input, output, session, eselist) {
-  # Get the expression matrix - no need for a gene selection
+dendro <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Get the expression matrix - no need for a gene selection
 
-  unpack.list(callModule(selectmatrix, "dendro", eselist, select_genes = TRUE, var_n = 1000, provide_all_genes = TRUE, default_gene_select = "variance"))
-  unpack.list(callModule(groupby, "dendro", eselist = eselist, group_label = "Color by", selectColData = selectColData))
+    unpack.list(selectmatrix("dendro", eselist, select_genes = TRUE, var_n = 1000, provide_all_genes = TRUE, default_gene_select = "variance"))
+    unpack.list(groupby("dendro", eselist = eselist, group_label = "Color by", selectColData = selectColData))
 
-  # Call to plotdownload module
+    # Call to plotdownload module
 
-  callModule(plotdownload, "dendro", makePlot = plotSampleDendroPlot, filename = "dendrogram.png", plotHeight = 600, plotWidth = 800)
+    plotdownload("dendro", makePlot = plotSampleDendroPlot, filename = "dendrogram.png", plotHeight = 600, plotWidth = 800)
 
-  # Reactive for making a plot for download
+    # Reactive for making a plot for download
 
-  plotSampleDendroPlot <- reactive({
-    clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
-      cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
-      palette = getPalette()
+    plotSampleDendroPlot <- reactive({
+      clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
+        cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
+        palette = getPalette()
+      )
+    })
+
+    # Fetch the label spacing
+
+    getLabelspace <- reactive({
+      input$labelspace
+    })
+
+    # Render the actual plot
+
+    output$sampleDendroPlot <- renderPlot(
+      {
+        withProgress(message = "Making sample dendrogram", value = 0, {
+          clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
+            cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
+            labelspace = getLabelspace(), palette = getPalette()
+          )
+        })
+      },
+      height = 600
     )
   })
-
-  # Fetch the label spacing
-
-  getLabelspace <- reactive({
-    input$labelspace
-  })
-
-  # Render the actual plot
-
-  output$sampleDendroPlot <- renderPlot(
-    {
-      withProgress(message = "Making sample dendrogram", value = 0, {
-        clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
-          cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
-          labelspace = getLabelspace(), palette = getPalette()
-        )
-      })
-    },
-    height = 600
-  )
 }
 
 #' Make a clustering dendrogram with coloring by experimental variable
@@ -167,7 +167,7 @@ dendro <- function(input, output, session, eselist) {
 #' clusteringDendrogram(mymatrix, data.frame(colData(airway)), colorby = "dex")
 #'
 clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, cor_method = "pearson", cluster_method = "ward.D", plot_title = "", labelspace = 0.2,
-                                 palette = NULL, palette_name = 'Set1') {
+                                 palette = NULL, palette_name = "Set1") {
   plotmatrix <- log2(plotmatrix + 1)
 
   hcd <- calculateDendrogram(plotmatrix, cor_method, cluster_method)
@@ -191,7 +191,7 @@ clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, cor_met
     p3 <- p3 + geom_point(data = labs, aes_string(x = "x", y = 0), size = 4)
   } else {
     if (is.null(palette)) {
-        palette <- makeColorScale(length(unique(experiment[[colorby]])), palette = palette_name)
+      palette <- makeColorScale(length(unique(experiment[[colorby]])), palette = palette_name)
     }
     labs[[colorby]] <- as.character(experiment[[colorby]][match(labs$label, rownames(experiment))])
     labs[[colorby]] <- na.replace(labs[[colorby]], replacement = "N/A")
@@ -199,13 +199,13 @@ clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, cor_met
     labs[[colorby]] <- factor(labs[[colorby]], levels = unique(na.replace(experiment[[colorby]], "N/A")))
     shapes <- rep(15:20, 10)[1:length(unique(experiment[[colorby]]))]
 
-    p3 <- p2 + 
+    p3 <- p2 +
       geom_text(
-        data = labs, 
-        angle = 90, 
-        hjust = 1, 
-        size = rel(5), 
-        aes_string(label = "label", x = "x", y = -(ymax / 40), colour = as.name(colorby)), 
+        data = labs,
+        angle = 90,
+        hjust = 1,
+        size = rel(5),
+        aes_string(label = "label", x = "x", y = -(ymax / 40), colour = as.name(colorby)),
         show.legend = F
       )
 
@@ -213,10 +213,10 @@ clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, cor_met
 
     p3 <- p3 + ggdendro::theme_dendro() + ylim(-(total_axis_size * labelspace), ymax) + scale_color_manual(name = prettifyVariablename(colorby), values = palette)
 
-    p3 <- p3 + 
-      geom_point(data = labs, aes_string(x = "x", y = 0, colour = as.name(colorby), shape = as.name(colorby)), size = 4) + 
+    p3 <- p3 +
+      geom_point(data = labs, aes_string(x = "x", y = 0, colour = as.name(colorby), shape = as.name(colorby)), size = 4) +
       scale_shape_manual(values = shapes, name = prettifyVariablename(colorby)) +
-      theme(title = element_text(size = rel(1.8)), legend.text = element_text(size = rel(1.8))) + 
+      theme(title = element_text(size = rel(1.8)), legend.text = element_text(size = rel(1.8))) +
       ggtitle(plot_title)
   }
 

--- a/R/dexseqplot.R
+++ b/R/dexseqplot.R
@@ -84,8 +84,8 @@ dexseqplotOutput <- function(id, eselist) {
 
 #' The server function of the dexseqplot Shiny module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
 #' This module produces a differential exon usage plot using the \code{plotDEXSeq}
 #' function of the DEXSeq package.
@@ -98,96 +98,93 @@ dexseqplotOutput <- function(id, eselist) {
 #' to the contrasts listed in the \code{contrasts} slot of the
 #' \code{ExploratorySummarizedExperiment}.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(dexseqplot, "dexseqplot", eselist)
+#' dexseqplot("dexseqplot", eselist)
 #'
-dexseqplot <- function(input, output, session, eselist) {
-  # Fetch the table of values for the gene
+dexseqplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Fetch the table of values for the gene
 
-  unpack.list(callModule(dexseqtable, "deuPlotTable",
-    eselist = eselist, allow_filtering = FALSE, getDEUGeneID = getDEUGeneID, show_controls = FALSE, page_length = 50,
-    link_to_deu_plot = FALSE
-  ))
+    unpack.list(dexseqtable("deuPlotTable", eselist = eselist, allow_filtering = FALSE, getDEUGeneID = getDEUGeneID, show_controls = FALSE, page_length = 50, link_to_deu_plot = FALSE))
 
-  # Create a field for selecting the gene ID
+    # Create a field for selecting the gene ID
 
-  unpack.list(callModule(labelselectfield, "genesymbol", eselist = eselist, getExperiment = getExperiment, labels_from_all_experiments = TRUE, url_field = "deu_gene"))
+    unpack.list(labelselectfield("genesymbol", eselist = eselist, getExperiment = getExperiment, labels_from_all_experiments = TRUE, url_field = "deu_gene"))
 
-  # Get the a gene ID for the currently input gene symbol. Could be a composite
+    # Get the a gene ID for the currently input gene symbol. Could be a composite
 
-  getDEUGeneID <- reactive({
-    ese <- getExperiment()
-    gene_id <- getSelectedIds()
-    deu <- ese@dexseq_results
-    selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
+    getDEUGeneID <- reactive({
+      ese <- getExperiment()
+      gene_id <- getSelectedIds()
+      deu <- ese@dexseq_results
+      selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
 
-    d <- deu[[as.numeric(selected_contrast_number)]]
+      d <- deu[[as.numeric(selected_contrast_number)]]
 
-    # Sometimes an exon can be part of multiple Ensembl gene records. The group ID will then be a composite like
-    # 'ENSRNOG00000051235+ENSRNOG00000051158+ENSRNOG00000000419'
+      # Sometimes an exon can be part of multiple Ensembl gene records. The group ID will then be a composite like
+      # 'ENSRNOG00000051235+ENSRNOG00000051158+ENSRNOG00000000419'
 
-    if (!gene_id %in% rownames(d)) {
-      gene_id <- unique(grep(gene_id, deu[[1]]$groupID, value = TRUE))[1]
-    }
+      if (!gene_id %in% rownames(d)) {
+        gene_id <- unique(grep(gene_id, deu[[1]]$groupID, value = TRUE))[1]
+      }
 
-    gene_id
-  })
+      gene_id
+    })
 
-  # Display the DEU plot
+    # Display the DEU plot
 
-  output$deuPlot <- renderPlot(
-    {
+    output$deuPlot <- renderPlot(
+      {
+        ese <- getExperiment()
+
+        selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
+        dexseq_result <- ese@dexseq_results[[as.numeric(selected_contrast_number)]]
+
+        selected_contrast <- getSelectedContrasts()[[1]][[1]]
+        gene_label <- getSelectedLabels()
+        gene_id <- getDEUGeneID()
+
+        withProgress(message = "Making differential exon usage plot", value = 0, {
+          DEXSeq::plotDEXSeq(dexseq_result,
+            geneID = gene_id, FDR = input$deuQvalPlotMax, fitExpToVar = selected_contrast[[1]][1], norCounts = input$deuNorcounts,
+            splicing = input$deuSplicing, displayTranscripts = input$deuDisplayTranscripts, expression = input$deuExpression, names = TRUE, legend = TRUE,
+            cex.axis = 1.2, cex = 1.3, lwd = 2
+          )
+        })
+      },
+      height = 600
+    )
+
+    # Provide the plot for download
+
+    makeDEUPlotForDownload <- reactive({
       ese <- getExperiment()
 
       selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
       dexseq_result <- ese@dexseq_results[[as.numeric(selected_contrast_number)]]
-
       selected_contrast <- getSelectedContrasts()[[1]][[1]]
       gene_label <- getSelectedLabels()
       gene_id <- getDEUGeneID()
 
-      withProgress(message = "Making differential exon usage plot", value = 0, {
-        DEXSeq::plotDEXSeq(dexseq_result,
-          geneID = gene_id, FDR = input$deuQvalPlotMax, fitExpToVar = selected_contrast[[1]][1], norCounts = input$deuNorcounts,
-          splicing = input$deuSplicing, displayTranscripts = input$deuDisplayTranscripts, expression = input$deuExpression, names = TRUE, legend = TRUE,
-          cex.axis = 1.2, cex = 1.3, lwd = 2
-        )
-      })
-    },
-    height = 600
-  )
+      DEXSeq::plotDEXSeq(dexseq_result,
+        geneID = gene_id, FDR = input$deuQvalPlotMax, fitExpToVar = selected_contrast[[1]][1], norCounts = input$deuNorcounts,
+        splicing = input$deuSplicing, displayTranscripts = input$deuDisplayTranscripts, expression = input$deuExpression, names = TRUE, legend = TRUE,
+        cex.axis = 1.2, cex = 1.3, lwd = 2
+      )
+    })
 
-  # Provide the plot for download
+    # Call to plotdownload module
 
-  makeDEUPlotForDownload <- reactive({
-    ese <- getExperiment()
+    plotdownload("deuPlot", makePlot = makeDEUPlotForDownload, filename = "deuplot.png", plotHeight = 800, plotWidth = 1200)
 
-    selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
-    dexseq_result <- ese@dexseq_results[[as.numeric(selected_contrast_number)]]
-    selected_contrast <- getSelectedContrasts()[[1]][[1]]
-    gene_label <- getSelectedLabels()
-    gene_id <- getDEUGeneID()
+    # Return the reactive for updating the gene input field. Will be used for updating the field when linking to this panel
 
-    DEXSeq::plotDEXSeq(dexseq_result,
-      geneID = gene_id, FDR = input$deuQvalPlotMax, fitExpToVar = selected_contrast[[1]][1], norCounts = input$deuNorcounts,
-      splicing = input$deuSplicing, displayTranscripts = input$deuDisplayTranscripts, expression = input$deuExpression, names = TRUE, legend = TRUE,
-      cex.axis = 1.2, cex = 1.3, lwd = 2
-    )
+    updateLabelField
   })
-
-  # Call to plotdownload module
-
-  callModule(plotdownload, "deuPlot", makePlot = makeDEUPlotForDownload, filename = "deuplot.png", plotHeight = 800, plotWidth = 1200)
-
-  # Return the reactive for updating the gene input field. Will be used for updating the field when linking to this panel
-
-  updateLabelField
 }

--- a/R/dexseqtable.R
+++ b/R/dexseqtable.R
@@ -113,12 +113,10 @@ dexseqtableOutput <- function(id) {
 #' to the contrasts listed in the \code{contrasts} slot of the
 #' \code{ExploratorySummarizedExperiment}.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param allow_filtering Allow user filtering of results (default: TRUE)?
@@ -135,137 +133,136 @@ dexseqtableOutput <- function(id) {
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(dexseqtable, "dexseqtable", eselist)
+#' dexseqtable("dexseqtable", eselist)
 #'
-dexseqtable <- function(input, output, session, eselist, allow_filtering = TRUE, getDEUGeneID = NULL, show_controls = TRUE, page_length = 15, link_to_deu_plot = TRUE) {
-  # Only use experiments with gene set analyses available
+dexseqtable <- function(id, eselist, allow_filtering = TRUE, getDEUGeneID = NULL, show_controls = TRUE, page_length = 15, link_to_deu_plot = TRUE) {
+  moduleServer(id, function(input, output, session) {
+    # Only use experiments with gene set analyses available
 
-  eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@dexseq_results) > 0))]
+    eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@dexseq_results) > 0))]
 
-  # Call the selectmatrix module and unpack the reactives it sends back
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE)
-  unpack.list(selectmatrix_reactives)
+    selectmatrix_reactives <- selectmatrix("expression", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE)
+    unpack.list(selectmatrix_reactives)
 
-  # Just use the contrasts module to select a comparison
+    # Just use the contrasts module to select a comparison
 
-  contrast_reactives <- callModule(contrasts, "deuContrast", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives)
-  unpack.list(contrast_reactives)
+    contrast_reactives <- contrasts("deuContrast", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives)
+    unpack.list(contrast_reactives)
 
-  makeDEUTables <- reactive({
-    ese <- getExperiment()
+    makeDEUTables <- reactive({
+      ese <- getExperiment()
 
-    withProgress(message = "Making DEU table for each contrast", value = 0, {
-      deu_tables <- lapply(1:length(ese@dexseq_results), function(contrast) {
-        d <- ese@dexseq_results[[contrast]]
+      withProgress(message = "Making DEU table for each contrast", value = 0, {
+        deu_tables <- lapply(1:length(ese@dexseq_results), function(contrast) {
+          d <- ese@dexseq_results[[contrast]]
 
-        # Add the mean values for the counts
+          # Add the mean values for the counts
 
-        counts <- DEXSeq::counts(d, normalized = TRUE)
-        contrast_samples <- getContrastSamples()
-        selected_contrast_samples <- contrast_samples[[contrast]]
+          counts <- DEXSeq::counts(d, normalized = TRUE)
+          contrast_samples <- getContrastSamples()
+          selected_contrast_samples <- contrast_samples[[contrast]]
 
-        mean_counts <- lapply(selected_contrast_samples, function(scs) {
-          rowMeans(counts[, scs])
+          mean_counts <- lapply(selected_contrast_samples, function(scs) {
+            rowMeans(counts[, scs])
+          })
+
+          d$mean1 <- round(mean_counts[[1]], 2)
+          d$mean2 <- round(mean_counts[[2]], 2)
+
+          # Make fold changes more useful
+
+          fccol <- grep("log2fold", colnames(d), value = TRUE)
+          d[, fccol] <- 2^d[, fccol]
+          d[d[, fccol] < 1 & !is.na(d[, fccol]), fccol] <- -1 / d[d[, fccol] < 1 & !is.na(d[, fccol]), fccol]
+
+          eu_cols <- colnames(d)[c(8, 9)]
+
+          deucols <- c("groupID", "featureID", "mean1", "mean2", eu_cols, fccol, "pvalue", "padj")
+          deu_table <- as.data.frame(d[, deucols])
+          deu_table[, c(fccol, eu_cols)] <- round(deu_table[, c(fccol, eu_cols)], 2)
+          deu_table[, c("pvalue", "padj")] <- signif(deu_table[, c("pvalue", "padj")], 3)
+
+          # Re-order by p value
+
+          deu_table <- deu_table[order(deu_table$padj), ]
+
+          # Make prettier column labels
+
+          colnames(deu_table) <- c(
+            "groupID", "Exon", paste0("Mean normalised count (", eu_cols, ")"), paste0("Exon usage (", eu_cols, ")"), "Relative exon usage fold change",
+            "P value", "FDR corrected p value"
+          )
+
+          # Add in gene symbols
+
+          deu_table$groupID <- gsub("\\+", " ", deu_table$groupID)
+
+          deu_table
         })
-
-        d$mean1 <- round(mean_counts[[1]], 2)
-        d$mean2 <- round(mean_counts[[2]], 2)
-
-        # Make fold changes more useful
-
-        fccol <- grep("log2fold", colnames(d), value = TRUE)
-        d[, fccol] <- 2^d[, fccol]
-        d[d[, fccol] < 1 & !is.na(d[, fccol]), fccol] <- -1 / d[d[, fccol] < 1 & !is.na(d[, fccol]), fccol]
-
-        eu_cols <- colnames(d)[c(8, 9)]
-
-        deucols <- c("groupID", "featureID", "mean1", "mean2", eu_cols, fccol, "pvalue", "padj")
-        deu_table <- as.data.frame(d[, deucols])
-        deu_table[, c(fccol, eu_cols)] <- round(deu_table[, c(fccol, eu_cols)], 2)
-        deu_table[, c("pvalue", "padj")] <- signif(deu_table[, c("pvalue", "padj")], 3)
-
-        # Re-order by p value
-
-        deu_table <- deu_table[order(deu_table$padj), ]
-
-        # Make prettier column labels
-
-        colnames(deu_table) <- c(
-          "groupID", "Exon", paste0("Mean normalised count (", eu_cols, ")"), paste0("Exon usage (", eu_cols, ")"), "Relative exon usage fold change",
-          "P value", "FDR corrected p value"
-        )
-
-        # Add in gene symbols
-
-        deu_table$groupID <- gsub("\\+", " ", deu_table$groupID)
-
-        deu_table
       })
     })
-  })
 
-  # Select a DEU table for the contrast of interest and filter based on the controls
+    # Select a DEU table for the contrast of interest and filter based on the controls
 
-  makeDEUTable <- reactive({
-    deu_tables <- makeDEUTables()
-    selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
-    deu_table <- deu_tables[[as.numeric(selected_contrast_number)]]
+    makeDEUTable <- reactive({
+      deu_tables <- makeDEUTables()
+      selected_contrast_number <- getSelectedContrastNumbers()[[1]][[1]]
+      deu_table <- deu_tables[[as.numeric(selected_contrast_number)]]
 
-    if (allow_filtering) {
-      if (input$deuMostSigExon) {
-        deu_table <- deu_table[match(unique(deu_table[, 1]), deu_table[, 1]), ]
+      if (allow_filtering) {
+        if (input$deuMostSigExon) {
+          deu_table <- deu_table[match(unique(deu_table[, 1]), deu_table[, 1]), ]
+        }
+
+        fclim <- getFoldChange()
+        fclim_card <- getFoldChangeCard()
+        pvallim <- getPval()
+        pvallim_card <- getPvalCard()
+        qvallim <- getQval()
+        qvallim_card <- getQvalCard()
+
+        # deu_table <- deu_table[which(deu_table[['FDR corrected p value']] < qvallim & abs(deu_table[['Relative exon usage fold change']]) > fclim), ]
+
+        deu_table <- deu_table[evaluateCardinalFilter(deu_table[["FDR corrected p value"]], qvallim_card, qvallim) & evaluateCardinalFilter(
+          deu_table[["P value"]],
+          pvallim_card, pvallim
+        ) & evaluateCardinalFilter(deu_table[["Relative exon usage fold change"]], fclim_card, fclim), ]
       }
 
-      fclim <- getFoldChange()
-      fclim_card <- getFoldChangeCard()
-      pvallim <- getPval()
-      pvallim_card <- getPvalCard()
-      qvallim <- getQval()
-      qvallim_card <- getQvalCard()
+      # If provided, filter by gene symbol
 
-      # deu_table <- deu_table[which(deu_table[['FDR corrected p value']] < qvallim & abs(deu_table[['Relative exon usage fold change']]) > fclim), ]
+      if (!is.null(getDEUGeneID)) {
+        gene_id <- getDEUGeneID()
+        deu_table <- deu_table[deu_table$groupID == gene_id, , drop = FALSE]
+        deu_table <- deu_table[order(deu_table$Exon), ]
+      }
 
-      deu_table <- deu_table[evaluateCardinalFilter(deu_table[["FDR corrected p value"]], qvallim_card, qvallim) & evaluateCardinalFilter(
-        deu_table[["P value"]],
-        pvallim_card, pvallim
-      ) & evaluateCardinalFilter(deu_table[["Relative exon usage fold change"]], fclim_card, fclim), ]
-    }
+      # Add labels
 
-    # If provided, filter by gene symbol
-
-    if (!is.null(getDEUGeneID)) {
-      gene_id <- getDEUGeneID()
-      deu_table <- deu_table[deu_table$groupID == gene_id, , drop = FALSE]
-      deu_table <- deu_table[order(deu_table$Exon), ]
-    }
-
-    # Add labels
-
-    ese <- getExperiment()
-    labelMatrix(deu_table, ese, "groupID", metafields = getMetafields())
-  })
-
-  # Make a linked version of the table for display. Override the label links so they point to DEU plots rather than gene pages
-
-  makeDisplayDEUTable <- reactive({
-    deu_table <- makeDEUTable()
-    url_roots <- eselist@url_roots
-    if (link_to_deu_plot) {
       ese <- getExperiment()
-      url_roots[[ese@labelfield]] <- "?deu_gene="
-    }
-    linkMatrix(deu_table, url_roots)
+      labelMatrix(deu_table, ese, "groupID", metafields = getMetafields())
+    })
+
+    # Make a linked version of the table for display. Override the label links so they point to DEU plots rather than gene pages
+
+    makeDisplayDEUTable <- reactive({
+      deu_table <- makeDEUTable()
+      url_roots <- eselist@url_roots
+      if (link_to_deu_plot) {
+        ese <- getExperiment()
+        url_roots[[ese@labelfield]] <- "?deu_gene="
+      }
+      linkMatrix(deu_table, url_roots)
+    })
+
+    # Pass the matrix to the simpletable module for display
+
+    simpletable("dexseqtable", displayMatrix = makeDisplayDEUTable, downloadMatrix = makeDEUTable, filename = "deutable", rownames = FALSE, show_controls = show_controls, pageLength = page_length)
+
+    # Return reactives for the matrix and controls so the same filters can be used in the 'dexseqplot' module
+
+    c(contrast_reactives, list(getExperiment = getExperiment, getSelectedContrastNumbers = getSelectedContrastNumbers, getSelectedContrasts = getSelectedContrasts))
   })
-
-  # Pass the matrix to the simpletable module for display
-
-  callModule(simpletable, "dexseqtable",
-    displayMatrix = makeDisplayDEUTable, downloadMatrix = makeDEUTable, filename = "deutable", rownames = FALSE, show_controls = show_controls,
-    pageLength = page_length
-  )
-
-  # Return reactives for the matrix and controls so the same filters can be used in the 'dexseqplot' module
-
-  c(contrast_reactives, list(getExperiment = getExperiment, getSelectedContrastNumbers = getSelectedContrastNumbers, getSelectedContrasts = getSelectedContrasts))
 }

--- a/R/differentialtable.R
+++ b/R/differentialtable.R
@@ -55,45 +55,42 @@ differentialtableOutput <- function(id) {
 #' This module provides information on the comparison betwen pairs of groups
 #' defined in a 'contrasts' slot of a ExploratorySummarizedExperimentList
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
 #' Essentially this funnction uses the \code{contrasts} module to group samples
 #' and calculate fold changes, adding test statistics where available.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(differentialtable, "differentialtable", eselist)
+#' differentialtable("differentialtable", eselist)
 #'
-differentialtable <- function(input, output, session, eselist) {
-  # Render the output area - and provide an input-dependent title
+differentialtable <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Render the output area - and provide an input-dependent title
 
-  output$differentialtable <- renderUI({
-    ns <- session$ns
+    output$differentialtable <- renderUI({
+      ns <- session$ns
 
-    simpletableOutput(ns("differentialtable"), tabletitle = paste("Differential expression in assay", getAssay(), sep = ": "))
+      simpletableOutput(ns("differentialtable"), tabletitle = paste("Differential expression in assay", getAssay(), sep = ": "))
+    })
+
+    # Call the selectmatrix module and unpack the reactives it sends back
+
+    selectmatrix_reactives <- selectmatrix("expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = TRUE, provide_all_genes = TRUE)
+    unpack.list(selectmatrix_reactives)
+
+    # Pass the matrix to the contrasts module for processing
+
+    unpack.list(contrasts("differential", selectmatrix_reactives = selectmatrix_reactives, eselist = eselist, multiple = TRUE))
+
+    # Pass the matrix to the simpletable module for display
+
+    simpletable("differentialtable", downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "differential", rownames = FALSE)
   })
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = TRUE, provide_all_genes = TRUE)
-  unpack.list(selectmatrix_reactives)
-
-  # Pass the matrix to the contrasts module for processing
-
-  unpack.list(callModule(contrasts, "differential", selectmatrix_reactives = selectmatrix_reactives, eselist = eselist, multiple = TRUE))
-
-  # Pass the matrix to the simpletable module for display
-
-  callModule(simpletable, "differentialtable",
-    downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "differential",
-    rownames = FALSE
-  )
 }

--- a/R/experimenttable.R
+++ b/R/experimenttable.R
@@ -77,21 +77,19 @@ experimenttableOutput <- function(id) {
 
 #' The server function of the experimenttable module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example). Essentially this just passes the results of \code{colData()}
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 #' applied to the specified SummarizedExperiment object to the
 #' \code{simpletable} module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(experimenttable, "experimenttable", eselist)
+#' experimenttable("experimenttable", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
@@ -99,12 +97,14 @@ experimenttableOutput <- function(id) {
 #' app <- prepareApp("experimenttable", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-experimenttable <- function(input, output, session, eselist) {
-  getExperiment <- reactive({
-    experiment <- data.frame(colData(eselist[[input$experiment]]), check.names = FALSE)
-    colnames(experiment) <- prettifyVariablename(colnames(experiment))
-    experiment
-  })
+experimenttable <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    getExperiment <- reactive({
+      experiment <- data.frame(colData(eselist[[input$experiment]]), check.names = FALSE)
+      colnames(experiment) <- prettifyVariablename(colnames(experiment))
+      experiment
+    })
 
-  callModule(simpletable, "experimenttable", displayMatrix = getExperiment, filename = "experiment", rownames = TRUE)
+    simpletable("experimenttable", displayMatrix = getExperiment, filename = "experiment", rownames = TRUE)
+  })
 }

--- a/R/foldchangeplot.R
+++ b/R/foldchangeplot.R
@@ -87,139 +87,133 @@ foldchangeplotOutput <- function(id) {
 #' This module is for making scatter plots comparing pairs of groups defined in
 #' a 'contrasts' slot of the ExploratorySummarizedExperimentList
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(foldchangeplot, "foldchangeplot", eselist)
+#' foldchangeplot("foldchangeplot", eselist)
 #'
 #' data(zhangneurons)
 #' app <- prepareApp("foldchangeplot", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-foldchangeplot <- function(input, output, session, eselist) {
-  output$foldchangetable <- renderUI({
-    ns <- session$ns
+foldchangeplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    output$foldchangetable <- renderUI({
+      ns <- session$ns
 
-    simpletableOutput(ns("foldchangetable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]], sep = ": "))
-  })
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE)
-  unpack.list(selectmatrix_reactives)
-
-  # Pass the matrix to the contrasts module for processing
-
-  unpack.list(callModule(contrasts, "differential", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives))
-
-  # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
-
-  unpack.list(callModule(geneselect, "foldchange", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
-
-  # Pass the matrix to the scatterplot module for display
-
-  callModule(scatterplot, "foldchange",
-    getDatamatrix = foldchangeTable, getTitle = getTitle, allow_3d = FALSE, getLabels = foldchangeLabels, x = 1, y = 2,
-    colorBy = colorBy, getLines = plotLines
-  )
-
-  # Make a title by selecting the single contrast name of the single filter set
-
-  getTitle <- reactive({
-    contrast_names <- getSelectedContrastNames()
-    contrast_names[[1]][[1]]
-  })
-
-  # Make a set of dashed lines to overlay on the plot representing thresholds
-
-  plotLines <- reactive({
-    fct <- foldchangeTable()
-
-    fclim <- getFoldChange()
-
-    normal_y <- !is.infinite(fct[, 2])
-    normal_x <- !is.infinite(fct[, 1])
-
-    ymax <- max(fct[normal_y, 2])
-    ymin <- min(fct[normal_y, 2])
-
-    xmax <- max(fct[normal_x, 1])
-    xmin <- min(fct[normal_x, 1])
-
-    min <- min(xmin, ymin)
-    max <- max(xmax, ymax)
-
-    lines <- data.frame(
-      name = c(rep("No change", 2), rep(paste0(abs(fclim), "-fold down"), 2), rep(paste0(abs(fclim), "-fold up"), 2)), x = c(
-        min, max,
-        min, max, min, max
-      ), y = c(c(min, max), (min - log2(abs(fclim))), (max - log2(abs(fclim))), (min + log2(abs(fclim))), (max + log2(abs(fclim)))),
-      stringsAsFactors = FALSE
-    )
-    lines$name <- factor(lines$name, levels = unique(lines$name))
-
-    # Use lines dependent on how the fold change filter is applied
-
-    fccard <- getFoldChangeCard()
-    if (fccard %in% c(">= or <= -", "<= and >= -")) {
-      lines
-    } else if (fccard == "<=" && sign(fclim) == "-1") {
-      droplevels(lines[1:4, ])
-    } else {
-      droplevels(lines[c(1, 2, 5, 6), ])
-    }
-  })
-
-  # Extract labels from the volcano table
-
-  foldchangeLabels <- reactive({
-    fct <- foldchangeTable()
-    fct$label
-  })
-
-  # Extract a vector use to make colors by group
-
-  colorBy <- reactive({
-    fct <- foldchangeTable()
-    fct$colorby
-  })
-
-  # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
-
-  foldchangeTable <- reactive({
-    withProgress(message = "Compiling fold change plot data", value = 0, {
-      sct <- selectedContrastsTables()
-      ct <- sct[[1]][[1]]
-      ct <- round(log2(ct[, 1:2]), 3)
-
-      cont <- getSelectedContrasts()[[1]][[1]]
-      colnames(ct) <- c(paste0("log2(", cont[2], ")"), paste0("log2(", cont[3], ")"))
-
-      fct <- filteredContrastsTables()[[1]][[1]]
-      ct$colorby <- "hidden"
-      ct[rownames(fct), "colorby"] <- "match contrast filters"
-      ct[selectRows(), "colorby"] <- "in highlighted gene set"
-      ct$colorby <- factor(ct$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
-
-      ct$label <- idToLabel(rownames(ct), getExperiment())
-      ct$label[!rownames(ct) %in% c(rownames(fct), selectRows())] <- NA
+      simpletableOutput(ns("foldchangetable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]], sep = ": "))
     })
-    ct
+
+    # Call the selectmatrix module and unpack the reactives it sends back
+
+    selectmatrix_reactives <- selectmatrix("expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE)
+    unpack.list(selectmatrix_reactives)
+
+    # Pass the matrix to the contrasts module for processing
+
+    unpack.list(contrasts("differential", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives))
+
+    # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
+
+    unpack.list(geneselect("foldchange", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
+
+    # Pass the matrix to the scatterplot module for display
+
+    scatterplot("foldchange", getDatamatrix = foldchangeTable, getTitle = getTitle, allow_3d = FALSE, getLabels = foldchangeLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
+
+    # Make a title by selecting the single contrast name of the single filter set
+
+    getTitle <- reactive({
+      contrast_names <- getSelectedContrastNames()
+      contrast_names[[1]][[1]]
+    })
+
+    # Make a set of dashed lines to overlay on the plot representing thresholds
+
+    plotLines <- reactive({
+      fct <- foldchangeTable()
+
+      fclim <- getFoldChange()
+
+      normal_y <- !is.infinite(fct[, 2])
+      normal_x <- !is.infinite(fct[, 1])
+
+      ymax <- max(fct[normal_y, 2])
+      ymin <- min(fct[normal_y, 2])
+
+      xmax <- max(fct[normal_x, 1])
+      xmin <- min(fct[normal_x, 1])
+
+      min <- min(xmin, ymin)
+      max <- max(xmax, ymax)
+
+      lines <- data.frame(
+        name = c(rep("No change", 2), rep(paste0(abs(fclim), "-fold down"), 2), rep(paste0(abs(fclim), "-fold up"), 2)), x = c(
+          min, max,
+          min, max, min, max
+        ), y = c(c(min, max), (min - log2(abs(fclim))), (max - log2(abs(fclim))), (min + log2(abs(fclim))), (max + log2(abs(fclim)))),
+        stringsAsFactors = FALSE
+      )
+      lines$name <- factor(lines$name, levels = unique(lines$name))
+
+      # Use lines dependent on how the fold change filter is applied
+
+      fccard <- getFoldChangeCard()
+      if (fccard %in% c(">= or <= -", "<= and >= -")) {
+        lines
+      } else if (fccard == "<=" && sign(fclim) == "-1") {
+        droplevels(lines[1:4, ])
+      } else {
+        droplevels(lines[c(1, 2, 5, 6), ])
+      }
+    })
+
+    # Extract labels from the volcano table
+
+    foldchangeLabels <- reactive({
+      fct <- foldchangeTable()
+      fct$label
+    })
+
+    # Extract a vector use to make colors by group
+
+    colorBy <- reactive({
+      fct <- foldchangeTable()
+      fct$colorby
+    })
+
+    # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
+
+    foldchangeTable <- reactive({
+      withProgress(message = "Compiling fold change plot data", value = 0, {
+        sct <- selectedContrastsTables()
+        ct <- sct[[1]][[1]]
+        ct <- round(log2(ct[, 1:2]), 3)
+
+        cont <- getSelectedContrasts()[[1]][[1]]
+        colnames(ct) <- c(paste0("log2(", cont[2], ")"), paste0("log2(", cont[3], ")"))
+
+        fct <- filteredContrastsTables()[[1]][[1]]
+        ct$colorby <- "hidden"
+        ct[rownames(fct), "colorby"] <- "match contrast filters"
+        ct[selectRows(), "colorby"] <- "in highlighted gene set"
+        ct$colorby <- factor(ct$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
+
+        ct$label <- idToLabel(rownames(ct), getExperiment())
+        ct$label[!rownames(ct) %in% c(rownames(fct), selectRows())] <- NA
+      })
+      ct
+    })
+
+    # Display the data as a table alongside
+
+    simpletable("foldchangetable", downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "foldchange", rownames = FALSE, pageLength = 10)
   })
-
-  # Display the data as a table alongside
-
-  callModule(simpletable, "foldchangetable",
-    downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "foldchange",
-    rownames = FALSE, pageLength = 10
-  )
 }

--- a/R/gene.R
+++ b/R/gene.R
@@ -76,163 +76,157 @@ geneOutput <- function(id, eselist) {
 #' The gene module picks specified rows out the assay data, either simply by id
 #' or label. This is used to create a gene-centric info page.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(gene, "gene", eselist)
+#' gene("gene", eselist)
 #'
-gene <- function(input, output, session, eselist) {
-  # Call all the required modules and unpack their reactives
+gene <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Call all the required modules and unpack their reactives
 
-  selectmatrix_reactives <- callModule(selectmatrix, "gene", eselist, var_n = 1000, select_samples = TRUE, select_genes = FALSE, provide_all_genes = FALSE)
-  unpack.list(selectmatrix_reactives)
-  unpack.list(callModule(labelselectfield, "gene_label",
-    eselist = eselist, getExperiment = getExperiment, labels_from_all_experiments = TRUE, url_field = "gene",
-    id_selection = TRUE, getNonEmptyRows = getNonEmptyRows
-  ))
-  unpack.list(callModule(contrasts, "gene", eselist = eselist, multiple = TRUE, show_controls = FALSE, selectmatrix_reactives = selectmatrix_reactives, select_all_contrasts = TRUE))
-  unpack.list(callModule(groupby, "gene", eselist = eselist, group_label = "Color by", selectColData = selectColData))
+    selectmatrix_reactives <- selectmatrix("gene", eselist, var_n = 1000, select_samples = TRUE, select_genes = FALSE, provide_all_genes = FALSE)
+    unpack.list(selectmatrix_reactives)
+    unpack.list(labelselectfield("gene_label", eselist = eselist, getExperiment = getExperiment, labels_from_all_experiments = TRUE, url_field = "gene", id_selection = TRUE, getNonEmptyRows = getNonEmptyRows))
+    unpack.list(contrasts("gene", eselist = eselist, multiple = TRUE, show_controls = FALSE, selectmatrix_reactives = selectmatrix_reactives, select_all_contrasts = TRUE))
+    unpack.list(groupby("gene", eselist = eselist, group_label = "Color by", selectColData = selectColData))
 
-  # The title and info link are reactive to the currently active experiment
+    # The title and info link are reactive to the currently active experiment
 
-  output$title <- renderUI({
-    en <- getExperimentName()
-    h3(paste(en, "expression bar plot"))
-  })
+    output$title <- renderUI({
+      en <- getExperimentName()
+      h3(paste(en, "expression bar plot"))
+    })
 
-  output$info <- renderUI({
-    ns <- session$ns
-    en <- getExperimentName()
-    gene_labels <- getSelectedLabels()
+    output$info <- renderUI({
+      ns <- session$ns
+      en <- getExperimentName()
+      gene_labels <- getSelectedLabels()
 
-    list(modalInput(ns("geneInfo"), paste(en, " info"), "help"), modalOutput(
-      ns("geneInfo"), paste(en, "information for", paste(gene_labels, sep = ", ")),
-      DT::dataTableOutput(ns("geneInfoTable"))
-    ))
-  })
+      list(modalInput(ns("geneInfo"), paste(en, " info"), "help"), modalOutput(
+        ns("geneInfo"), paste(en, "information for", paste(gene_labels, sep = ", ")),
+        DT::dataTableOutput(ns("geneInfoTable"))
+      ))
+    })
 
-  # Render the gene model plot
+    # Render the gene model plot
 
-  output$model <- renderUI({
-    ns <- session$ns
-    gene_labels <- getSelectedLabels()
+    output$model <- renderUI({
+      ns <- session$ns
+      gene_labels <- getSelectedLabels()
 
-    if (length(eselist@ensembl_species) > 0) {
-      out <- list(modalInput(ns("geneModel"), "Gene model", "help"), modalOutput(ns("geneModel"), paste(gene_labels[1], "gene model"), plotOutput(ns("geneModel"),
-        height = "600px"
-      )))
-    }
-  })
-
-  # Get the rows with valid data. Some rows of some assays may be blank
-
-  getSelectedIdsWithData <- reactive({
-    rowids <- getSelectedIds()
-
-    sm <- selectMatrix()
-    rowids <- rowids[rowids %in% rownames(sm)]
-    gene_labels <- getSelectedLabels()
-    assay <- getAssay()
-
-    validate(need(length(rowids) > 0, paste0("No values for gene labels '", paste(gene_labels, collapse = "', '"), "' in assay '", assay, "'")))
-
-    rowids
-  })
-
-  # Render the bar plot with plotly
-
-  output$barPlot <- renderPlotly({
-    withProgress(message = "Making bar plot", value = 0, {
-      ese <- getExperiment()
-      rows <- getSelectedIdsWithData()
-      barplot_expression <- selectMatrix()
-      barplot_expression <- barplot_expression[rows, , drop = FALSE]
-
-      if (length(ese@labelfield) > 0) {
-        rownames(barplot_expression) <- idToLabel(rows, ese, sep = "<br />")
+      if (length(eselist@ensembl_species) > 0) {
+        out <- list(modalInput(ns("geneModel"), "Gene model", "help"), modalOutput(ns("geneModel"), paste(gene_labels[1], "gene model"), plotOutput(ns("geneModel"),
+          height = "600px"
+        )))
       }
-
-      coldata <- selectColData()
-      groupby <- getGroupby()
-      assaymeasure <- getAssayMeasure()
-      palette <- getPalette()
-
-      p <- geneBarplot(barplot_expression, coldata, groupby, assaymeasure, palette = palette)
     })
-  })
 
-  # Make a gene region plot
+    # Get the rows with valid data. Some rows of some assays may be blank
 
-  output$geneModel <- renderPlot({
-    gene_labels <- getSelectedLabels()
-    ese <- getExperiment()
+    getSelectedIdsWithData <- reactive({
+      rowids <- getSelectedIds()
 
-    withProgress(message = paste("Fetching gene models from Ensembl for gene", gene_labels[1]), value = 0, {
-      annotation <- data.frame(SummarizedExperiment::mcols(ese), stringsAsFactors = FALSE)
-      annotation <- annotation[which(annotation[[ese@labelfield]] == gene_labels[1]), ]
+      sm <- selectMatrix()
+      rowids <- rowids[rowids %in% rownames(sm)]
+      gene_labels <- getSelectedLabels()
+      assay <- getAssay()
 
-      geneModelPlot(ensembl_species = eselist@ensembl_species, chromosome = annotation$chromosome_name, start = min(annotation$start_position), end = max(annotation$end_position))
+      validate(need(length(rowids) > 0, paste0("No values for gene labels '", paste(gene_labels, collapse = "', '"), "' in assay '", assay, "'")))
+
+      rowids
     })
-  })
 
-  # Make a table of the annotation data
+    # Render the bar plot with plotly
 
-  output$geneInfoTable <- DT::renderDataTable(
-    {
-      rows <- getSelectedIds()
+    output$barPlot <- renderPlotly({
+      withProgress(message = "Making bar plot", value = 0, {
+        ese <- getExperiment()
+        rows <- getSelectedIdsWithData()
+        barplot_expression <- selectMatrix()
+        barplot_expression <- barplot_expression[rows, , drop = FALSE]
+
+        if (length(ese@labelfield) > 0) {
+          rownames(barplot_expression) <- idToLabel(rows, ese, sep = "<br />")
+        }
+
+        coldata <- selectColData()
+        groupby <- getGroupby()
+        assaymeasure <- getAssayMeasure()
+        palette <- getPalette()
+
+        p <- geneBarplot(barplot_expression, coldata, groupby, assaymeasure, palette = palette)
+      })
+    })
+
+    # Make a gene region plot
+
+    output$geneModel <- renderPlot({
+      gene_labels <- getSelectedLabels()
       ese <- getExperiment()
 
-      validate(need(all(rows %in% rownames(ese)), FALSE))
+      withProgress(message = paste("Fetching gene models from Ensembl for gene", gene_labels[1]), value = 0, {
+        annotation <- data.frame(SummarizedExperiment::mcols(ese), stringsAsFactors = FALSE)
+        annotation <- annotation[which(annotation[[ese@labelfield]] == gene_labels[1]), ]
 
-      gene_info <- data.frame(SummarizedExperiment::mcols(ese[rows, , drop = FALSE]), check.names = FALSE, row.names = idToLabel(rows, ese, sep = " /<br/ >"))
-      gene_info <- t(linkMatrix(gene_info, eselist@url_roots))
-      rownames(gene_info) <- prettifyVariablename(rownames(gene_info))
-      gene_info
-    },
-    options = list(rownames = TRUE, pageLength = 20, dom = "t"),
-    escape = FALSE
-  )
+        geneModelPlot(ensembl_species = eselist@ensembl_species, chromosome = annotation$chromosome_name, start = min(annotation$start_position), end = max(annotation$end_position))
+      })
+    })
 
-  # Make the gene info table update (probably invisibly) even when hidden, so there's not a delay in rendering when the link to the modal is clicked.
+    # Make a table of the annotation data
 
-  outputOptions(output, "geneInfoTable", suspendWhenHidden = FALSE)
+    output$geneInfoTable <- DT::renderDataTable(
+      {
+        rows <- getSelectedIds()
+        ese <- getExperiment()
 
-  # Retrieve the contrasts table
+        validate(need(all(rows %in% rownames(ese)), FALSE))
 
-  getGeneContrastsTable <- reactive({
-    rows <- getSelectedIdsWithData()
-    contrasts_table <- labelledContrastsTable()
-    id_field <- getIdField()
+        gene_info <- data.frame(SummarizedExperiment::mcols(ese[rows, , drop = FALSE]), check.names = FALSE, row.names = idToLabel(rows, ese, sep = " /<br/ >"))
+        gene_info <- t(linkMatrix(gene_info, eselist@url_roots))
+        rownames(gene_info) <- prettifyVariablename(rownames(gene_info))
+        gene_info
+      },
+      options = list(rownames = TRUE, pageLength = 20, dom = "t"),
+      escape = FALSE
+    )
 
-    contrasts_table[contrasts_table[[prettifyVariablename(id_field)]] %in% rows, , drop = FALSE]
+    # Make the gene info table update (probably invisibly) even when hidden, so there's not a delay in rendering when the link to the modal is clicked.
+
+    outputOptions(output, "geneInfoTable", suspendWhenHidden = FALSE)
+
+    # Retrieve the contrasts table
+
+    getGeneContrastsTable <- reactive({
+      rows <- getSelectedIdsWithData()
+      contrasts_table <- labelledContrastsTable()
+      id_field <- getIdField()
+
+      contrasts_table[contrasts_table[[prettifyVariablename(id_field)]] %in% rows, , drop = FALSE]
+    })
+
+    # Link the contrasts table for display
+
+    getLinkedGeneContrastsTable <- reactive({
+      gene_contrasts_table <- getGeneContrastsTable()
+      linkMatrix(gene_contrasts_table, url_roots = eselist@url_roots)
+    })
+
+    # Render the contrasts table- when a valid label is supplied
+
+    simpletable("geneContrastsTable", downloadMatrix = getGeneContrastsTable, displayMatrix = getLinkedGeneContrastsTable, filename = "gene_contrasts", rownames = FALSE)
+
+    # Return the reactive for updating the gene input field. Will be used for updating the field when linking to this panel
+
+    updateLabelField
   })
-
-  # Link the contrasts table for display
-
-  getLinkedGeneContrastsTable <- reactive({
-    gene_contrasts_table <- getGeneContrastsTable()
-    linkMatrix(gene_contrasts_table, url_roots = eselist@url_roots)
-  })
-
-  # Render the contrasts table- when a valid label is supplied
-
-  callModule(simpletable, "geneContrastsTable",
-    downloadMatrix = getGeneContrastsTable, displayMatrix = getLinkedGeneContrastsTable, filename = "gene_contrasts",
-    rownames = FALSE
-  )
-
-  # Return the reactive for updating the gene input field. Will be used for updating the field when linking to this panel
-
-  updateLabelField
 }
 
 #' Main function for drawing the bar plot with plotly
@@ -253,7 +247,7 @@ gene <- function(input, output, session, eselist) {
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(gene, "gene", ses)
+#' gene("gene", ses)
 #'
 geneBarplot <- function(expression, experiment, colorby, expressionmeasure = "Expression", palette = NULL) {
   if (!is.null(colorby)) {

--- a/R/geneselect.R
+++ b/R/geneselect.R
@@ -32,9 +32,7 @@ geneselectInput <- function(id, select_genes = TRUE) {
 #' This module provides controls for selecting genes (matrix rows) by various
 #' criteria such as variance and gene set.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param getExperiment Reactive expression which returns a
@@ -59,194 +57,195 @@ geneselectInput <- function(id, select_genes = TRUE) {
 #' @keywords shiny
 #'
 #' @examples
-#' geneselect_functions <- callModule(geneselect, "heatmap", getExperiments)
+#' geneselect_functions <- geneselect("heatmap", getExperiments)
 #'
-geneselect <- function(input, output, session, eselist, getExperiment, var_n = 50, var_max = 500, selectSamples = reactive({
+geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, selectSamples = reactive({
                          colnames(getExperiment())
                        }), getAssay, provide_all = TRUE, provide_none = FALSE, default = NULL) {
-  # Check if we have the nessary component for gene sets
+  moduleServer(id, function(input, output, session) {
+    # Check if we have the nessary component for gene sets
 
-  useGenesets <- reactive({
-    ese <- getExperiment()
+    useGenesets <- reactive({
+      ese <- getExperiment()
 
-    # length(eselist@gene_sets) > 0 & all(unlist(lapply(c("gene_set_id_type", "labelfield"), function(x) length(slot(ese, x)) > 0)))
-    length(eselist@gene_set_id_type) > 0 && eselist@gene_set_id_type %in% colnames(mcols(ese))
-  })
+      # length(eselist@gene_sets) > 0 & all(unlist(lapply(c("gene_set_id_type", "labelfield"), function(x) length(slot(ese, x)) > 0)))
+      length(eselist@gene_set_id_type) > 0 && eselist@gene_set_id_type %in% colnames(mcols(ese))
+    })
 
-  # Grab the gene set functionality from it's module if we need it. We must also have gene sets and a way of mapping them to our results
+    # Grab the gene set functionality from it's module if we need it. We must also have gene sets and a way of mapping them to our results
 
-  unpack.list(callModule(genesetselect, "geneset", eselist = eselist, getExperiment = getExperiment))
+    unpack.list(genesetselect("geneset", eselist = eselist, getExperiment = getExperiment))
 
-  # Get rows by metadata: pick from available values
+    # Get rows by metadata: pick from available values
 
-  lsf_picked_methods <- callModule(labelselectfield, "gene_label_pick", eselist = eselist, getExperiment = getExperiment, field_selection = TRUE, list_input = FALSE)
+    lsf_picked_methods <- labelselectfield("gene_label_pick", eselist = eselist, getExperiment = getExperiment, field_selection = TRUE, list_input = FALSE)
 
-  # Get rows by metadata: paste in a list
+    # Get rows by metadata: paste in a list
 
-  lsf_listed_methods <- callModule(labelselectfield, "gene_label_list", eselist = eselist, getExperiment = getExperiment, field_selection = TRUE, list_input = TRUE)
+    lsf_listed_methods <- labelselectfield("gene_label_list", eselist = eselist, getExperiment = getExperiment, field_selection = TRUE, list_input = TRUE)
 
-  # Add the gene sets to the drop-down if required
+    # Add the gene sets to the drop-down if required
 
-  observeEvent(input$geneSelect, {
-    if (input$geneSelect == "gene set") {
-      updateGeneSetsList()
-    } else if (input$geneSelect == "metadata_pick") {
-      lsf_picked_methods$updateLabelField()
-    }
-  })
-
-  # Render the geneSelect UI element
-
-  output$geneSelect <- renderUI({
-    withProgress(message = "Rendering row selection", value = 0, {
-      ns <- session$ns
-
-      gene_select_methods <- c()
-      if (provide_none) {
-        gene_select_methods <- c(none = "none")
-      }
-      if (provide_all) {
-        gene_select_methods <- c(gene_select_methods, c(all = "all"))
-      }
-
-      gene_select_methods <- c(gene_select_methods, c(variance = "variance", `pick from valid metadata` = "metadata_pick", `supply list of metadata values` = "metadata_list"))
-
-
-      if (useGenesets()) {
-        gene_select_methods <- c(gene_select_methods, "gene set")
-      }
-
-      if (is.null(default)) {
-        selected <- gene_select_methods[1]
-      } else {
-        selected <- default
-      }
-
-      gene_select <- list(h5("Select genes/ rows"), selectInput(ns("geneSelect"), "Select genes by", gene_select_methods, selected = selected), conditionalPanel(condition = paste0(
-        "input['",
-        ns("geneSelect"), "'] == 'variance' "
-      ), sliderInput(ns("obs"), "Show top N most variant rows:", min = 10, max = var_max, value = var_n)), conditionalPanel(condition = paste0(
-        "input['",
-        ns("geneSelect"), "'] == 'metadata_pick' "
-      ), labelselectfieldInput(ns("gene_label_pick"))), conditionalPanel(condition = paste0(
-        "input['",
-        ns("geneSelect"), "'] == 'metadata_list' "
-      ), labelselectfieldInput(ns("gene_label_list"))))
-
-      # If gene sets have been provided, then make a gene sets filter
-
-      if (useGenesets()) {
-        gene_select[[length(gene_select) + 1]] <- conditionalPanel(condition = paste0("input['", ns("geneSelect"), "'] == 'gene set' "), genesetselectInput(ns("geneset")))
+    observeEvent(input$geneSelect, {
+      if (input$geneSelect == "gene set") {
+        updateGeneSetsList()
+      } else if (input$geneSelect == "metadata_pick") {
+        lsf_picked_methods$updateLabelField()
       }
     })
 
-    gene_select
-  })
+    # Render the geneSelect UI element
 
-  # Return the matrix so far, selected just on the basis of samples
+    output$geneSelect <- renderUI({
+      withProgress(message = "Rendering row selection", value = 0, {
+        ns <- session$ns
 
-  matrixFromSamples <- reactive({
-    ese <- getExperiment()
-    assay <- getAssay()
-    samples <- selectSamples()
+        gene_select_methods <- c()
+        if (provide_none) {
+          gene_select_methods <- c(none = "none")
+        }
+        if (provide_all) {
+          gene_select_methods <- c(gene_select_methods, c(all = "all"))
+        }
 
-    SummarizedExperiment::assays(ese)[[assay]][, samples, drop = FALSE]
-  })
+        gene_select_methods <- c(gene_select_methods, c(variance = "variance", `pick from valid metadata` = "metadata_pick", `supply list of metadata values` = "metadata_list"))
 
-  # Reactive function to calculate variances only when required
 
-  rowVariances <- reactive({
-    nonempty <- getNonEmptyRows()
-    withProgress(message = "Calculating row variances", value = 0, {
+        if (useGenesets()) {
+          gene_select_methods <- c(gene_select_methods, "gene set")
+        }
+
+        if (is.null(default)) {
+          selected <- gene_select_methods[1]
+        } else {
+          selected <- default
+        }
+
+        gene_select <- list(h5("Select genes/ rows"), selectInput(ns("geneSelect"), "Select genes by", gene_select_methods, selected = selected), conditionalPanel(condition = paste0(
+          "input['",
+          ns("geneSelect"), "'] == 'variance' "
+        ), sliderInput(ns("obs"), "Show top N most variant rows:", min = 10, max = var_max, value = var_n)), conditionalPanel(condition = paste0(
+          "input['",
+          ns("geneSelect"), "'] == 'metadata_pick' "
+        ), labelselectfieldInput(ns("gene_label_pick"))), conditionalPanel(condition = paste0(
+          "input['",
+          ns("geneSelect"), "'] == 'metadata_list' "
+        ), labelselectfieldInput(ns("gene_label_list"))))
+
+        # If gene sets have been provided, then make a gene sets filter
+
+        if (useGenesets()) {
+          gene_select[[length(gene_select) + 1]] <- conditionalPanel(condition = paste0("input['", ns("geneSelect"), "'] == 'gene set' "), genesetselectInput(ns("geneset")))
+        }
+      })
+
+      gene_select
+    })
+
+    # Return the matrix so far, selected just on the basis of samples
+
+    matrixFromSamples <- reactive({
+      ese <- getExperiment()
+      assay <- getAssay()
+      samples <- selectSamples()
+
+      SummarizedExperiment::assays(ese)[[assay]][, samples, drop = FALSE]
+    })
+
+    # Reactive function to calculate variances only when required
+
+    rowVariances <- reactive({
+      nonempty <- getNonEmptyRows()
+      withProgress(message = "Calculating row variances", value = 0, {
+        mfs <- matrixFromSamples()
+        apply(mfs, 1, var)
+      })
+    })
+
+    # Find which rows have values
+
+    getNonEmptyRows <- reactive({
       mfs <- matrixFromSamples()
-      apply(mfs, 1, var)
+      validate(need(!is.null(mfs), "Waiting for sample-selected matrix"))
+      complete <- complete.cases(mfs)
+      rownames(mfs)[complete]
     })
-  })
 
-  # Find which rows have values
-
-  getNonEmptyRows <- reactive({
-    mfs <- matrixFromSamples()
-    validate(need(!is.null(mfs), "Waiting for sample-selected matrix"))
-    complete <- complete.cases(mfs)
-    rownames(mfs)[complete]
-  })
-
-  getGeneSelect <- reactive({
+    getGeneSelect <- reactive({
       validate(need(!is.null(input$geneSelect), "Waiting for geneSelect"))
       input$geneSelect
-  })
-
-  # Make all the reactive expressions that will be needed by calling modules.
-
-  geneselect_functions <- list(getNonEmptyRows = getNonEmptyRows)
-
-  # Main output. Derive the expression matrix according to row-based criteria
-
-  geneselect_functions$selectRows <- reactive({
-    ese <- getExperiment()
-
-    withProgress(message = "Selecting rows", value = 0, {
-
-      gene_select <- getGeneSelect()
-      nonempty <- getNonEmptyRows()
-
-      if (gene_select == "none") {
-        return(c())
-      } else if (gene_select == "all") {
-        return(nonempty)
-      } else if (gene_select == "variance") {
-        vars <- rowVariances()
-        return(names(vars)[selectVariableGenes(input$obs, row_variances = vars)])
-      } else if (gene_select == "metadata_pick") {
-        selected_rows <- lsf_picked_methods$getSelectedIds()
-        return(intersect(selected_rows, nonempty))
-      } else if (gene_select == "metadata_list") {
-        selected_rows <- lsf_listed_methods$getSelectedIds()
-        return(intersect(selected_rows, nonempty))
-      } else {
-        if (gene_select == "gene set") {
-          selected_genes <- getPathwayGenes()
-        } else {
-          selected_genes <- unlist(strsplit(input$geneList, "\\n"))
-        }
-
-        # Use annotation for gene names if specified, otherwise use matrix rows
-
-        if (length(ese@labelfield) > 0) {
-          annotation <- data.frame(mcols(ese))
-          selected_rows <- as.character(annotation[which(tolower(annotation[[ese@labelfield]]) %in% tolower(selected_genes)), ese@idfield])
-        } else {
-          selected_rows <- rownames(ese)[which(tolower(rownames(ese))) %in% tolower(selected_genes)]
-        }
-
-        return(intersect(selected_rows, nonempty))
-      }
     })
+
+    # Make all the reactive expressions that will be needed by calling modules.
+
+    geneselect_functions <- list(getNonEmptyRows = getNonEmptyRows)
+
+    # Main output. Derive the expression matrix according to row-based criteria
+
+    geneselect_functions$selectRows <- reactive({
+      ese <- getExperiment()
+
+      withProgress(message = "Selecting rows", value = 0, {
+        gene_select <- getGeneSelect()
+        nonempty <- getNonEmptyRows()
+
+        if (gene_select == "none") {
+          return(c())
+        } else if (gene_select == "all") {
+          return(nonempty)
+        } else if (gene_select == "variance") {
+          vars <- rowVariances()
+          return(names(vars)[selectVariableGenes(input$obs, row_variances = vars)])
+        } else if (gene_select == "metadata_pick") {
+          selected_rows <- lsf_picked_methods$getSelectedIds()
+          return(intersect(selected_rows, nonempty))
+        } else if (gene_select == "metadata_list") {
+          selected_rows <- lsf_listed_methods$getSelectedIds()
+          return(intersect(selected_rows, nonempty))
+        } else {
+          if (gene_select == "gene set") {
+            selected_genes <- getPathwayGenes()
+          } else {
+            selected_genes <- unlist(strsplit(input$geneList, "\\n"))
+          }
+
+          # Use annotation for gene names if specified, otherwise use matrix rows
+
+          if (length(ese@labelfield) > 0) {
+            annotation <- data.frame(mcols(ese))
+            selected_rows <- as.character(annotation[which(tolower(annotation[[ese@labelfield]]) %in% tolower(selected_genes)), ese@idfield])
+          } else {
+            selected_rows <- rownames(ese)[which(tolower(rownames(ese))) %in% tolower(selected_genes)]
+          }
+
+          return(intersect(selected_rows, nonempty))
+        }
+      })
+    })
+
+    # Make a title
+
+    geneselect_functions$title <- reactive({
+      gene_select <- getGeneSelect()
+
+      title <- ""
+      if (gene_select == "all") {
+        title <- "All rows"
+      } else if (gene_select == "variance") {
+        title <- paste(paste("Top", input$obs, "rows"), "by variance")
+      } else if (gene_select == "gene set") {
+        title <- paste0("Genes in sets:\n", paste(prettifyGeneSetName(getGenesetNames()), collapse = "\n"))
+        # } else if (gene_select == 'list') { title <- 'Rows for specifified gene list'
+      } else if (gene_select == "metadata_pick") {
+        title <- "Rows by picked metadata field value"
+      } else if (gene_select == "metadata_list") {
+        title <- "Rows by metadata field value list"
+      }
+      title
+    })
+
+    geneselect_functions
   })
-
-  # Make a title
-
-  geneselect_functions$title <- reactive({
-    gene_select <- getGeneSelect()
-
-    title <- ""
-    if (gene_select == "all") {
-      title <- "All rows"
-    } else if (gene_select == "variance") {
-      title <- paste(paste("Top", input$obs, "rows"), "by variance")
-    } else if (gene_select == "gene set") {
-      title <- paste0("Genes in sets:\n", paste(prettifyGeneSetName(getGenesetNames()), collapse = "\n"))
-      # } else if (gene_select == 'list') { title <- 'Rows for specifified gene list'
-    } else if (gene_select == "metadata_pick") {
-      title <- "Rows by picked metadata field value"
-    } else if (gene_select == "metadata_list") {
-      title <- "Rows by metadata field value list"
-    }
-    title
-  })
-
-  geneselect_functions
 }
 
 #' Generate an integer ordering to select the n most variable genes out of a matrix

--- a/R/genesetanalysistable.R
+++ b/R/genesetanalysistable.R
@@ -155,14 +155,12 @@ genesetanalysistableOutput <- function(id) {
 #' fairly generic, and assumes only the presence of a 'p value' and 'FDR'
 #' column, so the output of other methods should be easily adapted to suit.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example). Essentially this just passes the results of \code{colData()}
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 #' applied to the specified SummarizedExperiment object to the
 #' \code{simpletable} module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
@@ -187,122 +185,118 @@ genesetanalysistableOutput <- function(id) {
 #'
 #' names(zhangneurons@gene_sets)
 #'
-#' callModule(genesetanalysistable, "genesetanalysistable", eselist)
+#' genesetanalysistable("genesetanalysistable", eselist)
 #'
-genesetanalysistable <- function(input, output, session, eselist) {
-  # Only use experiments with gene set analyses available
+genesetanalysistable <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Only use experiments with gene set analyses available
 
-  eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@gene_set_analyses) > 0))]
+    eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@gene_set_analyses) > 0))]
 
-  # For each experiment with gene set analysis, only keep assays associated with gene set results, so that the assay select doesn't have invalid options.
+    # For each experiment with gene set analysis, only keep assays associated with gene set results, so that the assay select doesn't have invalid options.
 
-  for (exp in names(eselist)) {
-    assays(eselist[[exp]]) <- assays(eselist[[exp]])[names(eselist[[exp]]@gene_set_analyses)]
-  }
-
-  # Extract the gene sets that have been analysed for the the user to select from
-
-  ns <- session$ns
-
-  output$geneSets <- renderUI({
-    genesetselectInput(ns("genesetanalysistable"))
-  })
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, select_assays = TRUE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE)
-  unpack.list(selectmatrix_reactives)
-
-  # Pass the matrix to the contrasts module for processing
-
-  unpack.list(callModule(contrasts, "genesetanalysistable",
-    eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE, default_foldchange = 1,
-    default_pval = 0.05, default_qval = 1
-  ))
-
-  # Parse the gene sets for ease of use
-
-  unpack.list(callModule(genesetselect, "genesetanalysistable", eselist, getExperiment, filter_by_type = TRUE, require_select = FALSE))
-
-  observe({
-    updateGeneSetsList()
-  })
-
-  getGeneSetAnalysis <- reactive({
-    validate(need(input$pval, "Waiting for p value"), need(input$fdr, "Waiting for FDR value"))
-
-    ese <- getExperiment()
-    assay <- getAssay()
-    gene_set_types <- getGeneSetTypes()
-    contrast_number <- as.numeric(getSelectedContrastNumbers()[[1]])
-
-    enrichment <- resolve_enrichment(ese, assay, gene_set_types, contrast_number, eselist@contrasts[[contrast_number]])
-    validate(need(!is.null(enrichment), "No enrichment results for this contrast"))
-    gst <- enrichment$gst
-    col_map <- enrichment$col_map
-
-    # Select out specific gene sets if they've been provided
-
-    selected_gene_sets <- getGenesetNames()
-    if (!is.null(selected_gene_sets)) {
-      validate(need(any(selected_gene_sets %in% rownames(gst)), "Selected gene sets not available in test results"))
-      gst <- gst[selected_gene_sets, , drop = FALSE]
+    for (exp in names(eselist)) {
+      assays(eselist[[exp]]) <- assays(eselist[[exp]])[names(eselist[[exp]]@gene_set_analyses)]
     }
 
-    # Move the row names to an actual column
+    # Extract the gene sets that have been analysed for the the user to select from
 
-    gst <- data.frame(gst, check.names = FALSE, stringsAsFactors = FALSE)
-    gst$gene_set_id <- rownames(gst)
-    gst <- gst[, c("gene_set_id", colnames(gst)[colnames(gst) != "gene_set_id"]), drop = FALSE]
+    ns <- session$ns
 
-    # Apply the user's filters
+    output$geneSets <- renderUI({
+      genesetselectInput(ns("genesetanalysistable"))
+    })
 
-    gst <- gst[gst[[col_map$pvalue]] < input$pval & gst[[col_map$fdr]] < input$fdr, , drop = FALSE]
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-    validate(need(nrow(gst) > 0, "No results matching specified filters"))
+    selectmatrix_reactives <- selectmatrix("expression", eselist, select_assays = TRUE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE)
+    unpack.list(selectmatrix_reactives)
 
-    if (nrow(gst) > 0) {
-      # Add in the differential genes
+    # Pass the matrix to the contrasts module for processing
 
-      ct <- filteredContrastsTables()[[1]][[1]]
-      up <- convertIds(rownames(ct)[ct[["Fold change"]] >= 0], ese, ese@labelfield)
-      down <- convertIds(rownames(ct)[ct[["Fold change"]] < 0], ese, ese@labelfield)
+    unpack.list(contrasts("genesetanalysistable", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE, default_foldchange = 1, default_pval = 0.05, default_qval = 1))
 
-      gene_sets <- getGeneSets()
+    # Parse the gene sets for ease of use
 
-      gst$significant_genes <- apply(gst, 1, function(row) {
-        direction_genes <- if (row[col_map$direction] == "Up") up else down
-        siggenes <- intersect(gene_sets[[gene_set_types]][[row["gene_set_id"]]], direction_genes)
-        paste(siggenes, collapse = " ")
-      })
+    unpack.list(genesetselect("genesetanalysistable", eselist, getExperiment, filter_by_type = TRUE, require_select = FALSE))
+
+    observe({
+      updateGeneSetsList()
+    })
+
+    getGeneSetAnalysis <- reactive({
+      validate(need(input$pval, "Waiting for p value"), need(input$fdr, "Waiting for FDR value"))
+
+      ese <- getExperiment()
+      assay <- getAssay()
+      gene_set_types <- getGeneSetTypes()
+      contrast_number <- as.numeric(getSelectedContrastNumbers()[[1]])
+
+      enrichment <- resolve_enrichment(ese, assay, gene_set_types, contrast_number, eselist@contrasts[[contrast_number]])
+      validate(need(!is.null(enrichment), "No enrichment results for this contrast"))
+      gst <- enrichment$gst
+      col_map <- enrichment$col_map
+
+      # Select out specific gene sets if they've been provided
+
+      selected_gene_sets <- getGenesetNames()
+      if (!is.null(selected_gene_sets)) {
+        validate(need(any(selected_gene_sets %in% rownames(gst)), "Selected gene sets not available in test results"))
+        gst <- gst[selected_gene_sets, , drop = FALSE]
+      }
+
+      # Move the row names to an actual column
+
+      gst <- data.frame(gst, check.names = FALSE, stringsAsFactors = FALSE)
+      gst$gene_set_id <- rownames(gst)
+      gst <- gst[, c("gene_set_id", colnames(gst)[colnames(gst) != "gene_set_id"]), drop = FALSE]
+
+      # Apply the user's filters
+
+      gst <- gst[gst[[col_map$pvalue]] < input$pval & gst[[col_map$fdr]] < input$fdr, , drop = FALSE]
+
+      validate(need(nrow(gst) > 0, "No results matching specified filters"))
+
+      if (nrow(gst) > 0) {
+        # Add in the differential genes
+
+        ct <- filteredContrastsTables()[[1]][[1]]
+        up <- convertIds(rownames(ct)[ct[["Fold change"]] >= 0], ese, ese@labelfield)
+        down <- convertIds(rownames(ct)[ct[["Fold change"]] < 0], ese, ese@labelfield)
+
+        gene_sets <- getGeneSets()
+
+        gst$significant_genes <- apply(gst, 1, function(row) {
+          direction_genes <- if (row[col_map$direction] == "Up") up else down
+          siggenes <- intersect(gene_sets[[gene_set_types]][[row["gene_set_id"]]], direction_genes)
+          paste(siggenes, collapse = " ")
+        })
+
+        gst
+      }
+    })
+
+    # Take the table and add links etc
+
+    getDisplayGeneSetAnalysis <- reactive({
+      gst <- getGeneSetAnalysis()
+
+      # Add links, but use a prettified version of the gene set name that re-flows to take up less space
+
+      gst <- linkMatrix(gst, eselist@url_roots, data.frame(gene_set_id = prettifyGeneSetName(gst$gene_set_id), stringsAsFactors = FALSE))
+      colnames(gst) <- prettifyVariablename(colnames(gst))
 
       gst
-    }
+    })
+
+    # Make an explanatory file name
+
+    makeFileName <- reactive({
+      gsub("[^a-zA-Z0-9_]", "_", paste("gsa", getSelectedContrastNames(), getGeneSetTypes()))
+    })
+
+    # Pass the matrix to the simpletable module for display
+
+    simpletable("genesetanalysistable", downloadMatrix = getGeneSetAnalysis, displayMatrix = getDisplayGeneSetAnalysis, filename = makeFileName, rownames = FALSE)
   })
-
-  # Take the table and add links etc
-
-  getDisplayGeneSetAnalysis <- reactive({
-    gst <- getGeneSetAnalysis()
-
-    # Add links, but use a prettified version of the gene set name that re-flows to take up less space
-
-    gst <- linkMatrix(gst, eselist@url_roots, data.frame(gene_set_id = prettifyGeneSetName(gst$gene_set_id), stringsAsFactors = FALSE))
-    colnames(gst) <- prettifyVariablename(colnames(gst))
-
-    gst
-  })
-
-  # Make an explanatory file name
-
-  makeFileName <- reactive({
-    gsub("[^a-zA-Z0-9_]", "_", paste("gsa", getSelectedContrastNames(), getGeneSetTypes()))
-  })
-
-  # Pass the matrix to the simpletable module for display
-
-  callModule(simpletable, "genesetanalysistable",
-    downloadMatrix = getGeneSetAnalysis, displayMatrix = getDisplayGeneSetAnalysis, filename = makeFileName,
-    rownames = FALSE
-  )
 }

--- a/R/genesetbarcodeplot.R
+++ b/R/genesetbarcodeplot.R
@@ -102,166 +102,163 @@ genesetbarcodeplotOutput <- function(id) {
 #' from the \code{gene_set_analyses} slot of the selected
 #' \code{ExploratorySummarizedExperiment} are displayed where provided.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(genesetbarcodeplot, "genesetbarcodeplot", eselist)
+#' genesetbarcodeplot("genesetbarcodeplot", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
 #' app <- prepareApp("genesetbarcodeplot", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-genesetbarcodeplot <- function(input, output, session, eselist) {
-  # Only use experiments with gene set analyses available
+genesetbarcodeplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Only use experiments with gene set analyses available
 
-  eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@gene_set_analyses) > 0))]
+    eselist <- eselist[unlist(lapply(eselist, function(ese) length(ese@gene_set_analyses) > 0))]
 
-  # For each experiment with gene set analysis, only keep assays associated with gene set results, so that the assay select doesn't have invalid options.
+    # For each experiment with gene set analysis, only keep assays associated with gene set results, so that the assay select doesn't have invalid options.
 
-  for (exp in names(eselist)) {
-    assays(eselist[[exp]]) <- assays(eselist[[exp]])[names(eselist[[exp]]@gene_set_analyses)]
-  }
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE)
-  unpack.list(selectmatrix_reactives)
-
-  # Pass the matrix to the contrasts module for processing
-
-  unpack.list(callModule(contrasts, "genesetbarcodeplot", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives))
-
-  # Parse the gene sets for ease of use
-
-  unpack.list(callModule(genesetselect, "genesetbarcodeplot", eselist, getExperiment, multiple = FALSE))
-
-  # Call to plotdownload module
-
-  callModule(plotdownload, "genesetbarcodeplot", makePlot = plotGenesetBarcodeplot, filename = "genesetbarcodeplot.png", plotHeight = 600, plotWidth = 800)
-
-  observe({
-    updateGeneSetsList()
-  })
-
-  # Make a sensible title for the plot
-
-  barcodeplotTitle <- reactive({
-    ese <- getExperiment()
-
-    title_components <- c(prettifyGeneSetName(unlist(getGenesetNames())), getSelectedContrastNames()[[1]])
-
-    gene_set_types <- getGenesetTypes()
-    assay <- getAssay()
-    gene_set_names <- getGenesetNames()
-    contrast_numbers <- as.numeric(getSelectedContrastNumbers()[[1]][[1]])
-
-    enrichment <- resolve_enrichment(ese, assay, gene_set_types, contrast_numbers, eselist@contrasts[[contrast_numbers]])
-
-    if (!is.null(enrichment) && all(gene_set_names %in% rownames(enrichment$gst))) {
-      gst <- enrichment$gst
-      col_map <- enrichment$col_map
-      fdr <- paste(signif(gst[gene_set_names, col_map$fdr], 3), collapse = ",")
-      direction <- paste(gst[gene_set_names, col_map$direction], collapse = ",")
-      title_components <- c(title_components, paste(paste("Direction:", direction), paste("FDR:", fdr)))
-    } else {
-      title_components <- c(title_components, "(no association)")
+    for (exp in names(eselist)) {
+      assays(eselist[[exp]]) <- assays(eselist[[exp]])[names(eselist[[exp]]@gene_set_analyses)]
     }
 
-    plot_title <- paste(title_components, collapse = "\n")
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-    plot_title
-  })
+    selectmatrix_reactives <- selectmatrix("expression", eselist, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE)
+    unpack.list(selectmatrix_reactives)
 
-  # Get the list of fold changes by which to rank genes
+    # Pass the matrix to the contrasts module for processing
 
-  getFoldChanges <- reactive({
-    ct <- filteredContrastsTables()[[1]][[1]]
-    ct$`Fold change`
-  })
+    unpack.list(contrasts("genesetbarcodeplot", eselist = eselist, multiple = FALSE, selectmatrix_reactives = selectmatrix_reactives))
 
-  # Get gene IDs of the same type as used for gene sets
+    # Parse the gene sets for ease of use
 
-  getGeneIDs <- reactive({
-    convertIds(rownames(filteredContrastsTables()[[1]][[1]]), getExperiment(), eselist@gene_set_id_type)
-  })
+    unpack.list(genesetselect("genesetbarcodeplot", eselist, getExperiment, multiple = FALSE))
 
-  # Make the barcode plot using limma for download
+    # Call to plotdownload module
 
-  plotGenesetBarcodeplot <- reactive({
-    set_genes <- getPathwayGenes()
-    fold_changes <- getFoldChanges()
-    gene_ids <- getGeneIDs()
-    title <- barcodeplotTitle()
+    plotdownload("genesetbarcodeplot", makePlot = plotGenesetBarcodeplot, filename = "genesetbarcodeplot.png", plotHeight = 600, plotWidth = 800)
 
-    barcode_plot(fold_changes, gene_ids, names(set_genes), title)
-  })
-
-  # Render the barcode plot
-
-  output$genesetbarcodeplot <- renderPlot({
-    set_genes <- getPathwayGenes()
-    fold_changes <- getFoldChanges()
-    gene_ids <- getGeneIDs()
-    title <- barcodeplotTitle()
-
-    barcode_plot(fold_changes, gene_ids, names(set_genes), title)
-  })
-
-  # Make a table of contrast data for the gene set Subset the linked contrasts table for the gene set genes
-
-  gsbpContrastsTable <- reactive({
-    lct <- labelledContrastsTable()
-    ese <- getExperiment()
-    set_genes <- getPathwayGenes()
-
-    lct[which(lct[[prettifyVariablename(ese@labelfield)]] %in% set_genes), ]
-  })
-
-  # Add links for display
-
-  gsbpLinkedContrastsTable <- reactive({
-    # Force the table (and its gene-set validation) here rather than letting it
-    # evaluate lazily inside linkMatrix()'s colnames() call, where a pending
-    # validation would surface as an error instead of a clean prompt.
-    contrasts_table <- gsbpContrastsTable()
-    linkMatrix(contrasts_table, eselist@url_roots)
-  })
-
-  # Provide the gene set genes in a table of contrst data
-
-  callModule(simpletable, "genesetbarcodeplot",
-    downloadMatrix = gsbpContrastsTable, displayMatrix = gsbpLinkedContrastsTable, filename = "gene_set_contrast",
-    rownames = FALSE, pageLength = 10
-  )
-
-  # Catch the gene set from the URL
-
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-
-    if (length(intersect(c("geneset"), names(query))) == 0) {
-      return()
-    }
-
-    url_observe <- observe({
-      if ("geneset" %in% names(query)) {
-        updateGeneset()
-      }
-      url_observe$suspend()
+    observe({
+      updateGeneSetsList()
     })
-  })
 
-  updateGeneset
+    # Make a sensible title for the plot
+
+    barcodeplotTitle <- reactive({
+      ese <- getExperiment()
+
+      title_components <- c(prettifyGeneSetName(unlist(getGenesetNames())), getSelectedContrastNames()[[1]])
+
+      gene_set_types <- getGenesetTypes()
+      assay <- getAssay()
+      gene_set_names <- getGenesetNames()
+      contrast_numbers <- as.numeric(getSelectedContrastNumbers()[[1]][[1]])
+
+      enrichment <- resolve_enrichment(ese, assay, gene_set_types, contrast_numbers, eselist@contrasts[[contrast_numbers]])
+
+      if (!is.null(enrichment) && all(gene_set_names %in% rownames(enrichment$gst))) {
+        gst <- enrichment$gst
+        col_map <- enrichment$col_map
+        fdr <- paste(signif(gst[gene_set_names, col_map$fdr], 3), collapse = ",")
+        direction <- paste(gst[gene_set_names, col_map$direction], collapse = ",")
+        title_components <- c(title_components, paste(paste("Direction:", direction), paste("FDR:", fdr)))
+      } else {
+        title_components <- c(title_components, "(no association)")
+      }
+
+      plot_title <- paste(title_components, collapse = "\n")
+
+      plot_title
+    })
+
+    # Get the list of fold changes by which to rank genes
+
+    getFoldChanges <- reactive({
+      ct <- filteredContrastsTables()[[1]][[1]]
+      ct$`Fold change`
+    })
+
+    # Get gene IDs of the same type as used for gene sets
+
+    getGeneIDs <- reactive({
+      convertIds(rownames(filteredContrastsTables()[[1]][[1]]), getExperiment(), eselist@gene_set_id_type)
+    })
+
+    # Make the barcode plot using limma for download
+
+    plotGenesetBarcodeplot <- reactive({
+      set_genes <- getPathwayGenes()
+      fold_changes <- getFoldChanges()
+      gene_ids <- getGeneIDs()
+      title <- barcodeplotTitle()
+
+      barcode_plot(fold_changes, gene_ids, names(set_genes), title)
+    })
+
+    # Render the barcode plot
+
+    output$genesetbarcodeplot <- renderPlot({
+      set_genes <- getPathwayGenes()
+      fold_changes <- getFoldChanges()
+      gene_ids <- getGeneIDs()
+      title <- barcodeplotTitle()
+
+      barcode_plot(fold_changes, gene_ids, names(set_genes), title)
+    })
+
+    # Make a table of contrast data for the gene set Subset the linked contrasts table for the gene set genes
+
+    gsbpContrastsTable <- reactive({
+      lct <- labelledContrastsTable()
+      ese <- getExperiment()
+      set_genes <- getPathwayGenes()
+
+      lct[which(lct[[prettifyVariablename(ese@labelfield)]] %in% set_genes), ]
+    })
+
+    # Add links for display
+
+    gsbpLinkedContrastsTable <- reactive({
+      # Force the table (and its gene-set validation) here rather than letting it
+      # evaluate lazily inside linkMatrix()'s colnames() call, where a pending
+      # validation would surface as an error instead of a clean prompt.
+      contrasts_table <- gsbpContrastsTable()
+      linkMatrix(contrasts_table, eselist@url_roots)
+    })
+
+    # Provide the gene set genes in a table of contrst data
+
+    simpletable("genesetbarcodeplot", downloadMatrix = gsbpContrastsTable, displayMatrix = gsbpLinkedContrastsTable, filename = "gene_set_contrast", rownames = FALSE, pageLength = 10)
+
+    # Catch the gene set from the URL
+
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+
+      if (length(intersect(c("geneset"), names(query))) == 0) {
+        return()
+      }
+
+      url_observe <- observe({
+        if ("geneset" %in% names(query)) {
+          updateGeneset()
+        }
+        url_observe$suspend()
+      })
+    })
+
+    updateGeneset
+  })
 }
 
 #' Make a gene set barcode plot using Limma

--- a/R/genesetselect.R
+++ b/R/genesetselect.R
@@ -34,9 +34,7 @@ genesetselectInput <- function(id, multiple = TRUE) {
 #' to thousands of entries. This would be difficult to do client-side using a
 #' standard select field.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist An ExploratorySummarizedExperimentList with its gene_sets
 #' slot set
 #' @param getExperiment Accessor for returning an
@@ -51,133 +49,135 @@ genesetselectInput <- function(id, multiple = TRUE) {
 #' @keywords shiny
 #'
 #' @examples
-#' geneset_functions <- callModule(genesetselect, "heatmap", getExperiment)
+#' geneset_functions <- genesetselect("heatmap", getExperiment)
 #'
-genesetselect <- function(input, output, session, eselist, getExperiment, multiple = TRUE, filter_by_type = FALSE, require_select = TRUE) {
-  # Allow user to select the type of gene set
+genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by_type = FALSE, require_select = TRUE) {
+  moduleServer(id, function(input, output, session) {
+    # Allow user to select the type of gene set
 
-  output$geneSetTypes <- renderUI({
-    if (filter_by_type) {
-      ese <- getExperiment()
+    output$geneSetTypes <- renderUI({
+      if (filter_by_type) {
+        ese <- getExperiment()
 
-      gene_set_types <- names(eselist@gene_sets[[ese@labelfield]])
-      ns <- session$ns
-      selectInput(ns("geneSetTypes"), "Gene set type", gene_set_types, selected = gene_set_types[1])
-    }
-  })
-
-  # Reactive to fetch the gene set types (if used)
-
-  getGeneSetTypes <- reactive({
-    ese <- getExperiment()
-    if (!filter_by_type) {
-      names(eselist@gene_sets[[ese@labelfield]])
-    } else {
-      validate(need(input$geneSetTypes, "Waiting for gene set type"))
-      input$geneSetTypes
-    }
-  })
-
-  # Get a list of names to show for the gene sets
-
-  getGeneSetNames <- reactive({
-    gene_sets <- getGeneSets()
-
-    structure(paste(unlist(lapply(1:length(gene_sets), function(x) paste(x, 1:length(gene_sets[[x]]), sep = "-")))), names = unlist(lapply(
-      names(gene_sets),
-      function(settype) paste0(prettifyGeneSetName(names(gene_sets[[settype]])), " (", settype, ")")
-    )))
-  })
-
-  # A reactive for relating codes back to gene set IDs
-
-  getGeneSetCodesByIDs <- reactive({
-    gene_sets <- getGeneSets()
-    structure(paste(unlist(lapply(1:length(gene_sets), function(x) paste(x, 1:length(gene_sets[[x]]), sep = "-")))), names = unlist(lapply(
-      names(gene_sets),
-      function(settype) names(gene_sets[[settype]])
-    )))
-  })
-
-  # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list.  This reactive must be called by
-  # the calling module.
-
-  updateGeneSetsList <- reactive({
-    updateSelectizeInput(session, "geneSets", choices = getGeneSetNames(), server = TRUE)
-  })
-
-  # Get gene sets with the proper label field keying
-
-  getGeneSets <- reactive({
-    ese <- getExperiment()
-    gene_sets <- eselist@gene_sets[[ese@labelfield]]
-    gene_set_types <- getGeneSetTypes()
-    gene_sets[gene_set_types]
-  })
-
-  # Rerieve and validate the gene set selection
-
-  getInputGeneSets <- reactive({
-    if (require_select) {
-      validate(need(input$geneSets, "Please select a gene set"))
-    }
-
-    if ((!multiple)) {
-      validate(need(length(input$geneSets) == 1, "Please select a single gene set only"))
-    }
-
-    input$geneSets
-  })
-
-  # Return list of reactive expressions
-
-  list(getGeneSetTypes = getGeneSetTypes, getGeneSets = getGeneSets, updateGeneSetsList = updateGeneSetsList, getGenesetNames = reactive({
-    gene_sets <- getGeneSets()
-    input_gene_sets <- getInputGeneSets()
-
-    if (is.null(input_gene_sets)) {
-      return(NULL)
-    }
-
-    unlist(lapply(input_gene_sets, function(pathcode) {
-      pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
-      names(gene_sets[[pathparts[1]]])[pathparts[2]]
-    }))
-  }), getGenesetTypes = reactive({
-    gene_sets <- getGeneSets()
-    input_gene_sets <- getInputGeneSets()
-
-    unique(unlist(lapply(input_gene_sets, function(pathcode) {
-      pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
-      names(gene_sets)[pathparts[1]]
-    })))
-  }), getPathwayGenes = reactive({
-    gene_sets <- getGeneSets()
-    input_gene_sets <- getInputGeneSets()
-
-    gene_sets <- getGeneSets()
-    path_gene_sets <- lapply(input_gene_sets, function(pathcode) {
-      pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
-      gene_sets[[pathparts[1]]][[pathparts[2]]]
+        gene_set_types <- names(eselist@gene_sets[[ese@labelfield]])
+        ns <- session$ns
+        selectInput(ns("geneSetTypes"), "Gene set type", gene_set_types, selected = gene_set_types[1])
+      }
     })
 
-    if (input$overlapType == "union") {
-      # Use c to preserve names
+    # Reactive to fetch the gene set types (if used)
 
-      Reduce(c, path_gene_sets)
-    } else {
-      # Again- this is more than a simple Reduce(intersect because of the need to preserve names
+    getGeneSetTypes <- reactive({
+      ese <- getExperiment()
+      if (!filter_by_type) {
+        names(eselist@gene_sets[[ese@labelfield]])
+      } else {
+        validate(need(input$geneSetTypes, "Waiting for gene set type"))
+        input$geneSetTypes
+      }
+    })
 
-      path_gene_sets[[1]][Reduce(intersect, lapply(path_gene_sets, names))]
-    }
-  }), updateGeneset = reactive({
-    query <- parseQueryString(session$clientData$url_search)
-    geneset_codes <- getGeneSetCodesByIDs()
-    validate(need(query$geneset %in% names(geneset_codes), "Invalid gene set ID entered"))
+    # Get a list of names to show for the gene sets
 
-    geneset_code <- getGeneSetCodesByIDs()[query$geneset]
-    updateSelectizeInput(session, "geneSets", selected = geneset_code, choices = getGeneSetNames(), server = TRUE)
-  }))
+    getGeneSetNames <- reactive({
+      gene_sets <- getGeneSets()
+
+      structure(paste(unlist(lapply(1:length(gene_sets), function(x) paste(x, 1:length(gene_sets[[x]]), sep = "-")))), names = unlist(lapply(
+        names(gene_sets),
+        function(settype) paste0(prettifyGeneSetName(names(gene_sets[[settype]])), " (", settype, ")")
+      )))
+    })
+
+    # A reactive for relating codes back to gene set IDs
+
+    getGeneSetCodesByIDs <- reactive({
+      gene_sets <- getGeneSets()
+      structure(paste(unlist(lapply(1:length(gene_sets), function(x) paste(x, 1:length(gene_sets[[x]]), sep = "-")))), names = unlist(lapply(
+        names(gene_sets),
+        function(settype) names(gene_sets[[settype]])
+      )))
+    })
+
+    # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list.  This reactive must be called by
+    # the calling module.
+
+    updateGeneSetsList <- reactive({
+      updateSelectizeInput(session, "geneSets", choices = getGeneSetNames(), server = TRUE)
+    })
+
+    # Get gene sets with the proper label field keying
+
+    getGeneSets <- reactive({
+      ese <- getExperiment()
+      gene_sets <- eselist@gene_sets[[ese@labelfield]]
+      gene_set_types <- getGeneSetTypes()
+      gene_sets[gene_set_types]
+    })
+
+    # Rerieve and validate the gene set selection
+
+    getInputGeneSets <- reactive({
+      if (require_select) {
+        validate(need(input$geneSets, "Please select a gene set"))
+      }
+
+      if ((!multiple)) {
+        validate(need(length(input$geneSets) == 1, "Please select a single gene set only"))
+      }
+
+      input$geneSets
+    })
+
+    # Return list of reactive expressions
+
+    list(getGeneSetTypes = getGeneSetTypes, getGeneSets = getGeneSets, updateGeneSetsList = updateGeneSetsList, getGenesetNames = reactive({
+      gene_sets <- getGeneSets()
+      input_gene_sets <- getInputGeneSets()
+
+      if (is.null(input_gene_sets)) {
+        return(NULL)
+      }
+
+      unlist(lapply(input_gene_sets, function(pathcode) {
+        pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
+        names(gene_sets[[pathparts[1]]])[pathparts[2]]
+      }))
+    }), getGenesetTypes = reactive({
+      gene_sets <- getGeneSets()
+      input_gene_sets <- getInputGeneSets()
+
+      unique(unlist(lapply(input_gene_sets, function(pathcode) {
+        pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
+        names(gene_sets)[pathparts[1]]
+      })))
+    }), getPathwayGenes = reactive({
+      gene_sets <- getGeneSets()
+      input_gene_sets <- getInputGeneSets()
+
+      gene_sets <- getGeneSets()
+      path_gene_sets <- lapply(input_gene_sets, function(pathcode) {
+        pathparts <- unlist(lapply(strsplit(pathcode, "-"), as.numeric))
+        gene_sets[[pathparts[1]]][[pathparts[2]]]
+      })
+
+      if (input$overlapType == "union") {
+        # Use c to preserve names
+
+        Reduce(c, path_gene_sets)
+      } else {
+        # Again- this is more than a simple Reduce(intersect because of the need to preserve names
+
+        path_gene_sets[[1]][Reduce(intersect, lapply(path_gene_sets, names))]
+      }
+    }), updateGeneset = reactive({
+      query <- parseQueryString(session$clientData$url_search)
+      geneset_codes <- getGeneSetCodesByIDs()
+      validate(need(query$geneset %in% names(geneset_codes), "Invalid gene set ID entered"))
+
+      geneset_code <- getGeneSetCodesByIDs()[query$geneset]
+      updateSelectizeInput(session, "geneSets", selected = geneset_code, choices = getGeneSetNames(), server = TRUE)
+    }))
+  })
 }
 
 #' Prettify gene set names like those from MSigDB

--- a/R/groupby.R
+++ b/R/groupby.R
@@ -31,9 +31,7 @@ groupbyInput <- function(id, color = TRUE) {
 #' The groupby module provides a UI element to choose from the
 #' \code{group_vars} in a SummarizedExperment. Useful for coloring in a PCA etc
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param group_label A label for the grouping field
@@ -49,76 +47,78 @@ groupbyInput <- function(id, color = TRUE) {
 #' @keywords shiny
 #'
 #' @examples
-#' geneset_functions <- callModule(groupby, "heatmap", getExperiment)
+#' geneset_functions <- groupby("heatmap", getExperiment)
 #'
-groupby <- function(input, output, session, eselist, group_label = "Group by", multiple = FALSE, selectColData = NULL, isDynamic = reactive({
+groupby <- function(id, eselist, group_label = "Group by", multiple = FALSE, selectColData = NULL, isDynamic = reactive({
                       TRUE
                     })) {
-  getPalette <- callModule(colormaker, "groupby", getNumberCategories = getNumberCategories)
+  moduleServer(id, function(input, output, session) {
+    getPalette <- colormaker("groupby", getNumberCategories = getNumberCategories)
 
-  # Choose a default grouping variable, either the one specified or the first
+    # Choose a default grouping variable, either the one specified or the first
 
-  getDefaultGroupby <- reactive({
-    if (multiple) {
-      eselist@group_vars
-    } else {
-      if (length(eselist@default_groupvar) > 0) {
-        eselist@default_groupvar
+    getDefaultGroupby <- reactive({
+      if (multiple) {
+        eselist@group_vars
       } else {
-        eselist@group_vars[1]
-      }
-    }
-  })
-
-  # Render function for the field
-
-  output$groupby_fields <- renderUI({
-    withProgress(message = "Rendering group by", value = 0, {
-      ns <- session$ns
-
-      if (length(eselist@group_vars) > 0) {
-        dynamic <- isDynamic()
-
-        group_options <- structure(eselist@group_vars, names = prettifyVariablename(eselist@group_vars))
-
-        if (multiple) {
-          groupinput <- checkboxGroupInput(ns("groupby"), group_label, group_options, selected = group_options, inline = TRUE)
+        if (length(eselist@default_groupvar) > 0) {
+          eselist@default_groupvar
         } else {
-          groupinput <- selectInput(ns("groupby"), group_label, group_options, selected = getDefaultGroupby())
+          eselist@group_vars[1]
         }
-
-        if (!dynamic) {
-          groupinput <- shinyjs::hidden(groupinput)
-        }
-
-        groupinput
-      } else {
-        hiddenInput(ns("groupby"), "NULL")
       }
     })
+
+    # Render function for the field
+
+    output$groupby_fields <- renderUI({
+      withProgress(message = "Rendering group by", value = 0, {
+        ns <- session$ns
+
+        if (length(eselist@group_vars) > 0) {
+          dynamic <- isDynamic()
+
+          group_options <- structure(eselist@group_vars, names = prettifyVariablename(eselist@group_vars))
+
+          if (multiple) {
+            groupinput <- checkboxGroupInput(ns("groupby"), group_label, group_options, selected = group_options, inline = TRUE)
+          } else {
+            groupinput <- selectInput(ns("groupby"), group_label, group_options, selected = getDefaultGroupby())
+          }
+
+          if (!dynamic) {
+            groupinput <- shinyjs::hidden(groupinput)
+          }
+
+          groupinput
+        } else {
+          hiddenInput(ns("groupby"), "NULL")
+        }
+      })
+    })
+
+    # Return a reactive that retrieves the field value
+
+    getGroupby <- reactive({
+      validate(need(input$groupby, "waiting for form to provide groupby"))
+      if (input$groupby[1] == "NULL") {
+        NULL
+      } else {
+        input$groupby
+      }
+    })
+
+    # Get the number of categories given an input experiment matrixa and the selected grouping variable.
+
+    getNumberCategories <- reactive({
+      group_by <- getGroupby()
+      coldata <- selectColData()
+
+      if (!is.null(group_by) && !is.null(coldata)) {
+        length(unique(coldata[[group_by]]))
+      }
+    })
+
+    list(getGroupby = getGroupby, getNumberCategories = getNumberCategories, getPalette = getPalette)
   })
-
-  # Return a reactive that retrieves the field value
-
-  getGroupby <- reactive({
-    validate(need(input$groupby, "waiting for form to provide groupby"))
-    if (input$groupby[1] == "NULL") {
-      NULL
-    } else {
-      input$groupby
-    }
-  })
-
-  # Get the number of categories given an input experiment matrixa and the selected grouping variable.
-
-  getNumberCategories <- reactive({
-    group_by <- getGroupby()
-    coldata <- selectColData()
-
-    if (!is.null(group_by) && !is.null(coldata)) {
-      length(unique(coldata[[group_by]]))
-    }
-  })
-
-  list(getGroupby = getGroupby, getNumberCategories = getNumberCategories, getPalette = getPalette)
 }

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -131,12 +131,10 @@ heatmapOutput <- function(id, type = "") {
 #' A pca heatmap plots the results of anova tests applied to examine the
 #' associations between principal components and experimental variables.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param type The type of heatmap that will be made. 'expression', 'samples' or
@@ -146,7 +144,7 @@ heatmapOutput <- function(id, type = "") {
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(heatmap, "heatmap", eselist, type = "pca")
+#' heatmap("heatmap", eselist, type = "pca")
 #'
 #' # Almost certainly used via application creation
 #'
@@ -154,221 +152,223 @@ heatmapOutput <- function(id, type = "") {
 #' app <- prepareApp("heatmap", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-heatmap <- function(input, output, session, eselist, type = "expression") {
-  ns <- session$ns
+heatmap <- function(id, eselist, type = "expression") {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
-  # Make the groupby UI element
+    # Make the groupby UI element
 
-  unpack.list(callModule(groupby, "heatmap", eselist = eselist, group_label = "Annotate with variables:", multiple = TRUE))
+    unpack.list(groupby("heatmap", eselist = eselist, group_label = "Annotate with variables:", multiple = TRUE))
 
-  # Call the selectmatrix module and unpack the reactives it sends back
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-  if (type == "expression") {
-    unpack.list(callModule(selectmatrix, "heatmap", eselist, var_max = 500))
-  } else {
-    unpack.list(callModule(selectmatrix, "heatmap", eselist, var_n = 1000, select_meta = FALSE, allow_summarise = FALSE))
-  }
+    if (type == "expression") {
+      unpack.list(selectmatrix("heatmap", eselist, var_max = 500))
+    } else {
+      unpack.list(selectmatrix("heatmap", eselist, var_n = 1000, select_meta = FALSE, allow_summarise = FALSE))
+    }
 
-  # Render the heatmap container
+    # Render the heatmap container
 
-  output$heatmap_ui <- renderUI({
-    withProgress(message = "Preparing heatmap container", value = 0, {
-      list(h3(makeTitle()), plotly::plotlyOutput(ns("interactiveHeatmap"), height = plotHeight()))
+    output$heatmap_ui <- renderUI({
+      withProgress(message = "Preparing heatmap container", value = 0, {
+        list(h3(makeTitle()), plotly::plotlyOutput(ns("interactiveHeatmap"), height = plotHeight()))
+      })
     })
-  })
 
-  # Create a title
+    # Create a title
 
-  makeTitle <- reactive({
-    if (type == "pca") {
-      paste("PCA vs variable association plot based on expression matrix:", matrixTitle())
-    } else if (type == "expression") {
-      paste("Expression heat map based on expression matrix:", matrixTitle())
-    } else {
-      paste("Sample clustering heat map based on expression matrix:", matrixTitle())
-    }
-  })
-
-  # Get the experiment data and tidy up as appropriate
-
-  getExperimentData <- reactive({
-    if (isSummarised()) {
-      NULL
-    } else {
-      ed <- selectColData()
-
-      anno_fields <- getGroupby()
-
-      if (!is.null(anno_fields)) {
-        # Prettify the factor levels for display
-
-        colnames(ed)[match(anno_fields, colnames(ed))] <- prettifyVariablename(anno_fields)
-        group_vars <- prettifyVariablename(anno_fields)
-
-        # Make factors from the specified grouping variables
-        sm <- selectMatrix()
-        ed <- ed[colnames(sm), , drop = FALSE]
-
-        ed <- data.frame(lapply(structure(group_vars, names = group_vars), function(x) factor(ed[, x], levels = unique(ed[, x]))),
-          check.names = FALSE,
-          stringsAsFactors = FALSE, row.names = rownames(ed)
-        )
-
-        # Order by the group variables for display purposes
-
-        ed[do.call(order, as.list(ed[, group_vars, drop = FALSE])), , drop = FALSE]
+    makeTitle <- reactive({
+      if (type == "pca") {
+        paste("PCA vs variable association plot based on expression matrix:", matrixTitle())
+      } else if (type == "expression") {
+        paste("Expression heat map based on expression matrix:", matrixTitle())
       } else {
-        ed
+        paste("Sample clustering heat map based on expression matrix:", matrixTitle())
       }
-    }
-  })
+    })
+
+    # Get the experiment data and tidy up as appropriate
+
+    getExperimentData <- reactive({
+      if (isSummarised()) {
+        NULL
+      } else {
+        ed <- selectColData()
+
+        anno_fields <- getGroupby()
+
+        if (!is.null(anno_fields)) {
+          # Prettify the factor levels for display
+
+          colnames(ed)[match(anno_fields, colnames(ed))] <- prettifyVariablename(anno_fields)
+          group_vars <- prettifyVariablename(anno_fields)
+
+          # Make factors from the specified grouping variables
+          sm <- selectMatrix()
+          ed <- ed[colnames(sm), , drop = FALSE]
+
+          ed <- data.frame(lapply(structure(group_vars, names = group_vars), function(x) factor(ed[, x], levels = unique(ed[, x]))),
+            check.names = FALSE,
+            stringsAsFactors = FALSE, row.names = rownames(ed)
+          )
+
+          # Order by the group variables for display purposes
+
+          ed[do.call(order, as.list(ed[, group_vars, drop = FALSE])), , drop = FALSE]
+        } else {
+          ed
+        }
+      }
+    })
 
 
-  # Get a matrix of annotation to use in the plots. This is the experiment data except when type is 'pca', when it's not relevant
+    # Get a matrix of annotation to use in the plots. This is the experiment data except when type is 'pca', when it's not relevant
 
-  getPlotAnnotation <- reactive({
-    if (type == "pca") {
-      NULL
-    } else {
-      getExperimentData()
-    }
-  })
+    getPlotAnnotation <- reactive({
+      if (type == "pca") {
+        NULL
+      } else {
+        getExperimentData()
+      }
+    })
 
-  # Get a a matrix of the values we actually want the user to see in mouseovers etc.
+    # Get a a matrix of the values we actually want the user to see in mouseovers etc.
 
-  getDisplayMatrix <- reactive({
-    pm <- selectMatrix()
+    getDisplayMatrix <- reactive({
+      pm <- selectMatrix()
 
-    if (type == "samples") {
-      pm <- cor(pm, use = "complete.obs", method = "spearman")
-    } else if (type == "pca") {
-      pm <- getPCAMatrix()
-    }
+      if (type == "samples") {
+        pm <- cor(pm, use = "complete.obs", method = "spearman")
+      } else if (type == "pca") {
+        pm <- getPCAMatrix()
+      }
 
-    # We can't do clustering with anything with the same value in all columns. So take these out.
+      # We can't do clustering with anything with the same value in all columns. So take these out.
 
-    if (as.logical(input$cluster_rows) && !is.null(getExperimentData())) {
-      pm <- pm[apply(pm, 1, function(x) length(unique(x)) > 1), , drop = FALSE]
-    }
+      if (as.logical(input$cluster_rows) && !is.null(getExperimentData())) {
+        pm <- pm[apply(pm, 1, function(x) length(unique(x)) > 1), , drop = FALSE]
+      }
 
-    # For expression, re-order by the experiment
+      # For expression, re-order by the experiment
 
-    if (type == "expression") {
-      pm <- pm[, rownames(getExperimentData())]
-    }
-    pm
-  })
+      if (type == "expression") {
+        pm <- pm[, rownames(getExperimentData())]
+      }
+      pm
+    })
 
-  # Create of values to use in plotting, i.e. to define the colors
+    # Create of values to use in plotting, i.e. to define the colors
 
-  getPlotMatrix <- reactive({
-    pm <- getDisplayMatrix()
+    getPlotMatrix <- reactive({
+      pm <- getDisplayMatrix()
 
-    if (type == "expression") {
-      pm <- log2(pm + 1)
-    } else if (type == "pca") {
-      pm[pm < 0.001] <- 0.001
-      pm <- log10(pm[apply(pm, 1, function(x) !all(is.na(x))), ])
-    }
-    pm
-  })
+      if (type == "expression") {
+        pm <- log2(pm + 1)
+      } else if (type == "pca") {
+        pm[pm < 0.001] <- 0.001
+        pm <- log10(pm[apply(pm, 1, function(x) !all(is.na(x))), ])
+      }
+      pm
+    })
 
-  # Run a PCA with the currently selected matrix
+    # Run a PCA with the currently selected matrix
 
-  getPCAMatrix <- reactive({
-    pcameta <- getExperimentData()
-    pcavals <- selectMatrix()[, rownames(pcameta)]
+    getPCAMatrix <- reactive({
+      pcameta <- getExperimentData()
+      pcavals <- selectMatrix()[, rownames(pcameta)]
 
-    pca <- runPCA(pcavals)
-    fraction_explained <- calculatePCAFractionExplained(pca)
-  
-    # Check for non-useful variables (those with 1 value, or N values where N is the
-    # number of samples)
-  
-    informative_variables <- chooseGroupingVariables(pcameta)
+      pca <- runPCA(pcavals)
+      fraction_explained <- calculatePCAFractionExplained(pca)
 
-    validate(
+      # Check for non-useful variables (those with 1 value, or N values where N is the
+      # number of samples)
+
+      informative_variables <- chooseGroupingVariables(pcameta)
+
+      validate(
         need(length(informative_variables) > 0, "Warning: supplied filters have reduced sample metadata selections so as to render all variables uninformative (number of unique values = 1 or N)")
-    )
-
-    anova_pca_metadata(pca_coords = pca$x, pcameta = pcameta, fraction_explained = fraction_explained)
-  })
-
-  # Calculate heights for the the various types of heatmap
-
-  plotHeight <- reactive({
-    display_matrix <- getDisplayMatrix()
-
-    # Allowance for the angled column labels
-    xaxis_labels_height <- 150
-
-    (nrow(display_matrix) * rowHeight()) + dendroHeight() + xaxis_labels_height
-  })
-
-  # Add a chunk for the dendrogram at the top
-
-  dendroHeight <- reactive({
-    if (as.logical(input$cluster_cols)) {
-      150
-    } else {
-      0
-    }
-  })
-
-  # Small row height for expression heat map (probably lots of rows)
-
-  rowHeight <- reactive({
-    if (type == "expression") {
-      12
-    } else if (type == "pca") {
-      20
-    } else {
-      20
-    }
-  })
-
-  # Make row labels
-
-  rowLabels <- reactive({
-    ese <- getExperiment()
-    plot_matrix <- getPlotMatrix()
-
-    if (length(ese@labelfield) > 0 && type == "expression") {
-      annotation <- as.data.frame(mcols(ese))
-      labels <- annotation[match(rownames(plot_matrix), annotation[[ese@idfield]]), ese@labelfield]
-      labels[!is.na(labels)] <- paste(labels[!is.na(labels)], rownames(plot_matrix)[!is.na(labels)], sep = " / ")
-      labels[is.na(labels)] <- rownames(plot_matrix)[is.na(labels)]
-      labels
-    } else {
-      rownames(plot_matrix)
-    }
-  })
-
-  # Make a color palette
-
-  makeColors <- reactive({
-    colors <- colorRampPalette(rev(RColorBrewer::brewer.pal(n = 7, name = "RdYlBu")))(100)
-
-    if (type == "pca") {
-      colors <- rev(colors)
-    }
-
-    colors
-  })
-
-  hideColorbar <- reactive({
-    type == "pca"
-  })
-
-  # Make the interactive heatmap
-
-  output$interactiveHeatmap <- plotly::renderPlotly({
-    withProgress(message = "Building interactive heatmap", value = 0, {
-      interactiveHeatmap(
-        plotmatrix = getPlotMatrix(), displaymatrix = getDisplayMatrix(), getPlotAnnotation(), cluster_cols = as.logical(input$cluster_cols),
-        cluster_rows = as.logical(input$cluster_rows), scale = input$scale, row_labels = rowLabels(), colors = makeColors(), cexCol = 1, cexRow = 1,
-        display_numbers = FALSE, hide_colorbar = hideColorbar()
       )
+
+      anova_pca_metadata(pca_coords = pca$x, pcameta = pcameta, fraction_explained = fraction_explained)
+    })
+
+    # Calculate heights for the the various types of heatmap
+
+    plotHeight <- reactive({
+      display_matrix <- getDisplayMatrix()
+
+      # Allowance for the angled column labels
+      xaxis_labels_height <- 150
+
+      (nrow(display_matrix) * rowHeight()) + dendroHeight() + xaxis_labels_height
+    })
+
+    # Add a chunk for the dendrogram at the top
+
+    dendroHeight <- reactive({
+      if (as.logical(input$cluster_cols)) {
+        150
+      } else {
+        0
+      }
+    })
+
+    # Small row height for expression heat map (probably lots of rows)
+
+    rowHeight <- reactive({
+      if (type == "expression") {
+        12
+      } else if (type == "pca") {
+        20
+      } else {
+        20
+      }
+    })
+
+    # Make row labels
+
+    rowLabels <- reactive({
+      ese <- getExperiment()
+      plot_matrix <- getPlotMatrix()
+
+      if (length(ese@labelfield) > 0 && type == "expression") {
+        annotation <- as.data.frame(mcols(ese))
+        labels <- annotation[match(rownames(plot_matrix), annotation[[ese@idfield]]), ese@labelfield]
+        labels[!is.na(labels)] <- paste(labels[!is.na(labels)], rownames(plot_matrix)[!is.na(labels)], sep = " / ")
+        labels[is.na(labels)] <- rownames(plot_matrix)[is.na(labels)]
+        labels
+      } else {
+        rownames(plot_matrix)
+      }
+    })
+
+    # Make a color palette
+
+    makeColors <- reactive({
+      colors <- colorRampPalette(rev(RColorBrewer::brewer.pal(n = 7, name = "RdYlBu")))(100)
+
+      if (type == "pca") {
+        colors <- rev(colors)
+      }
+
+      colors
+    })
+
+    hideColorbar <- reactive({
+      type == "pca"
+    })
+
+    # Make the interactive heatmap
+
+    output$interactiveHeatmap <- plotly::renderPlotly({
+      withProgress(message = "Building interactive heatmap", value = 0, {
+        interactiveHeatmap(
+          plotmatrix = getPlotMatrix(), displaymatrix = getDisplayMatrix(), getPlotAnnotation(), cluster_cols = as.logical(input$cluster_cols),
+          cluster_rows = as.logical(input$cluster_rows), scale = input$scale, row_labels = rowLabels(), colors = makeColors(), cexCol = 1, cexRow = 1,
+          display_numbers = FALSE, hide_colorbar = hideColorbar()
+        )
+      })
     })
   })
 }
@@ -604,18 +604,18 @@ splitAnnotationLegend <- function(p, col_side_colors, palette, ncol_heatmap) {
 #' @return output A numeric matrix of p values
 #' @export
 
-anova_pca_metadata <- function(pca_coords, pcameta, fraction_explained){
+anova_pca_metadata <- function(pca_coords, pcameta, fraction_explained) {
   # Use 10 components or however many fewer is produced by the PCA
-  
+
   last_pc <- 10
   if (ncol(pca_coords) < last_pc) {
     last_pc <- ncol(pca_coords)
   }
-  
+
   pcameta <- pcameta[, chooseGroupingVariables(pcameta), drop = FALSE]
 
   # Make a blank matrix to hold the p values
-  
+
   pvals <-
     matrix(
       data = NA,
@@ -632,9 +632,9 @@ anova_pca_metadata <- function(pca_coords, pcameta, fraction_explained){
         )
       )
     )
-  
+
   # Fill the matrix with anova p values
-  
+
   for (i in 1:ncol(pcameta)) {
     for (j in 1:last_pc) {
       fit <- aov(pca_coords[, j] ~ factor(pcameta[, i]))
@@ -643,6 +643,6 @@ anova_pca_metadata <- function(pca_coords, pcameta, fraction_explained){
       }
     }
   }
-  
+
   pvals
 }

--- a/R/illuminaarray.R
+++ b/R/illuminaarray.R
@@ -179,98 +179,98 @@ illuminaarrayInput <- function(id, eselist) {
 
 #' The server function of the illuminaarray module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(illuminaarray, "illuminaarray", eselist)
+#' illuminaarray("illuminaarray", eselist)
 #'
-illuminaarray <- function(input, output, session, eselist) {
-  # Add internal links to the tables with gene labels
+illuminaarray <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Add internal links to the tables with gene labels
 
-  for (esen in names(eselist)) {
-    ese <- eselist[[esen]]
+    for (esen in names(eselist)) {
+      ese <- eselist[[esen]]
 
-    if (length(ese@labelfield) > 0) {
-      eselist@url_roots[[ese@labelfield]] <- "?gene="
-      eselist@url_roots$significant_genes <- "?gene="
-      eselist@url_roots$gene_set_id <- "?geneset="
-    }
-  }
-
-  # Now a lot of boring calls to all the modules to activate the UI parts
-
-  callModule(experimenttable, "experimenttable", eselist)
-  callModule(rowmetatable, "rowmetatable", eselist)
-  callModule(heatmap, "heatmap-clustering", eselist, type = "samples")
-  callModule(clustering, "feature-clustering", eselist)
-  callModule(illuminaarrayqc, "illuminaarrayqc", eselist)
-  callModule(heatmap, "heatmap-expression", eselist, type = "expression")
-  callModule(heatmap, "heatmap-pca", eselist, type = "pca")
-  callModule(pca, "pca", eselist)
-  callModule(boxplot, "boxplot", eselist)
-  callModule(dendro, "dendro", eselist)
-  callModule(assaydatatable, "expression", eselist)
-
-  # Calls for the various optional tables
-
-  if (any(unlist(lapply(eselist, function(ese) {
-    length(ese@read_reports) > 0
-  })))) {
-    callModule(readreports, "readrep", eselist)
-  }
-
-  if (length(eselist@contrasts) > 0) {
-    callModule(differentialtable, "differential", eselist)
-    callModule(volcanoplot, "volcano", eselist)
-    callModule(foldchangeplot, "foldchange", eselist)
-    callModule(maplot, "ma", eselist)
-    callModule(genesetanalysistable, "genesetanalysis", eselist)
-    updateBarcodeGeneset <- callModule(genesetbarcodeplot, "illuminaarray", eselist)
-    if (length(eselist@contrasts) > 1) {
-      callModule(upset, "upset", eselist)
-    }
-  }
-
-  if (any(unlist(lapply(eselist, function(ese) {
-    length(ese@dexseq_results) > 0
-  })))) {
-    callModule(dexseqtable, "deutable", eselist)
-    updateDEUGeneLabel <- callModule(dexseqplot, "deuplot", eselist)
-  }
-
-  updateGeneLabel <- callModule(gene, "gene", eselist)
-
-  # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
-  # accordingly
-
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-
-    if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
-      return()
-    }
-
-    url_observe <- observe({
-      if ("deu_gene" %in% names(query)) {
-        updateNavbarPage(session, "illuminaarray", "deugene")
-        updateDEUGeneLabel()
-      } else if ("gene" %in% names(query)) {
-        updateNavbarPage(session, "illuminaarray", "geneinfo")
-        updateGeneLabel()
-      } else if ("geneset" %in% names(query)) {
-        updateNavbarPage(session, "illuminaarray", "genesetbarcode")
-        updateBarcodeGeneset()
+      if (length(ese@labelfield) > 0) {
+        eselist@url_roots[[ese@labelfield]] <- "?gene="
+        eselist@url_roots$significant_genes <- "?gene="
+        eselist@url_roots$gene_set_id <- "?geneset="
       }
-      url_observe$suspend()
+    }
+
+    # Now a lot of boring calls to all the modules to activate the UI parts
+
+    experimenttable("experimenttable", eselist)
+    rowmetatable("rowmetatable", eselist)
+    heatmap("heatmap-clustering", eselist, type = "samples")
+    clustering("feature-clustering", eselist)
+    illuminaarrayqc("illuminaarrayqc", eselist)
+    heatmap("heatmap-expression", eselist, type = "expression")
+    heatmap("heatmap-pca", eselist, type = "pca")
+    pca("pca", eselist)
+    boxplot("boxplot", eselist)
+    dendro("dendro", eselist)
+    assaydatatable("expression", eselist)
+
+    # Calls for the various optional tables
+
+    if (any(unlist(lapply(eselist, function(ese) {
+      length(ese@read_reports) > 0
+    })))) {
+      readreports("readrep", eselist)
+    }
+
+    if (length(eselist@contrasts) > 0) {
+      differentialtable("differential", eselist)
+      volcanoplot("volcano", eselist)
+      foldchangeplot("foldchange", eselist)
+      maplot("ma", eselist)
+      genesetanalysistable("genesetanalysis", eselist)
+      updateBarcodeGeneset <- genesetbarcodeplot("illuminaarray", eselist)
+      if (length(eselist@contrasts) > 1) {
+        upset("upset", eselist)
+      }
+    }
+
+    if (any(unlist(lapply(eselist, function(ese) {
+      length(ese@dexseq_results) > 0
+    })))) {
+      dexseqtable("deutable", eselist)
+      updateDEUGeneLabel <- dexseqplot("deuplot", eselist)
+    }
+
+    updateGeneLabel <- gene("gene", eselist)
+
+    # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
+    # accordingly
+
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+
+      if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
+        return()
+      }
+
+      url_observe <- observe({
+        if ("deu_gene" %in% names(query)) {
+          updateNavbarPage(session, "illuminaarray", "deugene")
+          updateDEUGeneLabel()
+        } else if ("gene" %in% names(query)) {
+          updateNavbarPage(session, "illuminaarray", "geneinfo")
+          updateGeneLabel()
+        } else if ("geneset" %in% names(query)) {
+          updateNavbarPage(session, "illuminaarray", "genesetbarcode")
+          updateBarcodeGeneset()
+        }
+        url_observe$suspend()
+      })
     })
   })
 }

--- a/R/illuminaarrayqc.R
+++ b/R/illuminaarrayqc.R
@@ -62,54 +62,54 @@ illuminaarrayqcOutput <- function(id) {
 #'
 #' This module plots control probes from an illumina microarray experiment.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(illuminaarayqc, "myid", eselist)
+#' illuminaarayqc("myid", eselist)
 #'
-illuminaarrayqc <- function(input, output, session, eselist) {
-  unpack.list(callModule(selectmatrix, "illuminaarrayqc", eselist[names(eselist) == "control"], select_genes = FALSE, select_samples = FALSE, select_assay = FALSE))
+illuminaarrayqc <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    unpack.list(selectmatrix("illuminaarrayqc", eselist[names(eselist) == "control"], select_genes = FALSE, select_samples = FALSE, select_assay = FALSE))
 
-  output$qcplot <- renderPlotly({
-    ese <- getExperiment()
-    experiment <- selectColData()
-    control_annotation <- getAnnotation()
-    controls <- selectMatrix()
+    output$qcplot <- renderPlotly({
+      ese <- getExperiment()
+      experiment <- selectColData()
+      control_annotation <- getAnnotation()
+      controls <- selectMatrix()
 
-    controls_merged <- merge(control_annotation, controls, by.x = "Array_Address_Id", by.y = "row.names")
+      controls_merged <- merge(control_annotation, controls, by.x = "Array_Address_Id", by.y = "row.names")
 
-    qc_groups <- list(
-      cy3_low = "phage_lambda_genome:low", cy3_med = "phage_lambda_genome:med", cy3_high = "phage_lambda_genome:high", low_stringency_pm = "phage_lambda_genome:pm",
-      low_stringency_mm = "phage_lambda_genome:mm2", negative = "permuted_negative", biotin = "phage_lambda_genome", labeling = "thrB", housekeeping = "housekeeping"
-    )
+      qc_groups <- list(
+        cy3_low = "phage_lambda_genome:low", cy3_med = "phage_lambda_genome:med", cy3_high = "phage_lambda_genome:high", low_stringency_pm = "phage_lambda_genome:pm",
+        low_stringency_mm = "phage_lambda_genome:mm2", negative = "permuted_negative", biotin = "phage_lambda_genome", labeling = "thrB", housekeeping = "housekeeping"
+      )
 
-    plotdata <- reshape2::melt(do.call(cbind, lapply(qc_groups, function(qcg) {
-      colMeans(controls_merged[grep(paste0(qcg, "($|,)"), controls_merged$Reporter_Group_id), colnames(controls)])
-    })))
+      plotdata <- reshape2::melt(do.call(cbind, lapply(qc_groups, function(qcg) {
+        colMeans(controls_merged[grep(paste0(qcg, "($|,)"), controls_merged$Reporter_Group_id), colnames(controls)])
+      })))
 
-    group_by(plotdata, Var2) %>%
-      plot_ly() %>%
-      add_lines(x = ~Var1, y = ~value, color = ~Var2, colors = c(
-        "red", "red", "red", "orange", "orange", "black",
-        "purple", "blue", "green"
-      ), linetype = ~Var2, linetypes = c("dot", "dash", "solid", "dash", "solid", "solid", "solid", "solid", "solid")) %>%
-      layout(xaxis = list(
-        categoryarray = rownames(experiment),
-        categoryorder = "array", title = ""
-      ), yaxis = list(title = "Intensity"), margin = list(b = 200)) %>%
-      config(showLink = TRUE)
+      group_by(plotdata, Var2) %>%
+        plot_ly() %>%
+        add_lines(x = ~Var1, y = ~value, color = ~Var2, colors = c(
+          "red", "red", "red", "orange", "orange", "black",
+          "purple", "blue", "green"
+        ), linetype = ~Var2, linetypes = c("dot", "dash", "solid", "dash", "solid", "solid", "solid", "solid", "solid")) %>%
+        layout(xaxis = list(
+          categoryarray = rownames(experiment),
+          categoryorder = "array", title = ""
+        ), yaxis = list(title = "Intensity"), margin = list(b = 200)) %>%
+        config(showLink = TRUE)
+    })
+
+    # Render the table and provide for download, using the simpletable module.
+
+    simpletable("qctable", downloadMatrix = selectLabelledMatrix, displayMatrix = selectLabelledLinkedMatrix, filename = "illumina_array_qc", rownames = FALSE)
   })
-
-  # Render the table and provide for download, using the simpletable module.
-
-  callModule(simpletable, "qctable", downloadMatrix = selectLabelledMatrix, displayMatrix = selectLabelledLinkedMatrix, filename = "illumina_array_qc", rownames = FALSE)
 }

--- a/R/labelselectfield.R
+++ b/R/labelselectfield.R
@@ -51,9 +51,7 @@ labelselectfieldInput <- function(id, max_items = 1, id_selection = FALSE) {
 #' to thousands of entries. This would be difficult to do client-side using a
 #' standard select field.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param getExperiment Reactive supplying
@@ -70,195 +68,196 @@ labelselectfieldInput <- function(id, max_items = 1, id_selection = FALSE) {
 #' @param list_input Boolean: will input be a list of values?
 #'
 #' @examples
-#' callModule(labelselectfield, "myid", eselist)
+#' labelselectfield("myid", eselist)
 #'
-labelselectfield <- function(input, output, session, eselist, getExperiment = NULL, labels_from_all_experiments = FALSE, url_field = "label", max_items = 1,
-                             field_selection = FALSE, id_selection = FALSE, getNonEmptyRows = NULL, list_input = FALSE) {
-  # This module will normally be initialised with a reactive that returns the currently selected experiment, whose metadata will be used for gene symbols
-  # etc.  But if that reactive is not present, we can use values from ALL experiments. In the latter case the field will be more static, in the former it
-  # will depend on the value of any experiment-selecting field.
+labelselectfield <- function(id, eselist, getExperiment = NULL, labels_from_all_experiments = FALSE, url_field = "label", max_items = 1, field_selection = FALSE, id_selection = FALSE, getNonEmptyRows = NULL, list_input = FALSE) {
+  moduleServer(id, function(input, output, session) {
+    # This module will normally be initialised with a reactive that returns the currently selected experiment, whose metadata will be used for gene symbols
+    # etc.  But if that reactive is not present, we can use values from ALL experiments. In the latter case the field will be more static, in the former it
+    # will depend on the value of any experiment-selecting field.
 
-  # A wrapper reactive to determine the experiments to consider when parsing metadata. Use all experiments if a reactie is not supplied.
+    # A wrapper reactive to determine the experiments to consider when parsing metadata. Use all experiments if a reactie is not supplied.
 
-  getExperiments <- reactive({
-    if (is.null(getExperiment)) {
-      eselist
-    } else {
-      list(getExperiment())
-    }
-  })
-
-  ### META-FIELD SELECTION
-
-  # Create an input for picking which metafield to use. Allow the choice of any non-numeric field
-
-  getMetaFields <- reactive({
-    ese <- getExperiment()
-    names(mcols(ese))[!unlist(lapply(mcols(ese), is.numeric))]
-  })
-
-  output$metaFields <- renderUI({
-    ns <- session$ns
-
-    ese <- getExperiment()
-
-    if (field_selection) {
-      metaFields <- getMetaFields()
-      selectInput(ns("metaField"), label = "Metadata field", choices = structure(metaFields, names = prettifyVariablename(metaFields)), selected = ese@labelfield)
-    } else {
-      # 'id' means use the row IDs
-
-      mf <- "id"
-      if (length(ese@labelfield) == 0) {
-        # If the idfield slot has been set, use its value instead of 'id'
-
-        if (length(ese@idfield) > 0) {
-          mf <- ese@idfield
-        }
+    getExperiments <- reactive({
+      if (is.null(getExperiment)) {
+        eselist
       } else {
-        mf <- ese@labelfield
-      }
-      hiddenInput(ns("metaField"), values = mf)
-    }
-  })
-
-  # Fetch the meta field from the input
-
-  getSelectedMetaField <- reactive({
-    validate(need(input$metaField, FALSE))
-    mf <- input$metaField
-    mf
-  })
-
-  ### META-FIELD VALUE SELECTION
-
-  # Set the meta values filter dependent on field
-
-  output$metaValue <- renderUI({
-    ns <- session$ns
-    mf <- getSelectedMetaField()
-
-    if (list_input) {
-      tags$textarea(id = ns("label"), rows = 3, cols = 20, "Paste list here, one per line")
-    } else {
-      selectizeInput(ns("label"), prettifyVariablename(mf), choices = NULL, options = list(
-        placeholder = "Type a value or scroll", maxItems = max_items,
-        addPrecedence = TRUE
-      ))
-    }
-  })
-
-  # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list
-
-  observeEvent(input$metaField, {
-    if (!list_input) {
-      updateSelectizeInput(session, "label", choices = getValidLabels(), server = TRUE)
-    }
-  })
-
-  # Get the list of labels. This will be used to populate the autocomplete field
-
-  getValidLabels <- reactive({
-    if (labels_from_all_experiments) {
-      exps <- eselist
-    } else {
-      exps <- getExperiments()
-    }
-
-    label_lists <- lapply(exps, function(ese) {
-      mf <- getSelectedMetaField()
-      if (mf == "id" || mf == ese@idfield) {
-        rownames(ese)
-      } else {
-        mcols(ese)[[mf]]
+        list(getExperiment())
       }
     })
 
-    labels <- unique(Reduce(union, label_lists))
-    labels[order(tolower(labels))]
-  })
+    ### META-FIELD SELECTION
 
-  # Get the value of the label field
+    # Create an input for picking which metafield to use. Allow the choice of any non-numeric field
 
-  getSelectedLabels <- reactive({
-    # mf <- getSelectedMetaField()
-    validate(need(!is.null(input$label) && input$label != "", FALSE))
+    getMetaFields <- reactive({
+      ese <- getExperiment()
+      names(mcols(ese))[!unlist(lapply(mcols(ese), is.numeric))]
+    })
 
-    if (list_input) {
-      unlist(strsplit(input$label, "\\n"))
-    } else {
-      input$label
-    }
-  })
+    output$metaFields <- renderUI({
+      ns <- session$ns
 
-  ### SELECTION OF IDS FOR METAFIELD VALUES
+      ese <- getExperiment()
 
-  # Allow selection from the ids pertaining to a given label
+      if (field_selection) {
+        metaFields <- getMetaFields()
+        selectInput(ns("metaField"), label = "Metadata field", choices = structure(metaFields, names = prettifyVariablename(metaFields)), selected = ese@labelfield)
+      } else {
+        # 'id' means use the row IDs
 
-  output$labelIds <- renderUI({
-    ns <- session$ns
+        mf <- "id"
+        if (length(ese@labelfield) == 0) {
+          # If the idfield slot has been set, use its value instead of 'id'
 
-    ids <- getAssociatedIds()
-
-    if (length(ids) == 1) {
-      hiddenInput(ns("ids"), ids)
-    } else {
-      checkboxGroupInput(ns("ids"), label = "Associated IDs", choices = getAssociatedIds(), selected = getAssociatedIds())
-    }
-  })
-
-  # Get the row or rows of the data that correspond to the input metadata
-
-  getSelectedIds <- reactive({
-    # If the user has been allowed to select IDs, fetch the value of the input field. Othewise return all IDs associated with the selected label
-
-    if (id_selection) {
-      validate(need(length(input$ids) > 0, "Waiting for ID list"))
-      input$ids
-    } else {
-      getAssociatedIds()
-    }
-  })
-
-  # Get the IDs for the selected labels
-
-  getAssociatedIds <- reactive({
-    labels <- getSelectedLabels()
-    exps <- getExperiments()
-    mf <- getSelectedMetaField()
-
-    # If we're just selecting based on row ID, then we don't need to consult the metadata
-
-    if (mf == "id") {
-      labels
-    } else {
-      id_lists <- lapply(exps, function(ese) {
-        if (mf == ese@idfield) {
-          labels
-        } else {
-          ids <- rownames(ese)[which(mcols(ese)[[mf]] %in% labels)]
-
-          # If an assay is specified, limit to valid IDs for that assay
-
-          if (!is.null(getNonEmptyRows)) {
-            ids <- intersect(ids, getNonEmptyRows())
+          if (length(ese@idfield) > 0) {
+            mf <- ese@idfield
           }
-          ids
+        } else {
+          mf <- ese@labelfield
+        }
+        hiddenInput(ns("metaField"), values = mf)
+      }
+    })
+
+    # Fetch the meta field from the input
+
+    getSelectedMetaField <- reactive({
+      validate(need(input$metaField, FALSE))
+      mf <- input$metaField
+      mf
+    })
+
+    ### META-FIELD VALUE SELECTION
+
+    # Set the meta values filter dependent on field
+
+    output$metaValue <- renderUI({
+      ns <- session$ns
+      mf <- getSelectedMetaField()
+
+      if (list_input) {
+        tags$textarea(id = ns("label"), rows = 3, cols = 20, "Paste list here, one per line")
+      } else {
+        selectizeInput(ns("label"), prettifyVariablename(mf), choices = NULL, options = list(
+          placeholder = "Type a value or scroll", maxItems = max_items,
+          addPrecedence = TRUE
+        ))
+      }
+    })
+
+    # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list
+
+    observeEvent(input$metaField, {
+      if (!list_input) {
+        updateSelectizeInput(session, "label", choices = getValidLabels(), server = TRUE)
+      }
+    })
+
+    # Get the list of labels. This will be used to populate the autocomplete field
+
+    getValidLabels <- reactive({
+      if (labels_from_all_experiments) {
+        exps <- eselist
+      } else {
+        exps <- getExperiments()
+      }
+
+      label_lists <- lapply(exps, function(ese) {
+        mf <- getSelectedMetaField()
+        if (mf == "id" || mf == ese@idfield) {
+          rownames(ese)
+        } else {
+          mcols(ese)[[mf]]
         }
       })
-      all_ids <- sort(Reduce(union, id_lists))
 
-      validate(need(length(all_ids) > 0, "No results for specified features. Check matrix selection"))
-      all_ids
-    }
+      labels <- unique(Reduce(union, label_lists))
+      labels[order(tolower(labels))]
+    })
+
+    # Get the value of the label field
+
+    getSelectedLabels <- reactive({
+      # mf <- getSelectedMetaField()
+      validate(need(!is.null(input$label) && input$label != "", FALSE))
+
+      if (list_input) {
+        unlist(strsplit(input$label, "\\n"))
+      } else {
+        input$label
+      }
+    })
+
+    ### SELECTION OF IDS FOR METAFIELD VALUES
+
+    # Allow selection from the ids pertaining to a given label
+
+    output$labelIds <- renderUI({
+      ns <- session$ns
+
+      ids <- getAssociatedIds()
+
+      if (length(ids) == 1) {
+        hiddenInput(ns("ids"), ids)
+      } else {
+        checkboxGroupInput(ns("ids"), label = "Associated IDs", choices = getAssociatedIds(), selected = getAssociatedIds())
+      }
+    })
+
+    # Get the row or rows of the data that correspond to the input metadata
+
+    getSelectedIds <- reactive({
+      # If the user has been allowed to select IDs, fetch the value of the input field. Othewise return all IDs associated with the selected label
+
+      if (id_selection) {
+        validate(need(length(input$ids) > 0, "Waiting for ID list"))
+        input$ids
+      } else {
+        getAssociatedIds()
+      }
+    })
+
+    # Get the IDs for the selected labels
+
+    getAssociatedIds <- reactive({
+      labels <- getSelectedLabels()
+      exps <- getExperiments()
+      mf <- getSelectedMetaField()
+
+      # If we're just selecting based on row ID, then we don't need to consult the metadata
+
+      if (mf == "id") {
+        labels
+      } else {
+        id_lists <- lapply(exps, function(ese) {
+          if (mf == ese@idfield) {
+            labels
+          } else {
+            ids <- rownames(ese)[which(mcols(ese)[[mf]] %in% labels)]
+
+            # If an assay is specified, limit to valid IDs for that assay
+
+            if (!is.null(getNonEmptyRows)) {
+              ids <- intersect(ids, getNonEmptyRows())
+            }
+            ids
+          }
+        })
+        all_ids <- sort(Reduce(union, id_lists))
+
+        validate(need(length(all_ids) > 0, "No results for specified features. Check matrix selection"))
+        all_ids
+      }
+    })
+
+    # A reactive for updating the label input field
+
+    updateLabelField <- reactive({
+      query <- parseQueryString(session$clientData$url_search)
+      updateSelectizeInput(session, "label", selected = query[[url_field]], choices = getValidLabels(), server = TRUE)
+    })
+
+    list(getSelectedLabels = getSelectedLabels, getValidLabels = getValidLabels, getSelectedIds = getSelectedIds, updateLabelField = updateLabelField)
   })
-
-  # A reactive for updating the label input field
-
-  updateLabelField <- reactive({
-    query <- parseQueryString(session$clientData$url_search)
-    updateSelectizeInput(session, "label", selected = query[[url_field]], choices = getValidLabels(), server = TRUE)
-  })
-
-  list(getSelectedLabels = getSelectedLabels, getValidLabels = getValidLabels, getSelectedIds = getSelectedIds, updateLabelField = updateLabelField)
 }

--- a/R/maplot.R
+++ b/R/maplot.R
@@ -90,19 +90,17 @@ maplotOutput <- function(id) {
 #' This module is for making scatter plots comparing pairs of groups defined in
 #' a 'contrasts' slot of the ExploratorySummarizedExperiment
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(maplot, "maplot", eselist)
+#' maplot("maplot", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
@@ -110,114 +108,113 @@ maplotOutput <- function(id) {
 #' app <- prepareApp("maplot", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-maplot <- function(input, output, session, eselist) {
-  output$matable <- renderUI({
-    ns <- session$ns
+maplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    output$matable <- renderUI({
+      ns <- session$ns
 
-    simpletableOutput(ns("matable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]], sep = ": "))
-  })
-
-  # Call the selectmatrix module and unpack the reactives it sends back
-
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE)
-  unpack.list(selectmatrix_reactives)
-
-  # Pass the matrix to the contrasts module for processing
-
-  unpack.list(callModule(contrasts, "differential", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE))
-
-  # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
-
-  unpack.list(callModule(geneselect, "ma", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
-
-  # Pass the matrix to the scatterplot module for display
-
-  callModule(scatterplot, "ma", getDatamatrix = maTable, getTitle = getTitle, allow_3d = FALSE, getLabels = maLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
-
-
-  # Make a title by selecting the single contrast name of the single filter set
-
-  getTitle <- reactive({
-    contrast_names <- getSelectedContrastNames()
-    contrast_names[[1]][[1]]
-  })
-
-  # Make a set of dashed lines to overlay on the plot representing thresholds
-
-  plotLines <- reactive({
-    withProgress(message = "Calculating lines", value = 0, {
-      mat <- maTable()
-
-      fclim <- getFoldChange()
-
-      normal_y <- !is.infinite(mat[, 2])
-      normal_x <- !is.infinite(mat[, 1])
-
-      ymax <- max(mat[normal_y, 2], na.rm = TRUE)
-      ymin <- min(mat[normal_y, 2], na.rm = TRUE)
-
-      xmax <- max(mat[normal_x, 1], na.rm = TRUE)
-      xmin <- min(mat[normal_x, 1], na.rm = TRUE)
-
-      lines <- data.frame(
-        name = c(rep(paste0(abs(fclim), "-fold down"), 2), rep(paste0(abs(fclim), "-fold up"), 2)), x = c(xmin, xmax, xmin, xmax),
-        y = c(rep(-log2(abs(fclim)), 2), rep(log2(abs(fclim)), 2))
-      )
-
-      # Use lines dependent on how the fold change filter is applied
-
-      fccard <- getFoldChangeCard()
-      if (fccard %in% c("> or <-", "< and >-")) {
-        lines
-      } else if (fccard == "<" && sign(fclim) == "-1") {
-        droplevels(lines[c(1, 2), ])
-      } else {
-        droplevels(lines[c(3, 4), ])
-      }
+      simpletableOutput(ns("matable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]], sep = ": "))
     })
-  })
+
+    # Call the selectmatrix module and unpack the reactives it sends back
+
+    selectmatrix_reactives <- selectmatrix("expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE)
+    unpack.list(selectmatrix_reactives)
+
+    # Pass the matrix to the contrasts module for processing
+
+    unpack.list(contrasts("differential", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE))
+
+    # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
+
+    unpack.list(geneselect("ma", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
+
+    # Pass the matrix to the scatterplot module for display
+
+    scatterplot("ma", getDatamatrix = maTable, getTitle = getTitle, allow_3d = FALSE, getLabels = maLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
 
 
-  # Extract labels from the volcano table
+    # Make a title by selecting the single contrast name of the single filter set
 
-  maLabels <- reactive({
-    fct <- maTable()
-    fct$label
-  })
-
-  # Extract a vector use to make colors by group
-
-  colorBy <- reactive({
-    fct <- maTable()
-    fct$colorby
-  })
-
-  # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
-
-  maTable <- reactive({
-    withProgress(message = "Compiling fold change plot data", value = 0, {
-      sct <- selectedContrastsTables()
-      ct <- sct[[1]][[1]]
-
-      matable <- data.frame(`log(10) mean expression` = round(log10(rowMeans(ct[, 1:2])), 3), `log(2) fold change` = round(sign(ct[["Fold change"]]) *
-        log2(abs(ct[["Fold change"]])), 3), row.names = rownames(ct), check.names = FALSE)
-
-      fct <- filteredContrastsTables()[[1]][[1]]
-      matable$colorby <- "hidden"
-      matable[rownames(fct), "colorby"] <- "match contrast filters"
-      matable[selectRows(), "colorby"] <- "in highlighted gene set"
-      matable$colorby <- factor(matable$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
-
-      matable$label <- idToLabel(rownames(matable), getExperiment())
-      matable$label[!rownames(matable) %in% c(rownames(fct), selectRows())] <- NA
+    getTitle <- reactive({
+      contrast_names <- getSelectedContrastNames()
+      contrast_names[[1]][[1]]
     })
-    matable
+
+    # Make a set of dashed lines to overlay on the plot representing thresholds
+
+    plotLines <- reactive({
+      withProgress(message = "Calculating lines", value = 0, {
+        mat <- maTable()
+
+        fclim <- getFoldChange()
+
+        normal_y <- !is.infinite(mat[, 2])
+        normal_x <- !is.infinite(mat[, 1])
+
+        ymax <- max(mat[normal_y, 2], na.rm = TRUE)
+        ymin <- min(mat[normal_y, 2], na.rm = TRUE)
+
+        xmax <- max(mat[normal_x, 1], na.rm = TRUE)
+        xmin <- min(mat[normal_x, 1], na.rm = TRUE)
+
+        lines <- data.frame(
+          name = c(rep(paste0(abs(fclim), "-fold down"), 2), rep(paste0(abs(fclim), "-fold up"), 2)), x = c(xmin, xmax, xmin, xmax),
+          y = c(rep(-log2(abs(fclim)), 2), rep(log2(abs(fclim)), 2))
+        )
+
+        # Use lines dependent on how the fold change filter is applied
+
+        fccard <- getFoldChangeCard()
+        if (fccard %in% c("> or <-", "< and >-")) {
+          lines
+        } else if (fccard == "<" && sign(fclim) == "-1") {
+          droplevels(lines[c(1, 2), ])
+        } else {
+          droplevels(lines[c(3, 4), ])
+        }
+      })
+    })
+
+
+    # Extract labels from the volcano table
+
+    maLabels <- reactive({
+      fct <- maTable()
+      fct$label
+    })
+
+    # Extract a vector use to make colors by group
+
+    colorBy <- reactive({
+      fct <- maTable()
+      fct$colorby
+    })
+
+    # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
+
+    maTable <- reactive({
+      withProgress(message = "Compiling fold change plot data", value = 0, {
+        sct <- selectedContrastsTables()
+        ct <- sct[[1]][[1]]
+
+        matable <- data.frame(`log(10) mean expression` = round(log10(rowMeans(ct[, 1:2])), 3), `log(2) fold change` = round(sign(ct[["Fold change"]]) *
+          log2(abs(ct[["Fold change"]])), 3), row.names = rownames(ct), check.names = FALSE)
+
+        fct <- filteredContrastsTables()[[1]][[1]]
+        matable$colorby <- "hidden"
+        matable[rownames(fct), "colorby"] <- "match contrast filters"
+        matable[selectRows(), "colorby"] <- "in highlighted gene set"
+        matable$colorby <- factor(matable$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
+
+        matable$label <- idToLabel(rownames(matable), getExperiment())
+        matable$label[!rownames(matable) %in% c(rownames(fct), selectRows())] <- NA
+      })
+      matable
+    })
+
+    # Display the data as a table alongside
+
+    simpletable("matable", downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "ma", rownames = FALSE, pageLength = 10)
   })
-
-  # Display the data as a table alongside
-
-  callModule(simpletable, "matable",
-    downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "ma", rownames = FALSE,
-    pageLength = 10
-  )
 }

--- a/R/pca.R
+++ b/R/pca.R
@@ -76,21 +76,19 @@ pcaOutput <- function(id) {
 #' \code{scatterplotcontrols} module, to power scatter plots for both components
 #' and loadings produced by the \code{scatterplots} module.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
 #' Matrix and UI selection elements provided by the selectmatrix module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(pca, "pca", eselist)
+#' pca("pca", eselist)
 #'
 #' # Almost certainly used via application creation
 #'
@@ -98,147 +96,143 @@ pcaOutput <- function(id) {
 #' app <- prepareApp("pca", zhangneurons)
 #' shiny::shinyApp(ui = app$ui, server = app$server)
 #'
-pca <- function(input, output, session, eselist) {
-  unpack.list(callModule(selectmatrix, "pca", eselist, var_n = 1000, select_genes = TRUE, provide_all_genes = TRUE, default_gene_select = "variance", select_meta = FALSE))
+pca <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    unpack.list(selectmatrix("pca", eselist, var_n = 1000, select_genes = TRUE, provide_all_genes = TRUE, default_gene_select = "variance", select_meta = FALSE))
 
-  # Call the groupby module to define sample groups and group colors
+    # Call the groupby module to define sample groups and group colors
 
-  unpack.list(callModule(groupby, "pca", eselist = eselist, group_label = "Color by", selectColData = selectColData))
+    unpack.list(groupby("pca", eselist = eselist, group_label = "Color by", selectColData = selectColData))
 
-  # Make a common set of controls to be used for components and loadings plots
+    # Make a common set of controls to be used for components and loadings plots
 
-  unpack.list(callModule(scatterplotcontrols, "pca", pcaMatrix))
+    unpack.list(scatterplotcontrols("pca", pcaMatrix))
 
-  # Create a PCA plot using the controls supplied by scatterplotcontrols module and unpacked above for both PCA and loading
+    # Create a PCA plot using the controls supplied by scatterplotcontrols module and unpacked above for both PCA and loading
 
-  callModule(scatterplot, "pca",
-    getDatamatrix = pcaMatrix, getThreedee = getThreedee, getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis, getShowLabels = getShowLabels,
-    getPointSize = getPointSize, getTitle = getComponentsTitle, colorBy = pcaColorBy, getPalette = getPalette
-  )
-  callModule(scatterplot, "loading",
-    getDatamatrix = loadingMatrix, getThreedee = getThreedee, getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis,
-    getShowLabels = getShowLabels, getPointSize = getPointSize, getTitle = getLoadingTitle, getLabels = getLoadLabels
-  )
+    scatterplot("pca", getDatamatrix = pcaMatrix, getThreedee = getThreedee, getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis, getShowLabels = getShowLabels, getPointSize = getPointSize, getTitle = getComponentsTitle, colorBy = pcaColorBy, getPalette = getPalette)
+    scatterplot("loading", getDatamatrix = loadingMatrix, getThreedee = getThreedee, getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis, getShowLabels = getShowLabels, getPointSize = getPointSize, getTitle = getLoadingTitle, getLabels = getLoadLabels)
 
-  # Simple title functions
+    # Simple title functions
 
-  getComponentsTitle <- reactive({
-    paste("Components plot for PCA on matrix:", tolower(matrixTitle()))
-  })
-
-  getLoadingTitle <- reactive({
-    paste("Loading plot for PCA on matrix:", tolower(matrixTitle()))
-  })
-
-  # Make a matrix of values to the PCA
-
-  pcaMatrix <- reactive({
-    withProgress(message = "Making PCA matrix", value = 0, {
-      fraction_explained <- calculatePCAFractionExplained()
-      plotdata <- data.frame(pca()$x)
-      colnames(plotdata) <- paste0(colnames(plotdata), ": ", fraction_explained, "%")
-      plotdata
+    getComponentsTitle <- reactive({
+      paste("Components plot for PCA on matrix:", tolower(matrixTitle()))
     })
-  })
 
-  pcaDisplayMatrix <- reactive({
-    pcam <- pcaMatrix()
-    pcam <- apply(pcam[, 1:min(ncol(pcam), 10)], 2, function(x) round(x, 2))
-    pcam
-  })
-
-  pcaColorBy <- reactive({
-    if (is.null(getGroupby())) {
-
-    } else {
-      pcb <- na.replace(selectColData()[[getGroupby()]], "N/A")
-      factor(pcb, levels = unique(pcb))
-    }
-  })
-
-  # Run the PCA
-
-  pca <- reactive({
-    pcamatrix <- selectMatrix()
-    withProgress(message = "Running principal component analysis", value = 0, {
-      runPCA(pcamatrix)
+    getLoadingTitle <- reactive({
+      paste("Loading plot for PCA on matrix:", tolower(matrixTitle()))
     })
-  })
 
-  # Fractional variance for each component
+    # Make a matrix of values to the PCA
 
-  calculatePCAFractionExplained <- reactive({
-    pca <- pca()
-    round((pca$sdev)^2 / sum(pca$sdev^2), 3) * 100
-  })
-
-  # Loading matrix
-
-  loadingMatrix <- reactive({
-    getLoadings()$load
-  })
-
-  selectedComponents <- reactive({
-    c(getXAxis(), getYAxis(), getZAxis())
-  })
-
-  # Fetch the loadings
-
-  getLoadings <- reactive({
-    withProgress(message = "Fetching loadings", value = 0, {
-      rot <- pca()$rotation
-      fraction_explained <- calculatePCAFractionExplained()
-      colnames(rot) <- paste0(colnames(rot), ": ", fraction_explained, "%")
-
-      loaded_rows <- Reduce(union, lapply(selectedComponents(), function(pc) rownames(rot)[order(abs(rot[, pc]), decreasing = TRUE)[1:input$n_loadings]]))
-
-      # Also return a table with the loadings converted to fractions
-
-      aload <- abs(rot)
-      fractions <- sweep(aload, 2, colSums(aload), "/")
-
-      list(load = rot[loaded_rows, ], fraction = fractions[loaded_rows, ])
+    pcaMatrix <- reactive({
+      withProgress(message = "Making PCA matrix", value = 0, {
+        fraction_explained <- calculatePCAFractionExplained()
+        plotdata <- data.frame(pca()$x)
+        colnames(plotdata) <- paste0(colnames(plotdata), ": ", fraction_explained, "%")
+        plotdata
+      })
     })
-  })
 
-  # Take the loadings and format them for display
-
-  makeLoadingTable <- reactive({
-    load <- getLoadings()$load[, selectedComponents()]
-    colnames(load) <- paste(colnames(load), "loading")
-
-    fraction <- getLoadings()$fraction[, selectedComponents()]
-    colnames(fraction) <- paste(colnames(fraction), "loading fraction")
-
-    interleaveColumns(load, fraction)
-  })
-
-  # Make a version of the loading table for display with rounded values and links
-
-  makeDisplayLoadingTable <- reactive({
-    linkMatrix(labelMatrix(data.frame(signif(makeLoadingTable(), 5), check.names = FALSE), getExperiment()), url_roots = eselist@url_roots)
-  })
-
-  makeDownloadLoadingTable <- reactive({
-    labelMatrix(data.frame(makeLoadingTable(), check.names = FALSE), getExperiment())
-  })
-
-  # Make labels for the laoding plot detailing the percent contributions to components etc
-
-  getLoadLabels <- reactive({
-    load <- getLoadings()
-
-    percent_contributions <- lapply(selectedComponents(), function(n) {
-      paste0(paste(paste0("PC", n), round((load$fraction[, n] * 100), 3), sep = ": "), "%")
+    pcaDisplayMatrix <- reactive({
+      pcam <- pcaMatrix()
+      pcam <- apply(pcam[, 1:min(ncol(pcam), 10)], 2, function(x) round(x, 2))
+      pcam
     })
-    percent_contributions$sep <- "<br />"
 
-    loadlabels <- paste(idToLabel(rownames(load$fraction), getExperiment()), do.call(paste, percent_contributions), sep = "<br />")
+    pcaColorBy <- reactive({
+      if (is.null(getGroupby())) {
+
+      } else {
+        pcb <- na.replace(selectColData()[[getGroupby()]], "N/A")
+        factor(pcb, levels = unique(pcb))
+      }
+    })
+
+    # Run the PCA
+
+    pca <- reactive({
+      pcamatrix <- selectMatrix()
+      withProgress(message = "Running principal component analysis", value = 0, {
+        runPCA(pcamatrix)
+      })
+    })
+
+    # Fractional variance for each component
+
+    calculatePCAFractionExplained <- reactive({
+      pca <- pca()
+      round((pca$sdev)^2 / sum(pca$sdev^2), 3) * 100
+    })
+
+    # Loading matrix
+
+    loadingMatrix <- reactive({
+      getLoadings()$load
+    })
+
+    selectedComponents <- reactive({
+      c(getXAxis(), getYAxis(), getZAxis())
+    })
+
+    # Fetch the loadings
+
+    getLoadings <- reactive({
+      withProgress(message = "Fetching loadings", value = 0, {
+        rot <- pca()$rotation
+        fraction_explained <- calculatePCAFractionExplained()
+        colnames(rot) <- paste0(colnames(rot), ": ", fraction_explained, "%")
+
+        loaded_rows <- Reduce(union, lapply(selectedComponents(), function(pc) rownames(rot)[order(abs(rot[, pc]), decreasing = TRUE)[1:input$n_loadings]]))
+
+        # Also return a table with the loadings converted to fractions
+
+        aload <- abs(rot)
+        fractions <- sweep(aload, 2, colSums(aload), "/")
+
+        list(load = rot[loaded_rows, ], fraction = fractions[loaded_rows, ])
+      })
+    })
+
+    # Take the loadings and format them for display
+
+    makeLoadingTable <- reactive({
+      load <- getLoadings()$load[, selectedComponents()]
+      colnames(load) <- paste(colnames(load), "loading")
+
+      fraction <- getLoadings()$fraction[, selectedComponents()]
+      colnames(fraction) <- paste(colnames(fraction), "loading fraction")
+
+      interleaveColumns(load, fraction)
+    })
+
+    # Make a version of the loading table for display with rounded values and links
+
+    makeDisplayLoadingTable <- reactive({
+      linkMatrix(labelMatrix(data.frame(signif(makeLoadingTable(), 5), check.names = FALSE), getExperiment()), url_roots = eselist@url_roots)
+    })
+
+    makeDownloadLoadingTable <- reactive({
+      labelMatrix(data.frame(makeLoadingTable(), check.names = FALSE), getExperiment())
+    })
+
+    # Make labels for the laoding plot detailing the percent contributions to components etc
+
+    getLoadLabels <- reactive({
+      load <- getLoadings()
+
+      percent_contributions <- lapply(selectedComponents(), function(n) {
+        paste0(paste(paste0("PC", n), round((load$fraction[, n] * 100), 3), sep = ": "), "%")
+      })
+      percent_contributions$sep <- "<br />"
+
+      loadlabels <- paste(idToLabel(rownames(load$fraction), getExperiment()), do.call(paste, percent_contributions), sep = "<br />")
+    })
+
+    simpletable("components", downloadMatrix = pcaDisplayMatrix, displayMatrix = pcaDisplayMatrix, filename = "components", rownames = TRUE)
+
+    simpletable("loading", downloadMatrix = makeDownloadLoadingTable, displayMatrix = makeDisplayLoadingTable, filename = "pcaloading", rownames = FALSE)
   })
-
-  callModule(simpletable, "components", downloadMatrix = pcaDisplayMatrix, displayMatrix = pcaDisplayMatrix, filename = "components", rownames = TRUE)
-
-  callModule(simpletable, "loading", downloadMatrix = makeDownloadLoadingTable, displayMatrix = makeDisplayLoadingTable, filename = "pcaloading", rownames = FALSE)
 }
 
 #' Run a simple PCA analysis
@@ -277,10 +271,9 @@ runPCA <- function(matrix, do_log = TRUE) {
 #'   and fractional variance contributions, respectively.
 
 compilePCAData <- function(matrix, ntop = NULL) {
-
-  if (is.null(ntop)){
+  if (is.null(ntop)) {
     select <- 1:nrow(matrix)
-  }else{
+  } else {
     select <- selectVariableGenes(matrix = matrix, ntop = ntop)
   }
 

--- a/R/plotdownload.R
+++ b/R/plotdownload.R
@@ -25,9 +25,7 @@ plotdownloadInput <- function(id, label = "Plot") {
 #' The plotdownload module provides export functionality for panels with plots.
 #' This will generally not be called directly, but by other modules
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param makePlot A reactive for generating the plot
 #' @param filename A filename (default = 'plot.png')
 #' @param plotHeight A number or reactive for calculating the height of the plot
@@ -37,20 +35,22 @@ plotdownloadInput <- function(id, label = "Plot") {
 #' @importFrom grDevices dev.off png
 #'
 #' @examples
-#' callModule(plotdownload, "heatmap", makePlot = plotHeatmap, filename = "heatmap.png", plotHeight = plotHeight, plotWidth = plotWidth)
+#' plotdownload("heatmap", makePlot = plotHeatmap, filename = "heatmap.png", plotHeight = plotHeight, plotWidth = plotWidth)
 #'
-plotdownload <- function(input, output, session, makePlot, filename = "plot.png", plotHeight, plotWidth) {
-  if (is.reactive(plotHeight)) {
-    plotHeight <- as.numeric(plotHeight())
-  }
+plotdownload <- function(id, makePlot, filename = "plot.png", plotHeight, plotWidth) {
+  moduleServer(id, function(input, output, session) {
+    if (is.reactive(plotHeight)) {
+      plotHeight <- as.numeric(plotHeight())
+    }
 
-  if (is.reactive(plotWidth)) {
-    plotWidth <- as.numeric(plotWidth())
-  }
+    if (is.reactive(plotWidth)) {
+      plotWidth <- as.numeric(plotWidth())
+    }
 
-  output$plotdownload <- downloadHandler(filename = filename, content = function(file) {
-    png(file, height = plotHeight, width = plotWidth, units = "px")
-    print(makePlot())
-    dev.off()
+    output$plotdownload <- downloadHandler(filename = filename, content = function(file) {
+      png(file, height = plotHeight, width = plotWidth, units = "px")
+      print(makePlot())
+      dev.off()
+    })
   })
 }

--- a/R/readreports.R
+++ b/R/readreports.R
@@ -53,97 +53,97 @@ readreportsOutput <- function(id, eselist) {
 #' Display plots and tables relating to read mapping, attrition during
 #' analysis etc.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperiment with \code{read_distribution}
 #' slot filled
 
-readreports <- function(input, output, session, eselist) {
-  ns <- session$ns
+readreports <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
-  unpack.list(callModule(selectmatrix, "readreports", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE))
+    unpack.list(selectmatrix("readreports", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE))
 
-  # Render a select for the report type based on what's in the 'read_reports' slot
+    # Render a select for the report type based on what's in the 'read_reports' slot
 
-  output$reportType <- renderUI({
-    ese <- getExperiment()
-    selectInput(ns("reportType"), "Report type", structure(names(ese@read_reports), names = prettifyVariablename(names(ese@read_reports))))
+    output$reportType <- renderUI({
+      ese <- getExperiment()
+      selectInput(ns("reportType"), "Report type", structure(names(ese@read_reports), names = prettifyVariablename(names(ese@read_reports))))
+    })
+
+    # Render bar plot controls with default behaviour dependent on report type
+
+    output$barplotControls <- renderUI({
+      default_mode <- getDefaultMode()
+      barplotInput(ns("barplot"), default_mode = default_mode)
+    })
+
+    # Render the bar plot with height dependent on the number of columns in the report (so that the legend fits)
+
+    output$barplotOutput <- renderUI({
+      ese <- getExperiment()
+      report_type <- getReportType()
+      min_height <- 400
+      height <- max(min_height, ncol(ese@read_reports[[report_type]]) * 20)
+      barplotOutput(ns("barplot"), height)
+    })
+
+    # Dynamic title for the plot
+
+    output$plotTitle <- renderUI({
+      report_type <- getReportType()
+      h3(paste(prettifyVariablename(report_type), "plot"))
+    })
+
+    # Dynamic title for the table
+
+    output$tableTitle <- renderUI({
+      report_type <- getReportType()
+      h4(paste(prettifyVariablename(report_type), "data"))
+    })
+
+    # Return the selected plot type when available
+
+    getReportType <- reactive({
+      validate(need(input$reportType, FALSE))
+      input$reportType
+    })
+
+    # Choose a default bar mode based on the report type. For read attrition when the counts at each analysis stage are a subset of those at the previous, it
+    # makes sense to use overlapped bars.
+
+    getDefaultMode <- reactive({
+      report_type <- getReportType()
+      if (report_type == "read_attrition") {
+        "overlay"
+      } else {
+        "stack"
+      }
+    })
+
+    # The barplot module expects data in columns by sample, so transform the table.
+
+    getPlotmatrix <- reactive({
+      report_table <- getReportTable()
+      t(report_table)
+    })
+
+    # Get the report table from the slot
+
+    getReportTable <- reactive({
+      ese <- getExperiment()
+      report_type <- getReportType()
+      plotmatrix <- ese@read_reports[[report_type]]
+      plotmatrix <- plotmatrix[, apply(plotmatrix, 2, function(x) sum(x > 10) > 0)]
+      plotmatrix <- plotmatrix[, order(colMeans(plotmatrix), decreasing = TRUE)]
+      colnames(plotmatrix) <- prettifyVariablename(colnames(plotmatrix))
+      plotmatrix
+    })
+
+    # Call the modules to produce the plot and table
+
+    barplot("barplot", getPlotmatrix = getPlotmatrix, getYLabel = reactive({
+      "Reads"
+    }))
+    simpletable("readrep", displayMatrix = getReportTable, filename = "read_report", rownames = TRUE)
   })
-
-  # Render bar plot controls with default behaviour dependent on report type
-
-  output$barplotControls <- renderUI({
-    default_mode <- getDefaultMode()
-    barplotInput(ns("barplot"), default_mode = default_mode)
-  })
-
-  # Render the bar plot with height dependent on the number of columns in the report (so that the legend fits)
-
-  output$barplotOutput <- renderUI({
-    ese <- getExperiment()
-    report_type <- getReportType()
-    min_height <- 400
-    height <- max(min_height, ncol(ese@read_reports[[report_type]]) * 20)
-    barplotOutput(ns("barplot"), height)
-  })
-
-  # Dynamic title for the plot
-
-  output$plotTitle <- renderUI({
-    report_type <- getReportType()
-    h3(paste(prettifyVariablename(report_type), "plot"))
-  })
-
-  # Dynamic title for the table
-
-  output$tableTitle <- renderUI({
-    report_type <- getReportType()
-    h4(paste(prettifyVariablename(report_type), "data"))
-  })
-
-  # Return the selected plot type when available
-
-  getReportType <- reactive({
-    validate(need(input$reportType, FALSE))
-    input$reportType
-  })
-
-  # Choose a default bar mode based on the report type. For read attrition when the counts at each analysis stage are a subset of those at the previous, it
-  # makes sense to use overlapped bars.
-
-  getDefaultMode <- reactive({
-    report_type <- getReportType()
-    if (report_type == "read_attrition") {
-      "overlay"
-    } else {
-      "stack"
-    }
-  })
-
-  # The barplot module expects data in columns by sample, so transform the table.
-
-  getPlotmatrix <- reactive({
-    report_table <- getReportTable()
-    t(report_table)
-  })
-
-  # Get the report table from the slot
-
-  getReportTable <- reactive({
-    ese <- getExperiment()
-    report_type <- getReportType()
-    plotmatrix <- ese@read_reports[[report_type]]
-    plotmatrix <- plotmatrix[, apply(plotmatrix, 2, function(x) sum(x > 10) > 0)]
-    plotmatrix <- plotmatrix[, order(colMeans(plotmatrix), decreasing = TRUE)]
-    colnames(plotmatrix) <- prettifyVariablename(colnames(plotmatrix))
-    plotmatrix
-  })
-
-  # Call the modules to produce the plot and table
-
-  callModule(barplot, "barplot", getPlotmatrix = getPlotmatrix, getYLabel = reactive({
-    "Reads"
-  }))
-  callModule(simpletable, "readrep", displayMatrix = getReportTable, filename = "read_report", rownames = TRUE)
 }

--- a/R/rnaseq.R
+++ b/R/rnaseq.R
@@ -84,7 +84,7 @@ rnaseqInput <- function(id, eselist) {
 
   navbar_menus <- pushToList(navbar_menus, do.call("navbarMenu", exploratory_menu))
 
-#  # Add the assay data menu
+  #  # Add the assay data menu
 
   assaydata_menu <- list("Assay data", tabPanel("Tables", sidebarLayout(sidebarPanel(assaydatatableInput(ns("expression"), eselist), width = 3), mainPanel(assaydatatableOutput(ns("expression")),
     width = 9
@@ -180,97 +180,97 @@ rnaseqInput <- function(id, eselist) {
 
 #' The server function of the rnaseq module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(rnaseq, "rnaseq", eselist)
+#' rnaseq("rnaseq", eselist)
 #'
-rnaseq <- function(input, output, session, eselist) {
-  # Add internal links to the tables with gene labels
+rnaseq <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    # Add internal links to the tables with gene labels
 
-  for (esen in names(eselist)) {
-    ese <- eselist[[esen]]
+    for (esen in names(eselist)) {
+      ese <- eselist[[esen]]
 
-    if (length(ese@labelfield) > 0) {
-      eselist@url_roots[[ese@labelfield]] <- "?gene="
-      eselist@url_roots$significant_genes <- "?gene="
-      eselist@url_roots$gene_set_id <- "?geneset="
-    }
-  }
-
-  # Now a lot of boring calls to all the modules to activate the UI parts
-
-  callModule(experimenttable, "experimenttable", eselist)
-  callModule(rowmetatable, "rowmetatable", eselist)
-  callModule(heatmap, "heatmap-clustering", eselist, type = "samples")
-  callModule(clustering, "feature-clustering", eselist)
-  callModule(heatmap, "heatmap-expression", eselist, type = "expression")
-  callModule(heatmap, "heatmap-pca", eselist, type = "pca")
-  callModule(pca, "pca", eselist)
-  callModule(boxplot, "boxplot", eselist)
-  callModule(dendro, "dendro", eselist)
-  callModule(assaydatatable, "expression", eselist)
-
-  # Calls for the various optional tables
-
-  if (any(unlist(lapply(eselist, function(ese) {
-    length(ese@read_reports) > 0
-  })))) {
-    callModule(readreports, "readrep", eselist)
-  }
-
-  if (length(eselist@contrasts) > 0) {
-    callModule(differentialtable, "differential", eselist)
-    callModule(volcanoplot, "volcano", eselist)
-    callModule(foldchangeplot, "foldchange", eselist)
-    callModule(maplot, "ma", eselist)
-    callModule(genesetanalysistable, "genesetanalysis", eselist)
-    updateBarcodeGeneset <- callModule(genesetbarcodeplot, "rnaseq", eselist)
-    if (length(eselist@contrasts) > 1) {
-      callModule(upset, "upset", eselist)
-    }
-  }
-
-  if (any(unlist(lapply(eselist, function(ese) {
-    length(ese@dexseq_results) > 0
-  })))) {
-    callModule(dexseqtable, "deutable", eselist)
-    updateDEUGeneLabel <- callModule(dexseqplot, "deuplot", eselist)
-  }
-
-  updateGeneLabel <- callModule(gene, "gene", eselist)
-
-  # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
-  # accordingly
-
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-
-    if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
-      return()
-    }
-
-    url_observe <- observe({
-      if ("deu_gene" %in% names(query)) {
-        updateNavbarPage(session, "rnaseq", "deugene")
-        updateDEUGeneLabel()
-      } else if ("gene" %in% names(query)) {
-        updateNavbarPage(session, "rnaseq", "geneinfo")
-        updateGeneLabel()
-      } else if ("geneset" %in% names(query)) {
-        updateNavbarPage(session, "rnaseq", "genesetbarcode")
-        updateBarcodeGeneset()
+      if (length(ese@labelfield) > 0) {
+        eselist@url_roots[[ese@labelfield]] <- "?gene="
+        eselist@url_roots$significant_genes <- "?gene="
+        eselist@url_roots$gene_set_id <- "?geneset="
       }
-      url_observe$suspend()
+    }
+
+    # Now a lot of boring calls to all the modules to activate the UI parts
+
+    experimenttable("experimenttable", eselist)
+    rowmetatable("rowmetatable", eselist)
+    heatmap("heatmap-clustering", eselist, type = "samples")
+    clustering("feature-clustering", eselist)
+    heatmap("heatmap-expression", eselist, type = "expression")
+    heatmap("heatmap-pca", eselist, type = "pca")
+    pca("pca", eselist)
+    boxplot("boxplot", eselist)
+    dendro("dendro", eselist)
+    assaydatatable("expression", eselist)
+
+    # Calls for the various optional tables
+
+    if (any(unlist(lapply(eselist, function(ese) {
+      length(ese@read_reports) > 0
+    })))) {
+      readreports("readrep", eselist)
+    }
+
+    if (length(eselist@contrasts) > 0) {
+      differentialtable("differential", eselist)
+      volcanoplot("volcano", eselist)
+      foldchangeplot("foldchange", eselist)
+      maplot("ma", eselist)
+      genesetanalysistable("genesetanalysis", eselist)
+      updateBarcodeGeneset <- genesetbarcodeplot("rnaseq", eselist)
+      if (length(eselist@contrasts) > 1) {
+        upset("upset", eselist)
+      }
+    }
+
+    if (any(unlist(lapply(eselist, function(ese) {
+      length(ese@dexseq_results) > 0
+    })))) {
+      dexseqtable("deutable", eselist)
+      updateDEUGeneLabel <- dexseqplot("deuplot", eselist)
+    }
+
+    updateGeneLabel <- gene("gene", eselist)
+
+    # Catch the specified gene from the URL, switch to the gene info tab, and and use the reactive supplied by the gene module to update its gene label field
+    # accordingly
+
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+
+      if (length(intersect(c("gene", "geneset", "deu_gene"), names(query))) == 0) {
+        return()
+      }
+
+      url_observe <- observe({
+        if ("deu_gene" %in% names(query)) {
+          updateNavbarPage(session, "rnaseq", "deugene")
+          updateDEUGeneLabel()
+        } else if ("gene" %in% names(query)) {
+          updateNavbarPage(session, "rnaseq", "geneinfo")
+          updateGeneLabel()
+        } else if ("geneset" %in% names(query)) {
+          updateNavbarPage(session, "rnaseq", "genesetbarcode")
+          updateBarcodeGeneset()
+        }
+        url_observe$suspend()
+      })
     })
   })
 }

--- a/R/rowmetatable.R
+++ b/R/rowmetatable.R
@@ -55,34 +55,34 @@ rowmetatableOutput <- function(id) {
 
 #' The server function of the rowmetatable module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example). Essentially this just passes the results of \code{colData()}
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 #' applied to the specified SummarizedExperiment object to the
 #' \code{simpletable} module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(rowmetatable, "rowmetatable", eselist)
+#' rowmetatable("rowmetatable", eselist)
 #'
-rowmetatable <- function(input, output, session, eselist) {
-  getRowMeta <- reactive({
-    meta <- getAnnotation()
-    meta
-  })
+rowmetatable <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    getRowMeta <- reactive({
+      meta <- getAnnotation()
+      meta
+    })
 
-  getLinkedRowMeta <- reactive({
-    meta <- getRowMeta()
-    colnames(meta) <- prettifyVariablename(colnames(meta))
-    linkMatrix(meta, eselist@url_roots)
-  })
+    getLinkedRowMeta <- reactive({
+      meta <- getRowMeta()
+      colnames(meta) <- prettifyVariablename(colnames(meta))
+      linkMatrix(meta, eselist@url_roots)
+    })
 
-  unpack.list(callModule(selectmatrix, "rowmetatable", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE))
-  callModule(simpletable, "rowmetatable", displayMatrix = getLinkedRowMeta, downloadMatrix = getRowMeta, filename = "rowmeta", rownames = TRUE, pageLength = 10)
+    unpack.list(selectmatrix("rowmetatable", eselist, select_assays = FALSE, select_samples = FALSE, select_genes = FALSE, select_meta = FALSE))
+    simpletable("rowmetatable", displayMatrix = getLinkedRowMeta, downloadMatrix = getRowMeta, filename = "rowmeta", rownames = TRUE, pageLength = 10)
+  })
 }

--- a/R/sampleselect.R
+++ b/R/sampleselect.R
@@ -72,12 +72,10 @@ sampleselectInput <- function(id, eselist, getExperiment, select_samples = TRUE)
 #' This module provides controls for selecting matrix columns by sample or
 #' group name.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param getExperiment Reactive expression that returns a
@@ -91,79 +89,80 @@ sampleselectInput <- function(id, eselist, getExperiment, select_samples = TRUE)
 #' @keywords shiny
 #'
 #' @examples
-#' selectSamples <- callModule(sampleselect, "selectmatrix", getExperiment)
+#' selectSamples <- sampleselect("selectmatrix", getExperiment)
 #'
-sampleselect <- function(input, output, session, eselist, getExperiment, allow_summarise = TRUE) {
-  if (allow_summarise){
-    getSummaryType <- callModule(summarisematrix, "summarise")
-  }
-
-  # Render the sampleGroupVal() element based on sampleGroupVar
-
-  output$groupSamples <- renderUI({
-    ese <- getExperiment()
-
-    if (input$sampleSelect == "group" && length(eselist@group_vars) > 0) {
-      validate(need(input$sampleGroupVar, FALSE))
-      group_values <- as.character(unique(ese[[isolate(input$sampleGroupVar)]]))
-      ns <- session$ns
-
-      inputs <- list(checkboxGroupInput(ns("sampleGroupVal"), "Groups", group_values, selected = group_values))
-      if (allow_summarise){
-        inputs <- pushToList(inputs, summarisematrixInput(ns("summarise"))) 
-      }
-      inputs
+sampleselect <- function(id, eselist, getExperiment, allow_summarise = TRUE) {
+  moduleServer(id, function(input, output, session) {
+    if (allow_summarise) {
+      getSummaryType <- summarisematrix("summarise")
     }
-  })
 
-  # Output a reactive so that other modules know whether we've selected by sample or group
+    # Render the sampleGroupVal() element based on sampleGroupVar
 
-  getSampleSelect <- reactive({
-    input$sampleSelect
-  })
-
-  # Return summary type
-
-  getSampleGroupVar <- reactive({
-    input$sampleGroupVar
-  })
-
-  # Reactive expression for selecting the specified columns
-
-  selectSamples <- reactive({
-    withProgress(message = "Selecting samples", value = 0, {
-
-      validate(need(!is.null(getSampleSelect()), "Waiting for form to provide sampleSelect"))
+    output$groupSamples <- renderUI({
       ese <- getExperiment()
 
-      if (getSampleSelect() == "all") {
-        return(colnames(ese))
-      } else {
-        validate(need(!is.null(input$samples), "Waiting for form to provide samples"))
+      if (input$sampleSelect == "group" && length(eselist@group_vars) > 0) {
+        validate(need(input$sampleGroupVar, FALSE))
+        group_values <- as.character(unique(ese[[isolate(input$sampleGroupVar)]]))
+        ns <- session$ns
 
-        if (length(eselist@group_vars) > 0) {
-          validate(need(!is.null(input$sampleGroupVal), FALSE))
+        inputs <- list(checkboxGroupInput(ns("sampleGroupVal"), "Groups", group_values, selected = group_values))
+        if (allow_summarise) {
+          inputs <- pushToList(inputs, summarisematrixInput(ns("summarise")))
         }
-
-        if (getSampleSelect() == "name") {
-          return(input$samples)
-        } else {
-          # Any NA in the colData will become string '' via the inputs, so make sure we consider that when matching
-
-          samplegroups <- as.character(ese[[isolate(input$sampleGroupVar)]])
-          samplegroups[is.na(samplegroups)] <- ""
-
-          return(colnames(ese)[samplegroups %in% input$sampleGroupVal])
-        }
+        inputs
       }
     })
+
+    # Output a reactive so that other modules know whether we've selected by sample or group
+
+    getSampleSelect <- reactive({
+      input$sampleSelect
+    })
+
+    # Return summary type
+
+    getSampleGroupVar <- reactive({
+      input$sampleGroupVar
+    })
+
+    # Reactive expression for selecting the specified columns
+
+    selectSamples <- reactive({
+      withProgress(message = "Selecting samples", value = 0, {
+        validate(need(!is.null(getSampleSelect()), "Waiting for form to provide sampleSelect"))
+        ese <- getExperiment()
+
+        if (getSampleSelect() == "all") {
+          return(colnames(ese))
+        } else {
+          validate(need(!is.null(input$samples), "Waiting for form to provide samples"))
+
+          if (length(eselist@group_vars) > 0) {
+            validate(need(!is.null(input$sampleGroupVal), FALSE))
+          }
+
+          if (getSampleSelect() == "name") {
+            return(input$samples)
+          } else {
+            # Any NA in the colData will become string '' via the inputs, so make sure we consider that when matching
+
+            samplegroups <- as.character(ese[[isolate(input$sampleGroupVar)]])
+            samplegroups[is.na(samplegroups)] <- ""
+
+            return(colnames(ese)[samplegroups %in% input$sampleGroupVal])
+          }
+        }
+      })
+    })
+
+    reactives <- list(selectSamples = selectSamples, getSampleGroupVar = getSampleGroupVar, getSampleSelect = getSampleSelect)
+
+    if (allow_summarise) {
+      reactives[["getSummaryType"]] <- getSummaryType
+    }
+
+    reactives
   })
-
-  reactives <- list(selectSamples = selectSamples, getSampleGroupVar = getSampleGroupVar, getSampleSelect = getSampleSelect)
-
-  if (allow_summarise){
-    reactives[['getSummaryType']] <- getSummaryType
-  }
-
-  reactives
 }

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -55,9 +55,7 @@ scatterplotOutput <- function(id) {
 #' server function. This setup allows the same set of controls to power
 #' multiple scatter plots.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param getDatamatrix Reactive supplying a matrix. If using external controls
 #' this should match the one supplied to \code{scatterplotcontrols}
 #' @param getThreedee A reactive defining whether to plot in 3D. If set to NULL
@@ -106,114 +104,115 @@ scatterplotOutput <- function(id) {
 #' Three columns required: name, x and y, with two rows for every value of
 #' name. These two rows represent the start and end of a line.
 
-scatterplot <- function(input, output, session, getDatamatrix, getThreedee = NULL, getXAxis = NULL, getYAxis = NULL, getZAxis = NULL, getShowLabels = NULL,
-                        getPointSize = NULL, getPalette = NULL, colorBy = NULL, getTitle = reactive({
+scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, getYAxis = NULL, getZAxis = NULL, getShowLabels = NULL, getPointSize = NULL, getPalette = NULL, colorBy = NULL, getTitle = reactive({
                           ""
                         }), getLabels = reactive({
                           rownames(getDatamatrix())
                         }), allow_3d = TRUE, x = NA, y = NA, z = NA, getLines = reactive({
                           NULL
                         })) {
-  # If inputs are not provided, render controls to provide them
+  moduleServer(id, function(input, output, session) {
+    # If inputs are not provided, render controls to provide them
 
-  ns <- session$ns
+    ns <- session$ns
 
-  # If no colors are provided, make our own if necessary. This will cause the 'getPalette' reactive to be passed back from scatterplotcontrols.
+    # If no colors are provided, make our own if necessary. This will cause the 'getPalette' reactive to be passed back from scatterplotcontrols.
 
-  getNumberColors <- reactive({
-    make_colors <- is.null(getPalette) && !is.null(colorBy)
-    if (make_colors) {
-      cb <- colorBy()
-      nlevels(cb)
-    } else {
-      NULL
-    }
-  })
-
-  # getThreedee used to determine whether the controls were provided.
-
-  if (is.null(getThreedee)) {
-    output$controls <- renderUI({
-      make_colors <- !is.null(getNumberColors())
-      controls <- list(scatterplotcontrolsInput(ns("scatter"), allow_3d = allow_3d, make_colors = make_colors))
-    })
-    unpack.list(callModule(scatterplotcontrols, "scatter", getDatamatrix, x = x, y = y, z = z, makeColors = getNumberColors))
-  }
-
-  # Axis data accessors
-
-  xdata <- reactive({
-    getDatamatrix()[, getXAxis()]
-  })
-
-  ydata <- reactive({
-    getDatamatrix()[, getYAxis()]
-  })
-
-  zdata <- reactive({
-    if (is.null(getZAxis())) {
-      NULL
-    } else {
-      getDatamatrix()[, getZAxis()]
-    }
-  })
-
-  # Slight offset for labels on the y axis
-
-  yLabData <- reactive({
-    if (!getThreedee()) {
-      label_offset_y <- (max(getDatamatrix()[[getYAxis()]]) - min(getDatamatrix()[[getYAxis()]])) / 40
-      ydata() + label_offset_y
-    } else {
-      ydata()
-    }
-  })
-
-  # Choose the right plot type
-
-  plotType <- reactive({
-    if (getThreedee()) {
-      "scatter3d"
-    } else {
-      "scatter"
-    }
-  })
-
-  # Only show a legend if we're coloring points
-
-  showLegend <- reactive({
-    if (is.null(colorBy)) {
-      FALSE
-    } else {
-      TRUE
-    }
-  })
-
-  # Chain the various steps together.
-
-  output$scatter <- renderPlotly({
-    withProgress(message = "Drawing scatter plot", value = 0, {
-      if (!is.null(colorBy)) {
-        cb = colorBy()
-          
-        # If a palette was supplied, or if we made our own...
-
-        if (is.null(getPalette)) {
-          palette <- getScatterPalette()
-        } else {
-          palette <- getPalette()
-        }
-      }else{
-        cb = NULL
+    getNumberColors <- reactive({
+      make_colors <- is.null(getPalette) && !is.null(colorBy)
+      if (make_colors) {
+        cb <- colorBy()
+        nlevels(cb)
+      } else {
+        NULL
       }
+    })
 
-      plotly_scatterplot(
-        x = xdata(), y = ydata(), z = zdata(), colorby = cb, plot_type = plotType(), title = getTitle(),
-        xlab = colnames(getDatamatrix())[getXAxis()], ylab = colnames(getDatamatrix())[getYAxis()],
-        zlab = colnames(getDatamatrix())[geZXAxis()], palette = palette, labels = getLabels(),
-        show_labels = getShowLabels(), lines = getLines(), showlegend =showLegend(), 
-        point_size = getPointSize()
-      )
+    # getThreedee used to determine whether the controls were provided.
+
+    if (is.null(getThreedee)) {
+      output$controls <- renderUI({
+        make_colors <- !is.null(getNumberColors())
+        controls <- list(scatterplotcontrolsInput(ns("scatter"), allow_3d = allow_3d, make_colors = make_colors))
+      })
+      unpack.list(scatterplotcontrols("scatter", getDatamatrix, x = x, y = y, z = z, makeColors = getNumberColors))
+    }
+
+    # Axis data accessors
+
+    xdata <- reactive({
+      getDatamatrix()[, getXAxis()]
+    })
+
+    ydata <- reactive({
+      getDatamatrix()[, getYAxis()]
+    })
+
+    zdata <- reactive({
+      if (is.null(getZAxis())) {
+        NULL
+      } else {
+        getDatamatrix()[, getZAxis()]
+      }
+    })
+
+    # Slight offset for labels on the y axis
+
+    yLabData <- reactive({
+      if (!getThreedee()) {
+        label_offset_y <- (max(getDatamatrix()[[getYAxis()]]) - min(getDatamatrix()[[getYAxis()]])) / 40
+        ydata() + label_offset_y
+      } else {
+        ydata()
+      }
+    })
+
+    # Choose the right plot type
+
+    plotType <- reactive({
+      if (getThreedee()) {
+        "scatter3d"
+      } else {
+        "scatter"
+      }
+    })
+
+    # Only show a legend if we're coloring points
+
+    showLegend <- reactive({
+      if (is.null(colorBy)) {
+        FALSE
+      } else {
+        TRUE
+      }
+    })
+
+    # Chain the various steps together.
+
+    output$scatter <- renderPlotly({
+      withProgress(message = "Drawing scatter plot", value = 0, {
+        if (!is.null(colorBy)) {
+          cb <- colorBy()
+
+          # If a palette was supplied, or if we made our own...
+
+          if (is.null(getPalette)) {
+            palette <- getScatterPalette()
+          } else {
+            palette <- getPalette()
+          }
+        } else {
+          cb <- NULL
+        }
+
+        plotly_scatterplot(
+          x = xdata(), y = ydata(), z = zdata(), colorby = cb, plot_type = plotType(), title = getTitle(),
+          xlab = colnames(getDatamatrix())[getXAxis()], ylab = colnames(getDatamatrix())[getYAxis()],
+          zlab = colnames(getDatamatrix())[geZXAxis()], palette = palette, labels = getLabels(),
+          show_labels = getShowLabels(), lines = getLines(), showlegend = showLegend(),
+          point_size = getPointSize()
+        )
+      })
     })
   })
 }
@@ -394,8 +393,8 @@ adjustLayout <- function(p, title = "", legend_title = "", xlab = "x", ylab = "y
 
 plotly_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scatter", title = "", legend_title = "",
                                xlab = "x", ylab = "y", zlab = "z", palette = NULL, point_size = 5, labels = NULL,
-                               show_labels = FALSE, lines = NULL, hline_thresholds = NULL, vline_thresholds = NULL, 
-                               showlegend = TRUE, palette_name = 'Set1') {
+                               show_labels = FALSE, lines = NULL, hline_thresholds = NULL, vline_thresholds = NULL,
+                               showlegend = TRUE, palette_name = "Set1") {
   # We'll only label and color points with non-NA labels
 
   if (is.null(labels)) {
@@ -408,10 +407,10 @@ plotly_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scat
     colorby <- factor(colorby)
   }
 
-  if (is.null(palette)){
+  if (is.null(palette)) {
     if (any(labelled) && !is.null(colorby)) {
       palette <- makeColorScale(length(unique(colorby[labelled])), palette = palette_name)
-    }else{
+    } else {
       palette <- makeColorScale(1)
     }
   }
@@ -507,21 +506,21 @@ plotly_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scat
 static_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scatter", title = "", legend_title = NULL,
                                xlab = "x", ylab = "y", zlab = "z", palette = NULL, point_size = 1, labels = colorby,
                                show_labels = FALSE, hline_thresholds = NULL, vline_thresholds = NULL, showlegend = TRUE,
-                               palette_name = 'Set1') {
+                               palette_name = "Set1") {
   labelled <- !is.na(labels)
 
   if ((!is.null(colorby)) && !is.factor(colorby)) {
     colorby <- factor(colorby)
   }
-  
-  if (is.null(palette)){
+
+  if (is.null(palette)) {
     if (any(labelled) && !is.null(colorby)) {
       palette <- makeColorScale(length(unique(colorby[labelled])), palette = palette_name)
-    }else{
+    } else {
       palette <- makeColorScale(1)
     }
   }
-  
+
   if (plot_type == "scatter") {
     plotdata <- data.frame(
       x = x,

--- a/R/scatterplotcontrols.R
+++ b/R/scatterplotcontrols.R
@@ -37,9 +37,7 @@ scatterplotcontrolsInput <- function(id, allow_3d = TRUE, make_colors = FALSE) {
 #' This module provides controls (2D/3D, axes etc) for scatter plots, which
 #' may then be used by one or more instances of the scatterplot module.
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param getDatamatrix Reactive expression that returns a matrix from which
 #' coulumn headers will be used to create axis select drop-downs. The same
 #' reactive should be supplied to the scatterplot module
@@ -57,80 +55,82 @@ scatterplotcontrolsInput <- function(id, allow_3d = TRUE, make_colors = FALSE) {
 #' @return output A list of reactives for accessing input values
 #'
 #' @examples
-#' unpack.list(callModule(scatterplotcontrols, "pca", pcaMatrix, x = 1, y = 2)) # To have fixed axes rather than user-selected
+#' unpack.list(scatterplotcontrols("pca", pcaMatrix, x = 1, y = 2)) # To have fixed axes rather than user-selected
 #'
-scatterplotcontrols <- function(input, output, session, getDatamatrix, x = NA, y = NA, z = NA, makeColors = NULL) {
-  output$plotColumns <- renderUI({
-    withProgress(message = "Making scatter plot controls", value = 0, {
-      ns <- session$ns
-      datamatrix <- getDatamatrix()
-      vars <- structure(1:ncol(datamatrix), names = colnames(datamatrix))
+scatterplotcontrols <- function(id, getDatamatrix, x = NA, y = NA, z = NA, makeColors = NULL) {
+  moduleServer(id, function(input, output, session) {
+    output$plotColumns <- renderUI({
+      withProgress(message = "Making scatter plot controls", value = 0, {
+        ns <- session$ns
+        datamatrix <- getDatamatrix()
+        vars <- structure(1:ncol(datamatrix), names = colnames(datamatrix))
 
-      # Work out how many axes we need
+        # Work out how many axes we need
 
-      axes <- list(x = x, y = y)
-      if (getThreedee()) {
-        axes$z <- z
-      }
-
-      # Make a select for each axis
-
-      axis_filters <- lapply(1:length(axes), function(n) {
-        ax <- names(axes)[n]
-
-        if (is.na(axes[n])) {
-          selectInput(ns(paste0(ax, "Axis")), paste(ax, "axis"), vars, selected = n)
-        } else {
-          hiddenInput(ns(paste0(ax, "Axis")), axes[n])
+        axes <- list(x = x, y = y)
+        if (getThreedee()) {
+          axes$z <- z
         }
+
+        # Make a select for each axis
+
+        axis_filters <- lapply(1:length(axes), function(n) {
+          ax <- names(axes)[n]
+
+          if (is.na(axes[n])) {
+            selectInput(ns(paste0(ax, "Axis")), paste(ax, "axis"), vars, selected = n)
+          } else {
+            hiddenInput(ns(paste0(ax, "Axis")), axes[n])
+          }
+        })
       })
+      axis_filters
     })
-    axis_filters
-  })
 
-  # Provide accessor methods for inputs
+    # Provide accessor methods for inputs
 
-  getXAxis <- reactive({
-    validate(need(input$xAxis, FALSE))
-    as.numeric(input$xAxis)
-  })
+    getXAxis <- reactive({
+      validate(need(input$xAxis, FALSE))
+      as.numeric(input$xAxis)
+    })
 
-  getYAxis <- reactive({
-    validate(need(input$yAxis, FALSE))
-    as.numeric(input$yAxis)
-  })
+    getYAxis <- reactive({
+      validate(need(input$yAxis, FALSE))
+      as.numeric(input$yAxis)
+    })
 
-  getZAxis <- reactive({
-    if (getThreedee()) {
-      validate(need(input$zAxis, FALSE))
-      as.numeric(input$zAxis)
-    } else {
-      NULL
+    getZAxis <- reactive({
+      if (getThreedee()) {
+        validate(need(input$zAxis, FALSE))
+        as.numeric(input$zAxis)
+      } else {
+        NULL
+      }
+    })
+
+    getThreedee <- reactive({
+      validate(need(input$threedee, FALSE))
+      as.logical(input$threedee)
+    })
+
+    getShowLabels <- reactive({
+      validate(need(input$threedee, "Waiting for showLabels"))
+      as.logical(input$showLabels)
+    })
+
+    getPointSize <- reactive({
+      validate(need(input$threedee, "Waiting for pointsize"))
+      input$pointSize
+    })
+
+    reactives <- list(getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis, getThreedee = getThreedee, getShowLabels = getShowLabels, getPointSize = getPointSize)
+
+    # If specified, make a palette for the specified number of colors
+
+    if (!is.null(makeColors)) {
+      reactives$getScatterPalette <- colormaker("scatterplot", getNumberCategories = makeColors)
     }
+
+    reactives
   })
-
-  getThreedee <- reactive({
-    validate(need(input$threedee, FALSE))
-    as.logical(input$threedee)
-  })
-
-  getShowLabels <- reactive({
-    validate(need(input$threedee, "Waiting for showLabels"))
-    as.logical(input$showLabels)
-  })
-
-  getPointSize <- reactive({
-    validate(need(input$threedee, "Waiting for pointsize"))
-    input$pointSize
-  })
-
-  reactives <- list(getXAxis = getXAxis, getYAxis = getYAxis, getZAxis = getZAxis, getThreedee = getThreedee, getShowLabels = getShowLabels, getPointSize = getPointSize)
-
-  # If specified, make a palette for the specified number of colors
-
-  if (!is.null(makeColors)) {
-    reactives$getScatterPalette <- callModule(colormaker, "scatterplot", getNumberCategories = makeColors)
-  }
-
-  reactives
 }

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -66,12 +66,10 @@ selectmatrixInput <- function(id, eselist, require_contrast_stats = FALSE) {
 #' This will generally not be called directly, but by other modules such as the
 #' heatmap module.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param var_n The number of rows to select when doing so by variance. Default
@@ -100,251 +98,249 @@ selectmatrixInput <- function(id, eselist, require_contrast_stats = FALSE) {
 #' @keywords shiny
 #'
 #' @examples
-#' selectSamples <- callModule(sampleselect, "selectmatrix", eselist)
+#' selectSamples <- sampleselect("selectmatrix", eselist)
 #'
-selectmatrix <- function(input, output, session, eselist, var_n = 50, var_max = NULL, select_assays = TRUE, select_samples = TRUE, select_genes = TRUE, provide_all_genes = FALSE,
-                         default_gene_select = NULL, require_contrast_stats = FALSE, rounding = 2, select_meta = TRUE, allow_summarise = TRUE) {
-  # Use the sampleselect and geneselect modules to generate reactive expressions that can be used to derive an expression matrix
+selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays = TRUE, select_samples = TRUE, select_genes = TRUE, provide_all_genes = FALSE, default_gene_select = NULL, require_contrast_stats = FALSE, rounding = 2, select_meta = TRUE, allow_summarise = TRUE) {
+  moduleServer(id, function(input, output, session) {
+    # Use the sampleselect and geneselect modules to generate reactive expressions that can be used to derive an expression matrix
 
-  unpack.list(callModule(sampleselect, "selectmatrix", eselist = eselist, getExperiment, allow_summarise = allow_summarise))
-  unpack.list(callModule(geneselect, "selectmatrix",
-    eselist = eselist, getExperiment, var_n = var_n, var_max = varMax(), selectSamples = selectSamples,
-    getAssay = getAssay, provide_all = provide_all_genes, default = default_gene_select
-  ))
+    unpack.list(sampleselect("selectmatrix", eselist = eselist, getExperiment, allow_summarise = allow_summarise))
+    unpack.list(geneselect("selectmatrix", eselist = eselist, getExperiment, var_n = var_n, var_max = varMax(), selectSamples = selectSamples, getAssay = getAssay, provide_all = provide_all_genes, default = default_gene_select))
 
-  # Render controls for selecting the experiment (where a user has supplied multiple SummarizedExpression objects in a list) and assay within each
+    # Render controls for selecting the experiment (where a user has supplied multiple SummarizedExpression objects in a list) and assay within each
 
-  ns <- session$ns
+    ns <- session$ns
 
-  output$assay <- renderUI({
-    withProgress(message = "Rendering assay drop-down", value = 0, {
-      ns <- session$ns
+    output$assay <- renderUI({
+      withProgress(message = "Rendering assay drop-down", value = 0, {
+        ns <- session$ns
 
-      if (length(validAssays()) > 1 && select_assays) {
-        assayselect <- selectInput(ns("assay"), "Matrix", validAssays())
-      } else {
-        assayselect <- hiddenInput(ns("assay"), validAssays()[1])
-      }
+        if (length(validAssays()) > 1 && select_assays) {
+          assayselect <- selectInput(ns("assay"), "Matrix", validAssays())
+        } else {
+          assayselect <- hiddenInput(ns("assay"), validAssays()[1])
+        }
 
-      assayselect
+        assayselect
+      })
     })
-  })
 
-  # Alow users to add extra metadata columns to the display
+    # Alow users to add extra metadata columns to the display
 
-  output$meta <- renderUI({
-    ese <- getExperiment()
-    if (select_meta) {
-      metafields <- colnames(mcols(ese))
-      if (length(ese@idfield) > 0) {
-        metafields <- setdiff(metafields, ese@idfield)
-      }
-
-      checkboxGroupInput(ns("metafields"), "Add meta fields", structure(metafields, names = prettifyVariablename(metafields)),
-        selected = ese@labelfield,
-        inline = TRUE
-      )
-    } else if (length(ese@labelfield) > 0) {
-      hiddenInput(id = ns("metafields"), values = ese@labelfield)
-    }
-  })
-
-  getMetafields <- reactive({
-    input$metafields
-  })
-
-  # Render sample selection controls
-
-  output$samples <- renderUI({
-    sampleselectInput(ns("selectmatrix"), eselist = eselist, getExperiment = getExperiment, select_samples = select_samples)
-  })
-
-  # Render row selection controls
-
-  output$rows <- renderUI({
-    geneselectInput(ns("selectmatrix"), select_genes = select_genes)
-  })
-
-  # Get list of assays
-
-  validAssays <- reactive({
-    ese <- getExperiment()
-
-    if (require_contrast_stats) {
-      valid_assays <- names(ese@contrast_stats)
-    } else {
-      names(SummarizedExperiment::assays(ese))
-    }
-  })
-
-  # Reactive for getting the right ExploratorySummarizedExperiment and passing it on to sample and gene selection
-
-  getExperiment <- reactive({
-    eid <- getExperimentId()
-    eselist[[eid]]
-  })
-
-  # Name of the experment is useful sometimes
-
-  getExperimentId <- reactive({
-    validate(need(input$experiment, "Waiting for experiment selection"))
-    input$experiment
-  })
-
-  getExperimentName <- reactive({
-    eid <- getExperimentId()
-    prettifyVariablename(eid)
-  })
-
-  # Get the row labels where available
-
-  getRowLabels <- reactive({
-    withProgress(message = "Deriving row labels", value = 0, {
+    output$meta <- renderUI({
       ese <- getExperiment()
-      # if (!is.null(ese@idfield)) {
-      idToLabel(rownames(ese), ese)
-      # } else { rownames(ese) }
-    })
-  })
+      if (select_meta) {
+        metafields <- colnames(mcols(ese))
+        if (length(ese@idfield) > 0) {
+          metafields <- setdiff(metafields, ese@idfield)
+        }
 
-  # Allow calling modules to retrieve the current assay
-
-  getAssay <- reactive({
-    validate(need(!is.null(input$assay), "Waiting for form to provide assay"))
-    input$assay
-  })
-
-  # Retrieve the assay measure to display with plots etc (where defined by the user)
-
-  getAssayMeasure <- reactive({
-    ese <- getExperiment()
-    if (length(ese@assay_measures) > 0 && getAssay() %in% names(ese@assay_measures)) {
-      ese@assay_measures[[getAssay()]]
-    } else {
-      "expression"
-    }
-  })
-
-  varMax <- reactive({
-    if (is.null(var_max)) {
-      nrow(getExperiment())
-    } else {
-      var_max
-    }
-  })
-
-  getAssayMatrix <- reactive({
-    ese <- getExperiment()
-    assay <- getAssay()
-
-    SummarizedExperiment::assays(ese)[[assay]]
-  })
-
-  # Generate an expression matrix given the selected experiment, assay, rows and columns
-
-  selectMatrix <- reactive({
-    withProgress(message = "Getting expression data subset", value = 0, {
-      rows <- selectRows()
-      validate(need(length(rows) > 0, "No matching rows in selected matrix"))
-      assay_matrix <- getAssayMatrix()
-      samples <- selectSamples()
-      rows <- selectRows()
-
-      selected_matrix <- assay_matrix[rows, samples, drop = FALSE]
-      if (allow_summarise && getSampleSelect() == "group" && getSummaryType() != "none") {
-        selected_matrix <- summarizeMatrix(selected_matrix, selectColData()[[getSampleGroupVar()]], getSummaryType())
+        checkboxGroupInput(ns("metafields"), "Add meta fields", structure(metafields, names = prettifyVariablename(metafields)),
+          selected = ese@labelfield,
+          inline = TRUE
+        )
+      } else if (length(ese@labelfield) > 0) {
+        hiddenInput(id = ns("metafields"), values = ese@labelfield)
       }
+    })
 
-      # This just to deal with annoying dimension-dropping beviour of apply() on a single-row matrix
+    getMetafields <- reactive({
+      input$metafields
+    })
 
-      if (nrow(selected_matrix) == 1) {
-        selected_matrix[1, ] <- apply(selected_matrix, 2, round, rounding)
-        selected_matrix
+    # Render sample selection controls
+
+    output$samples <- renderUI({
+      sampleselectInput(ns("selectmatrix"), eselist = eselist, getExperiment = getExperiment, select_samples = select_samples)
+    })
+
+    # Render row selection controls
+
+    output$rows <- renderUI({
+      geneselectInput(ns("selectmatrix"), select_genes = select_genes)
+    })
+
+    # Get list of assays
+
+    validAssays <- reactive({
+      ese <- getExperiment()
+
+      if (require_contrast_stats) {
+        valid_assays <- names(ese@contrast_stats)
       } else {
-        apply(selected_matrix, 2, round, rounding)
+        names(SummarizedExperiment::assays(ese))
       }
     })
-  })
 
-  # Extract experimental variables given selection parameters
+    # Reactive for getting the right ExploratorySummarizedExperiment and passing it on to sample and gene selection
 
-  selectColData <- reactive({
-    validate(need(length(selectSamples()) > 0, "Waiting for sample selection"))
-    withProgress(message = "Extracting experiment metadata", value = 0, {
-      droplevels(data.frame(colData(getExperiment())[selectSamples(), , drop = FALSE], check.names = FALSE))
+    getExperiment <- reactive({
+      eid <- getExperimentId()
+      eselist[[eid]]
     })
-  })
 
-  # Calling modules may need to know if the data are sumamrised. E.g. heatmaps only need to display sample metadata for unsummarised matrices Will only be
-  # summarised if grouping variables were supplied!
+    # Name of the experment is useful sometimes
 
-  isSummarised <- reactive({
-    allow_summarise && length(eselist@group_vars) > 0 && getSummaryType() != "none"
-  })
-
-  # Extract the annotation from the SummarizedExperiment
-
-  getAnnotation <- reactive({
-    ese <- getExperiment()
-    validate(need(ncol(mcols(ese)) > 0, "Selected experiment contains no row metadata"))
-    withProgress(message = "Deriving annotation", value = 0, {
-      data.frame(mcols(ese))
+    getExperimentId <- reactive({
+      validate(need(input$experiment, "Waiting for experiment selection"))
+      input$experiment
     })
+
+    getExperimentName <- reactive({
+      eid <- getExperimentId()
+      prettifyVariablename(eid)
+    })
+
+    # Get the row labels where available
+
+    getRowLabels <- reactive({
+      withProgress(message = "Deriving row labels", value = 0, {
+        ese <- getExperiment()
+        # if (!is.null(ese@idfield)) {
+        idToLabel(rownames(ese), ese)
+        # } else { rownames(ese) }
+      })
+    })
+
+    # Allow calling modules to retrieve the current assay
+
+    getAssay <- reactive({
+      validate(need(!is.null(input$assay), "Waiting for form to provide assay"))
+      input$assay
+    })
+
+    # Retrieve the assay measure to display with plots etc (where defined by the user)
+
+    getAssayMeasure <- reactive({
+      ese <- getExperiment()
+      if (length(ese@assay_measures) > 0 && getAssay() %in% names(ese@assay_measures)) {
+        ese@assay_measures[[getAssay()]]
+      } else {
+        "expression"
+      }
+    })
+
+    varMax <- reactive({
+      if (is.null(var_max)) {
+        nrow(getExperiment())
+      } else {
+        var_max
+      }
+    })
+
+    getAssayMatrix <- reactive({
+      ese <- getExperiment()
+      assay <- getAssay()
+
+      SummarizedExperiment::assays(ese)[[assay]]
+    })
+
+    # Generate an expression matrix given the selected experiment, assay, rows and columns
+
+    selectMatrix <- reactive({
+      withProgress(message = "Getting expression data subset", value = 0, {
+        rows <- selectRows()
+        validate(need(length(rows) > 0, "No matching rows in selected matrix"))
+        assay_matrix <- getAssayMatrix()
+        samples <- selectSamples()
+        rows <- selectRows()
+
+        selected_matrix <- assay_matrix[rows, samples, drop = FALSE]
+        if (allow_summarise && getSampleSelect() == "group" && getSummaryType() != "none") {
+          selected_matrix <- summarizeMatrix(selected_matrix, selectColData()[[getSampleGroupVar()]], getSummaryType())
+        }
+
+        # This just to deal with annoying dimension-dropping beviour of apply() on a single-row matrix
+
+        if (nrow(selected_matrix) == 1) {
+          selected_matrix[1, ] <- apply(selected_matrix, 2, round, rounding)
+          selected_matrix
+        } else {
+          apply(selected_matrix, 2, round, rounding)
+        }
+      })
+    })
+
+    # Extract experimental variables given selection parameters
+
+    selectColData <- reactive({
+      validate(need(length(selectSamples()) > 0, "Waiting for sample selection"))
+      withProgress(message = "Extracting experiment metadata", value = 0, {
+        droplevels(data.frame(colData(getExperiment())[selectSamples(), , drop = FALSE], check.names = FALSE))
+      })
+    })
+
+    # Calling modules may need to know if the data are sumamrised. E.g. heatmaps only need to display sample metadata for unsummarised matrices Will only be
+    # summarised if grouping variables were supplied!
+
+    isSummarised <- reactive({
+      allow_summarise && length(eselist@group_vars) > 0 && getSummaryType() != "none"
+    })
+
+    # Extract the annotation from the SummarizedExperiment
+
+    getAnnotation <- reactive({
+      ese <- getExperiment()
+      validate(need(ncol(mcols(ese)) > 0, "Selected experiment contains no row metadata"))
+      withProgress(message = "Deriving annotation", value = 0, {
+        data.frame(mcols(ese))
+      })
+    })
+
+    # Use selectMatrix() to get the data matrix, then apply the appropriate labels. Useful in cases where the matrix is destined for display
+
+    selectLabelledMatrix <- reactive({
+      selected_matrix <- data.frame(selectMatrix(), check.names = FALSE)
+      se <- getExperiment()
+
+      labelMatrix(selected_matrix, se, metafields = getMetafields())
+    })
+
+    # Use selectLabelledMatrix to get the labelled matrix and add some links.
+
+    selectLabelledLinkedMatrix <- reactive({
+      selected_matrix <- selectLabelledMatrix()
+      se <- getExperiment()
+
+      if (length(eselist@url_roots) > 0) {
+        linkMatrix(selected_matrix, eselist@url_roots)
+      } else {
+        selected_matrix
+      }
+    })
+
+    # Accessors for the id and label fields of the current experiment
+
+    getIdField <- reactive({
+      ese <- getExperiment()
+      if (length(ese@idfield) > 0) {
+        ese@idfield
+      } else {
+        "id"
+      }
+    })
+
+    getLabelField <- reactive({
+      ese <- getExperiment()
+      if (length(ese@labelfield) > 0) {
+        ese@labelfield
+      } else {
+        # ese@idfield
+        NULL
+      }
+    })
+
+    # getAssayIds <- reactive({ assay_matrix <- getAssayMatrix() rownames(assay_matrix[complete.cases(assay_matrix),,drop=F]) })
+
+    # Return the list of reactive expressions we'll need to access the data
+
+    list(
+      getExperimentId = getExperimentId, getExperiment = getExperiment, getAssayMeasure = getAssayMeasure, selectMatrix = selectMatrix, selectLabelledMatrix = selectLabelledMatrix,
+      matrixTitle = title, selectColData = selectColData, isSummarised = isSummarised, getAssay = getAssay, getAssayMatrix = getAssayMatrix, selectLabelledLinkedMatrix = selectLabelledLinkedMatrix,
+      getRowLabels = getRowLabels, getAnnotation = getAnnotation, getIdField = getIdField, getLabelField = getLabelField, getExperimentId = getExperimentId,
+      getExperimentName = getExperimentName, getNonEmptyRows = getNonEmptyRows, getMetafields = getMetafields
+    )
   })
-
-  # Use selectMatrix() to get the data matrix, then apply the appropriate labels. Useful in cases where the matrix is destined for display
-
-  selectLabelledMatrix <- reactive({
-    selected_matrix <- data.frame(selectMatrix(), check.names = FALSE)
-    se <- getExperiment()
-
-    labelMatrix(selected_matrix, se, metafields = getMetafields())
-  })
-
-  # Use selectLabelledMatrix to get the labelled matrix and add some links.
-
-  selectLabelledLinkedMatrix <- reactive({
-    selected_matrix <- selectLabelledMatrix()
-    se <- getExperiment()
-
-    if (length(eselist@url_roots) > 0) {
-      linkMatrix(selected_matrix, eselist@url_roots)
-    } else {
-      selected_matrix
-    }
-  })
-
-  # Accessors for the id and label fields of the current experiment
-
-  getIdField <- reactive({
-    ese <- getExperiment()
-    if (length(ese@idfield) > 0) {
-      ese@idfield
-    } else {
-      "id"
-    }
-  })
-
-  getLabelField <- reactive({
-    ese <- getExperiment()
-    if (length(ese@labelfield) > 0) {
-      ese@labelfield
-    } else {
-      # ese@idfield
-      NULL
-    }
-  })
-
-  # getAssayIds <- reactive({ assay_matrix <- getAssayMatrix() rownames(assay_matrix[complete.cases(assay_matrix),,drop=F]) })
-
-  # Return the list of reactive expressions we'll need to access the data
-
-  list(
-    getExperimentId = getExperimentId, getExperiment = getExperiment, getAssayMeasure = getAssayMeasure, selectMatrix = selectMatrix, selectLabelledMatrix = selectLabelledMatrix,
-    matrixTitle = title, selectColData = selectColData, isSummarised = isSummarised, getAssay = getAssay, getAssayMatrix = getAssayMatrix, selectLabelledLinkedMatrix = selectLabelledLinkedMatrix,
-    getRowLabels = getRowLabels, getAnnotation = getAnnotation, getIdField = getIdField, getLabelField = getLabelField, getExperimentId = getExperimentId,
-    getExperimentName = getExperimentName, getNonEmptyRows = getNonEmptyRows, getMetafields = getMetafields
-  )
 }
 
 #' Add columns to display ID and label in a table

--- a/R/shinyngs.R
+++ b/R/shinyngs.R
@@ -68,13 +68,14 @@
 #'
 #'   \subsection{Usage}{Any application seeking to create dendrograms need only
 #'   call \code{\link{dendroInput}} \code{\link{dendroOutput}} in the parts of
-#'   their application where inputs and outputs should appear, and then use
-#'   \code{\link[shiny]{callModule}} (again using the same ID) to activate them.
+#'   their application where inputs and outputs should appear, and then call
+#'   \code{\link{dendro}} directly (again using the same ID) to activate them,
+#'   via \code{\link[shiny]{moduleServer}}.
 #'
 #'   \preformatted{
 #'   dendroInput(ns('dendro'), eselist)
 #'   dendroOutput(ns('dendro'))
-#'   callModule(dendro, 'dendro', eselist) }}
+#'   dendro('dendro', eselist) }}
 #'
 #'   These module functions are not currently exported, not currenlty being
 #'   intended for use outside \code{shinyngs}. This may change.

--- a/R/simpletable.R
+++ b/R/simpletable.R
@@ -57,12 +57,10 @@ simpletableOutput <- function(id, tabletitle = NULL) {
 
 #' The server function of the simpletable module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param downloadMatrix Reactive expression for retrieving the plot to supply
 #' for download (default: NULL, in which case \code{displayMatrix()} will be
 #' used)
@@ -78,35 +76,37 @@ simpletableOutput <- function(id, tabletitle = NULL) {
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(simpletable, "simpletable", my_data_frame)
+#' simpletable("simpletable", my_data_frame)
 #'
-simpletable <- function(input, output, session, downloadMatrix = NULL, displayMatrix, pageLength = 15, filename, rownames = FALSE, show_controls = TRUE, filter = "none") {
-  if (is.null(downloadMatrix)) {
-    downloadMatrix <- displayMatrix
-  }
-
-  options <- list(pageLength = pageLength, lengthMenu = list(c(5, 10, 15, 25, 50, 100), c("5", "10", "15", "25", "50", "100")), dom = "ltip")
-
-  if (show_controls) {
-    options$dom <- paste0("f", options$dom)
-  }
-
-  output$datatable <- DT::renderDataTable(
-    {
-      displayMatrix()
-    },
-    options = options,
-    filter = filter,
-    rownames = rownames,
-    escape = FALSE
-  )
-
-  output$downloadTable <- downloadHandler(filename = function() {
-    if (is.reactive(filename)) {
-      filename <- filename()
+simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 15, filename, rownames = FALSE, show_controls = TRUE, filter = "none") {
+  moduleServer(id, function(input, output, session) {
+    if (is.null(downloadMatrix)) {
+      downloadMatrix <- displayMatrix
     }
-    paste0(filename, ".csv")
-  }, content = function(file) {
-    write.csv(downloadMatrix(), file = file, row.names = rownames)
+
+    options <- list(pageLength = pageLength, lengthMenu = list(c(5, 10, 15, 25, 50, 100), c("5", "10", "15", "25", "50", "100")), dom = "ltip")
+
+    if (show_controls) {
+      options$dom <- paste0("f", options$dom)
+    }
+
+    output$datatable <- DT::renderDataTable(
+      {
+        displayMatrix()
+      },
+      options = options,
+      filter = filter,
+      rownames = rownames,
+      escape = FALSE
+    )
+
+    output$downloadTable <- downloadHandler(filename = function() {
+      if (is.reactive(filename)) {
+        filename <- filename()
+      }
+      paste0(filename, ".csv")
+    }, content = function(file) {
+      write.csv(downloadMatrix(), file = file, row.names = rownames)
+    })
   })
 }

--- a/R/summarisematrix.R
+++ b/R/summarisematrix.R
@@ -39,18 +39,18 @@ summarisematrixInput <- function(id, allow_none = TRUE, select_summary_type = TR
 #' This module provides a form element and associated get function for defining
 #' how a summary statistic is calculated (probably by mean).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(summarisematrix)
+#' summarisematrix()
 #'
-summarisematrix <- function(input, output, session) {
-  getSummaryType <- reactive({
-    input$summaryType
+summarisematrix <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    getSummaryType <- reactive({
+      input$summaryType
+    })
   })
 }
 

--- a/R/upset.R
+++ b/R/upset.R
@@ -95,12 +95,10 @@ upsetOutput <- function(id, eselist) {
 #' (rather than assigning every item to its highest-order intersection). It
 #' also seems to have sped things up.
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example).
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example).
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #' @param setlimit Maximum number of sets
@@ -113,353 +111,349 @@ upsetOutput <- function(id, eselist) {
 #' Gehlenborg N (2016). <em>UpSetR: A More Scalable Alternative to Venn and Euler Diagrams for Visualizing Intersecting Sets</em>. R package version 1.3.0, \url{https://CRAN.R-project.org/package=UpSetR}
 #'
 #' @examples
-#' callModule(upstart, "myid", eselist)
+#' upstart("myid", eselist)
 #'
-upset <- function(input, output, session, eselist, setlimit = 16) {
-  ns <- session$ns
+upset <- function(id, eselist, setlimit = 16) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
-  # Call the selectmatrix module and unpack the reactives it sends back
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-  selectmatrix_reactives <- callModule(selectmatrix, "upset", eselist,
-    var_n = 1000, select_samples = FALSE, select_genes = TRUE, provide_all_genes = TRUE,
-    select_meta = FALSE
-  )
-  unpack.list(selectmatrix_reactives)
+    selectmatrix_reactives <- selectmatrix("upset", eselist, var_n = 1000, select_samples = FALSE, select_genes = TRUE, provide_all_genes = TRUE, select_meta = FALSE)
+    unpack.list(selectmatrix_reactives)
 
-  # Pass the matrix to the contrasts module for processing
+    # Pass the matrix to the contrasts module for processing
 
-  unpack.list(callModule(contrasts, "upset", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = TRUE, select_all_contrasts = TRUE))
+    unpack.list(contrasts("upset", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = TRUE, select_all_contrasts = TRUE))
 
-  ############################################################################# Render dynamic fields
+    ############################################################################# Render dynamic fields
 
-  output$nsets <- renderUI({
-    max_sets <- getMaxSets()
-    sliderInput(ns("nsets"), label = "Number of sets", min = 2, max = max_sets, step = 1, value = max_sets)
-  })
+    output$nsets <- renderUI({
+      max_sets <- getMaxSets()
+      sliderInput(ns("nsets"), label = "Number of sets", min = 2, max = max_sets, step = 1, value = max_sets)
+    })
 
-  output$minorder <- renderUI({
-    assignment_type <- getIntersectionAssignmentType()
-    max_order <- getMaxIntersectionOrder()
+    output$minorder <- renderUI({
+      assignment_type <- getIntersectionAssignmentType()
+      max_order <- getMaxIntersectionOrder()
 
-    # No point starting at size 1 in a non-upset plot, since the areas associated with each individual set will be the same size as the sets themselves
+      # No point starting at size 1 in a non-upset plot, since the areas associated with each individual set will be the same size as the sets themselves
 
-    if (assignment_type == "upset") {
-      startsize <- 1
-    } else {
-      startsize <- 2
-    }
-
-    sliderInput(ns("minorder"), label = "Minimum number of sets in an intersection", min = 1, max = max_order, step = 1, value = startsize)
-  })
-
-  output$differential_parameters <- renderUI({
-    query_strings <- getQueryStrings()
-    HTML(query_strings[1])
-  })
-
-  output$subset_notice <- renderUI({
-    valid_sets <- getValidSets()
-    max_sets <- ifelse(length(valid_sets) > setlimit, setlimit, length(valid_sets))
-
-    message <- paste(length(valid_sets), "valid differential sets found (count > 0)")
-    if (length(valid_sets) > setlimit) {
-      message <- paste(message, "<br />(Note: the set selection used to produce the below plot has been limited to", max_sets, "sets")
-      if (input$separate_by_direction) {
-        message <- paste(message, paste("(", floor((max_sets / 2)), " contrasts)"))
+      if (assignment_type == "upset") {
+        startsize <- 1
+      } else {
+        startsize <- 2
       }
-      message <- paste(message, "due to computational limitations. You may wish to refine your choice of contrasts)")
-    }
-    HTML(message)
-  })
 
-  ############################################################################# Form accessors
+      sliderInput(ns("minorder"), label = "Minimum number of sets in an intersection", min = 1, max = max_order, step = 1, value = startsize)
+    })
+
+    output$differential_parameters <- renderUI({
+      query_strings <- getQueryStrings()
+      HTML(query_strings[1])
+    })
+
+    output$subset_notice <- renderUI({
+      valid_sets <- getValidSets()
+      max_sets <- ifelse(length(valid_sets) > setlimit, setlimit, length(valid_sets))
+
+      message <- paste(length(valid_sets), "valid differential sets found (count > 0)")
+      if (length(valid_sets) > setlimit) {
+        message <- paste(message, "<br />(Note: the set selection used to produce the below plot has been limited to", max_sets, "sets")
+        if (input$separate_by_direction) {
+          message <- paste(message, paste("(", floor((max_sets / 2)), " contrasts)"))
+        }
+        message <- paste(message, "due to computational limitations. You may wish to refine your choice of contrasts)")
+      }
+      HTML(message)
+    })
+
+    ############################################################################# Form accessors
 
 
-  # Accessor for the nsets parameter
+    # Accessor for the nsets parameter
 
-  getNsets <- reactive({
-    validate(need(!is.null(input$nsets), "Waiting for nsets"))
-    input$nsets
-  })
+    getNsets <- reactive({
+      validate(need(!is.null(input$nsets), "Waiting for nsets"))
+      input$nsets
+    })
 
-  # Accessor for the minorder parameter
+    # Accessor for the minorder parameter
 
-  getMinOrder <- reactive({
-    validate(need(!is.null(input$minorder), "Waiting for minorder"))
-    input$minorder
-  })
+    getMinOrder <- reactive({
+      validate(need(!is.null(input$minorder), "Waiting for minorder"))
+      input$minorder
+    })
 
-  # Accessor for the nintersections parameter
+    # Accessor for the nintersections parameter
 
-  getNintersections <- reactive({
-    validate(need(!is.null(input$nintersects), "Waiting for nintersects"))
-    input$nintersects
-  })
+    getNintersections <- reactive({
+      validate(need(!is.null(input$nintersects), "Waiting for nintersects"))
+      input$nintersects
+    })
 
-  # Accessor for the groupby parameter
+    # Accessor for the groupby parameter
 
-  getGroupby <- reactive({
-    validate(need(!is.null(input$group_by), "Waiting for group_by"))
-    input$group_by
-  })
+    getGroupby <- reactive({
+      validate(need(!is.null(input$group_by), "Waiting for group_by"))
+      input$group_by
+    })
 
-  getShowEmptyIntersections <- reactive({
-    validate(need(!is.null(input$show_empty_intersections), "Waiting for empty intersections option"))
-    input$show_empty_intersections
-  })
+    getShowEmptyIntersections <- reactive({
+      validate(need(!is.null(input$show_empty_intersections), "Waiting for empty intersections option"))
+      input$show_empty_intersections
+    })
 
-  # Accessor for the intersection assignment type
+    # Accessor for the intersection assignment type
 
-  getIntersectionAssignmentType <- reactive({
-    validate(need(!is.null(input$intersection_assignment_type), "Waiting for group_by"))
-    input$intersection_assignment_type
-  })
+    getIntersectionAssignmentType <- reactive({
+      validate(need(!is.null(input$intersection_assignment_type), "Waiting for group_by"))
+      input$intersection_assignment_type
+    })
 
-  # Set sorting
+    # Set sorting
 
-  getSetSort <- reactive({
-    validate(need(!is.null(input$set_sort), "Waiting for set_sort"))
-    input$set_sort
-  })
+    getSetSort <- reactive({
+      validate(need(!is.null(input$set_sort), "Waiting for set_sort"))
+      input$set_sort
+    })
 
-  # Bar numbers
+    # Bar numbers
 
-  getBarNumbers <- reactive({
-    validate(need(!is.null(input$bar_numbers), "Waiting for bar numbers"))
-    input$bar_numbers
-  })
+    getBarNumbers <- reactive({
+      validate(need(!is.null(input$bar_numbers), "Waiting for bar numbers"))
+      input$bar_numbers
+    })
 
-  ############################################################################# The business end- derive sets and pass for intersection
+    ############################################################################# The business end- derive sets and pass for intersection
 
-  # Look at the contrasts and remove any contrast with no differential features
+    # Look at the contrasts and remove any contrast with no differential features
 
-  getValidSets <- reactive({
-    withProgress(message = "Deriving input sets", value = 0, {
-      fcts <- unlist(filteredContrastsTables(), recursive = FALSE)
-      names(fcts) <- unlist(getSafeSelectedContrastNames(), recursive = FALSE)
-
-      fcts <- fcts[unlist(lapply(fcts, function(x) nrow(x) > 0))]
-
-      # If specified by the user, separate gene sets into 'up' and 'down' for each contrast
-
-      if (input$separate_by_direction) {
-        fcts <- unlist(lapply(fcts, function(x) {
-          y <- split(x, x[["Fold change"]] > 0)
-          names(y)[names(y) == "TRUE"] <- "up"
-          names(y)[names(y) == "FALSE"] <- "down"
-          y
-        }), recursive = FALSE)
+    getValidSets <- reactive({
+      withProgress(message = "Deriving input sets", value = 0, {
+        fcts <- unlist(filteredContrastsTables(), recursive = FALSE)
+        names(fcts) <- unlist(getSafeSelectedContrastNames(), recursive = FALSE)
 
         fcts <- fcts[unlist(lapply(fcts, function(x) nrow(x) > 0))]
-      }
 
-      fcts <- fcts[unlist(lapply(fcts, function(x) nrow(x) > 0))]
-      fcts <- lapply(fcts, rownames)
+        # If specified by the user, separate gene sets into 'up' and 'down' for each contrast
 
-      setsort <- getSetSort()
-      if (setsort) {
-        fcts <- fcts[order(unlist(lapply(fcts, length)))]
-      }
+        if (input$separate_by_direction) {
+          fcts <- unlist(lapply(fcts, function(x) {
+            y <- split(x, x[["Fold change"]] > 0)
+            names(y)[names(y) == "TRUE"] <- "up"
+            names(y)[names(y) == "FALSE"] <- "down"
+            y
+          }), recursive = FALSE)
 
-      fcts
-    })
-  })
+          fcts <- fcts[unlist(lapply(fcts, function(x) nrow(x) > 0))]
+        }
 
-  # Get the maximum number of sets
+        fcts <- fcts[unlist(lapply(fcts, function(x) nrow(x) > 0))]
+        fcts <- lapply(fcts, rownames)
 
-  getMaxSets <- reactive({
-    valid_sets <- getValidSets()
-    ifelse(length(valid_sets) > setlimit, setlimit, length(valid_sets))
-  })
+        setsort <- getSetSort()
+        if (setsort) {
+          fcts <- fcts[order(unlist(lapply(fcts, length)))]
+        }
 
-  # Get the sets we're going to use based on nsets
-
-  getSets <- reactive({
-    valid_sets <- getValidSets()
-    nsets <- getNsets()
-    valid_sets[1:nsets]
-  })
-
-  # Calculate intersections between sets
-
-  calculateIntersections <- reactive({
-    selected_sets <- getSets()
-
-    withProgress(message = "Calculating set intersections", value = 0, {
-      nsets <- getNsets()
-
-      # Get all possible combinations of sets
-
-      combinations <- function(items, pick) {
-        x <- combn(items, pick)
-        lapply(seq_len(ncol(x)), function(i) x[, i])
-      }
-
-      combos <- lapply(1:nsets, function(x) {
-        combinations(1:length(selected_sets), x)
+        fcts
       })
+    })
 
-      # Calculate the intersections of all these combinations
+    # Get the maximum number of sets
 
-      withProgress(message = "Running intersect()", value = 0, {
-        intersects <- lapply(combos, function(combonos) {
-          lapply(combonos, function(combo) {
-            Reduce(intersect, selected_sets[combo])
+    getMaxSets <- reactive({
+      valid_sets <- getValidSets()
+      ifelse(length(valid_sets) > setlimit, setlimit, length(valid_sets))
+    })
+
+    # Get the sets we're going to use based on nsets
+
+    getSets <- reactive({
+      valid_sets <- getValidSets()
+      nsets <- getNsets()
+      valid_sets[1:nsets]
+    })
+
+    # Calculate intersections between sets
+
+    calculateIntersections <- reactive({
+      selected_sets <- getSets()
+
+      withProgress(message = "Calculating set intersections", value = 0, {
+        nsets <- getNsets()
+
+        # Get all possible combinations of sets
+
+        combinations <- function(items, pick) {
+          x <- combn(items, pick)
+          lapply(seq_len(ncol(x)), function(i) x[, i])
+        }
+
+        combos <- lapply(1:nsets, function(x) {
+          combinations(1:length(selected_sets), x)
+        })
+
+        # Calculate the intersections of all these combinations
+
+        withProgress(message = "Running intersect()", value = 0, {
+          intersects <- lapply(combos, function(combonos) {
+            lapply(combonos, function(combo) {
+              Reduce(intersect, selected_sets[combo])
+            })
           })
         })
-      })
 
-      # For UpSet-ness, membership of higher-order intersections takes priority. Otherwise just return the number of entries in each intersection
+        # For UpSet-ness, membership of higher-order intersections takes priority. Otherwise just return the number of entries in each intersection
 
-      assignment_type <- getIntersectionAssignmentType()
+        assignment_type <- getIntersectionAssignmentType()
 
-      intersects <- lapply(1:length(intersects), function(i) {
-        intersectno <- intersects[[i]]
-        members_in_higher_levels <- unlist(intersects[(i + 1):length(intersects)])
-        lapply(intersectno, function(intersect) {
-          if (assignment_type == "upset") {
-            length(setdiff(intersect, members_in_higher_levels))
-          } else {
-            length(intersect)
-          }
+        intersects <- lapply(1:length(intersects), function(i) {
+          intersectno <- intersects[[i]]
+          members_in_higher_levels <- unlist(intersects[(i + 1):length(intersects)])
+          lapply(intersectno, function(intersect) {
+            if (assignment_type == "upset") {
+              length(setdiff(intersect, members_in_higher_levels))
+            } else {
+              length(intersect)
+            }
+          })
         })
+
+        combos <- unlist(combos, recursive = FALSE)
+        intersects <- unlist(intersects)
+
+        if (!getShowEmptyIntersections()) {
+          combos <- combos[which(intersects > 0)]
+          intersects <- intersects[which(intersects > 0)]
+        }
+
+        # Sort by intersect size
+
+        combos <- combos[order(intersects, decreasing = TRUE)]
+        intersects <- intersects[order(intersects, decreasing = TRUE)]
+
+        list(combinations = combos, intersections = intersects)
       })
+    })
 
-      combos <- unlist(combos, recursive = FALSE)
-      intersects <- unlist(intersects)
+    # Post-process intersections to remove lower-order interactions from display if requested
 
-      if (!getShowEmptyIntersections()) {
-        combos <- combos[which(intersects > 0)]
-        intersects <- intersects[which(intersects > 0)]
+    getIntersections <- reactive({
+      minorder <- getMinOrder()
+      ints <- calculateIntersections()
+
+      selected <- unlist(lapply(ints$combinations, length)) >= minorder
+      lapply(ints, function(x) x[selected])
+    })
+
+    ########################################################################### Render the plot with it separate components
+
+    output$plotly_upset <- renderPlotly({
+      grid <- upsetGrid()
+      set_size_chart <- upsetSetSizeBarChart()
+      intersect_size_chart <- upsetIntersectSizeBarChart()
+
+      intersect_size_chart <- intersect_size_chart %>% layout(yaxis = list(title = "Intersections size"))
+
+      s1 <- subplot(plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"),
+        set_size_chart,
+        nrows = 2, widths = c(0.6, 0.4)
+      )
+      s2 <- subplot(intersect_size_chart, grid, nrows = 2, shareX = TRUE) %>% layout(showlegend = FALSE)
+
+      subplot(s1, s2, widths = c(0.3, 0.7))
+    })
+
+    # Calculate the maximum number of sets in an intersection
+
+    getMaxIntersectionOrder <- reactive({
+      ints <- calculateIntersections()
+      max(unlist(lapply(ints$combinations[ints$intersections > 0], length)))
+    })
+
+    # Add some line returns to contrast names
+
+    getSetNames <- reactive({
+      selected_sets <- getSets()
+      gsub("_", " ", names(selected_sets))
+    })
+
+    # Make the grid of points indicating set membership in intersections
+
+    upsetGrid <- reactive({
+      selected_sets <- getSets()
+      ints <- getIntersections()
+
+      intersects <- ints$intersections
+      combos <- ints$combinations
+
+      # Reduce the maximum number of intersections if we don't have that many
+
+      nintersections <- getNintersections()
+      nintersections <- min(nintersections, length(combos))
+
+      # Fetch the number of sets
+
+      nsets <- getNsets()
+      setnames <- getSetNames()
+
+      lines <- data.table::rbindlist(lapply(1:nintersections, function(combono) {
+        data.frame(combo = combono, x = rep(combono, max(2, length(combos[[combono]]))), y = (nsets - combos[[combono]]) + 1, name = setnames[combos[[combono]]])
+      }))
+
+      plot_ly(type = "scatter", mode = "markers", marker = list(color = "lightgrey", size = 8)) %>%
+        add_trace(type = "scatter", x = rep(
+          1:nintersections,
+          length(selected_sets)
+        ), y = unlist(lapply(1:length(selected_sets), function(x) rep(x - 0.5, nintersections))), hoverinfo = "none") %>%
+        add_trace(
+          type = "scatter",
+          data = group_by(lines, combo), mode = "lines+markers", x = lines$x, y = lines$y - 0.5, line = list(color = "black", width = 3), marker = list(
+            color = "black",
+            size = 10
+          ), hoverinfo = "text", text = ~name
+        ) %>%
+        layout(xaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE), yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, nsets), zeroline = FALSE, range = 1:nsets), margin = list(t = 0, b = 40))
+    })
+
+    # Make the bar chart illustrating set sizes
+
+    upsetSetSizeBarChart <- reactive({
+      setnames <- getSetNames()
+      selected_sets <- getSets()
+
+      plot_ly(x = unlist(lapply(selected_sets, length)), y = setnames, type = "bar", orientation = "h", marker = list(color = "black")) %>% layout(bargap = 0.4, yaxis = list(categoryarray = rev(setnames), categoryorder = "array"))
+    })
+
+    # Make the bar chart illustrating intersect size
+
+    upsetIntersectSizeBarChart <- reactive({
+      ints <- getIntersections()
+      intersects <- ints$intersections
+      combos <- ints$combinations
+      nintersections <- getNintersections()
+
+      p <- plot_ly(showlegend = FALSE) %>% add_trace(x = 1:nintersections, y = unlist(intersects[1:nintersections]), type = "bar", marker = list(
+        color = "black",
+        hoverinfo = "none"
+      ))
+
+      bar_numbers <- getBarNumbers()
+
+      if (bar_numbers) {
+        p <- p %>% add_trace(
+          type = "scatter", mode = "text", x = 1:nintersections, y = unlist(intersects[1:nintersections]) + (max(intersects) * 0.05),
+          text = unlist(intersects[1:nintersections]), textfont = list(color = "black")
+        )
       }
 
-      # Sort by intersect size
-
-      combos <- combos[order(intersects, decreasing = TRUE)]
-      intersects <- intersects[order(intersects, decreasing = TRUE)]
-
-      list(combinations = combos, intersections = intersects)
+      p
     })
+
+    # Provide the differential set summary for download
+
+    simpletable("upset", downloadMatrix = makeDifferentialSetSummary, displayMatrix = makeDifferentialSetSummary, filter = "none", filename = "differential_summary", rownames = FALSE)
   })
-
-  # Post-process intersections to remove lower-order interactions from display if requested
-
-  getIntersections <- reactive({
-    minorder <- getMinOrder()
-    ints <- calculateIntersections()
-
-    selected <- unlist(lapply(ints$combinations, length)) >= minorder
-    lapply(ints, function(x) x[selected])
-  })
-
-  ########################################################################### Render the plot with it separate components
-
-  output$plotly_upset <- renderPlotly({
-    grid <- upsetGrid()
-    set_size_chart <- upsetSetSizeBarChart()
-    intersect_size_chart <- upsetIntersectSizeBarChart()
-
-    intersect_size_chart <- intersect_size_chart %>% layout(yaxis = list(title = "Intersections size"))
-
-    s1 <- subplot(plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"),
-      set_size_chart,
-      nrows = 2, widths = c(0.6, 0.4)
-    )
-    s2 <- subplot(intersect_size_chart, grid, nrows = 2, shareX = TRUE) %>% layout(showlegend = FALSE)
-
-    subplot(s1, s2, widths = c(0.3, 0.7))
-  })
-
-  # Calculate the maximum number of sets in an intersection
-
-  getMaxIntersectionOrder <- reactive({
-    ints <- calculateIntersections()
-    max(unlist(lapply(ints$combinations[ints$intersections > 0], length)))
-  })
-
-  # Add some line returns to contrast names
-
-  getSetNames <- reactive({
-    selected_sets <- getSets()
-    gsub("_", " ", names(selected_sets))
-  })
-
-  # Make the grid of points indicating set membership in intersections
-
-  upsetGrid <- reactive({
-    selected_sets <- getSets()
-    ints <- getIntersections()
-
-    intersects <- ints$intersections
-    combos <- ints$combinations
-
-    # Reduce the maximum number of intersections if we don't have that many
-
-    nintersections <- getNintersections()
-    nintersections <- min(nintersections, length(combos))
-
-    # Fetch the number of sets
-
-    nsets <- getNsets()
-    setnames <- getSetNames()
-
-    lines <- data.table::rbindlist(lapply(1:nintersections, function(combono) {
-      data.frame(combo = combono, x = rep(combono, max(2, length(combos[[combono]]))), y = (nsets - combos[[combono]]) + 1, name = setnames[combos[[combono]]])
-    }))
-
-    plot_ly(type = "scatter", mode = "markers", marker = list(color = "lightgrey", size = 8)) %>%
-      add_trace(type = "scatter", x = rep(
-        1:nintersections,
-        length(selected_sets)
-      ), y = unlist(lapply(1:length(selected_sets), function(x) rep(x - 0.5, nintersections))), hoverinfo = "none") %>%
-      add_trace(
-        type = "scatter",
-        data = group_by(lines, combo), mode = "lines+markers", x = lines$x, y = lines$y - 0.5, line = list(color = "black", width = 3), marker = list(
-          color = "black",
-          size = 10
-        ), hoverinfo = "text", text = ~name
-      ) %>%
-      layout(xaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE), yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, nsets), zeroline = FALSE, range = 1:nsets), margin = list(t = 0, b = 40))
-  })
-
-  # Make the bar chart illustrating set sizes
-
-  upsetSetSizeBarChart <- reactive({
-    setnames <- getSetNames()
-    selected_sets <- getSets()
-
-    plot_ly(x = unlist(lapply(selected_sets, length)), y = setnames, type = "bar", orientation = "h", marker = list(color = "black")) %>% layout(bargap = 0.4, yaxis = list(categoryarray = rev(setnames), categoryorder = "array"))
-  })
-
-  # Make the bar chart illustrating intersect size
-
-  upsetIntersectSizeBarChart <- reactive({
-    ints <- getIntersections()
-    intersects <- ints$intersections
-    combos <- ints$combinations
-    nintersections <- getNintersections()
-
-    p <- plot_ly(showlegend = FALSE) %>% add_trace(x = 1:nintersections, y = unlist(intersects[1:nintersections]), type = "bar", marker = list(
-      color = "black",
-      hoverinfo = "none"
-    ))
-
-    bar_numbers <- getBarNumbers()
-
-    if (bar_numbers) {
-      p <- p %>% add_trace(
-        type = "scatter", mode = "text", x = 1:nintersections, y = unlist(intersects[1:nintersections]) + (max(intersects) * 0.05),
-        text = unlist(intersects[1:nintersections]), textfont = list(color = "black")
-      )
-    }
-
-    p
-  })
-
-  # Provide the differential set summary for download
-
-  callModule(simpletable, "upset",
-    downloadMatrix = makeDifferentialSetSummary, displayMatrix = makeDifferentialSetSummary, filter = "none", filename = "differential_summary",
-    rownames = FALSE
-  )
 }

--- a/R/volcanoplot.R
+++ b/R/volcanoplot.R
@@ -94,21 +94,19 @@ volcanoplotOutput <- function(id) {
 
 #' The server function of the \code{volcanoplot} module
 #'
-#' This function is not called directly, but rather via callModule() (see
-#' example). Essentially this just passes the results of \code{colData()}
+#' This function is called directly, using the same id as its UI counterpart,
+#' and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 #' applied to the specified SummarizedExperiment object to the
 #' \code{simpletable} module
 #'
-#' @param input Input object
-#' @param output Output object
-#' @param session Session object
+#' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
 #'
 #' @keywords shiny
 #'
 #' @examples
-#' callModule(differentialtable, "differentialtable", eselist)
+#' differentialtable("differentialtable", eselist)
 #'
 #' # However, almost certainly called via application creation:
 #'
@@ -116,136 +114,129 @@ volcanoplotOutput <- function(id) {
 #' app <- prepareApp("volcanoplot", zhangneurons)
 #' shinyApp(ui = app$ui, server = app$server)
 #'
-volcanoplot <- function(input, output, session, eselist) {
-  output$volcanotable <- renderUI({
-    ns <- session$ns
+volcanoplot <- function(id, eselist) {
+  moduleServer(id, function(input, output, session) {
+    output$volcanotable <- renderUI({
+      ns <- session$ns
 
-    simpletableOutput(ns("volcanotable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]][[1]], sep = ": "))
-  })
+      simpletableOutput(ns("volcanotable"), tabletitle = paste("Plot data for contrast", getSelectedContrastNames()[[1]][[1]], sep = ": "))
+    })
 
-  # Call the selectmatrix module and unpack the reactives it sends back
+    # Call the selectmatrix module and unpack the reactives it sends back
 
-  selectmatrix_reactives <- callModule(selectmatrix, "expression", eselist,
-    var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE,
-    require_contrast_stats = TRUE
-  )
-  unpack.list(selectmatrix_reactives)
+    selectmatrix_reactives <- selectmatrix("expression", eselist, var_n = 1000, select_samples = FALSE, select_genes = FALSE, provide_all_genes = TRUE, require_contrast_stats = TRUE)
+    unpack.list(selectmatrix_reactives)
 
-  # Pass the matrix to the contrasts module for processing
+    # Pass the matrix to the contrasts module for processing
 
-  unpack.list(callModule(contrasts, "differential", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE))
+    unpack.list(contrasts("differential", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = FALSE))
 
-  # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
+    # Call the geneselect module (indpependently of selectmatrix) to generate sets of genes to highlight
 
-  unpack.list(callModule(geneselect, "volcano", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
+    unpack.list(geneselect("volcano", eselist = eselist, getExperiment = getExperiment, getAssay = getAssay, provide_all = FALSE, provide_none = TRUE))
 
-  # Pass the matrix to the scatterplot module for display
+    # Pass the matrix to the scatterplot module for display
 
-  callModule(scatterplot, "volcano",
-    getDatamatrix = volcanoTable, getTitle = getTitle, allow_3d = FALSE, getLabels = volcanoLabels, x = 1, y = 2, colorBy = colorBy,
-    getLines = plotLines
-  )
+    scatterplot("volcano", getDatamatrix = volcanoTable, getTitle = getTitle, allow_3d = FALSE, getLabels = volcanoLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
 
-  # Make a title by selecting the single contrast name of the single filter set
+    # Make a title by selecting the single contrast name of the single filter set
 
-  getTitle <- reactive({
-    contrast_names <- getSelectedContrastNames()
-    contrast_names[[1]][[1]]
-  })
+    getTitle <- reactive({
+      contrast_names <- getSelectedContrastNames()
+      contrast_names[[1]][[1]]
+    })
 
-  # Make a set of dashed lines to overlay on the plot representing thresholds
+    # Make a set of dashed lines to overlay on the plot representing thresholds
 
-  plotLines <- reactive({
-    withProgress(message = "Calculating lines", value = 0, {
+    plotLines <- reactive({
+      withProgress(message = "Calculating lines", value = 0, {
+        vt <- volcanoTable()
+
+        fclim <- getFoldChange()
+        qvallim <- getQval()
+
+        normal_y <- !is.infinite(vt[, 2])
+        normal_x <- !is.infinite(vt[, 1])
+
+        ymax <- max(vt[normal_y, 2], na.rm = TRUE)
+        ymin <- min(vt[normal_y, 2], na.rm = TRUE)
+
+        xmax <- max(vt[normal_x, 1], na.rm = TRUE)
+        xmin <- min(vt[normal_x, 1], na.rm = TRUE)
+
+        lines <- data.frame(
+          name = c(
+            rep(paste0(abs(fclim), "-fold down"), 2),
+            rep(paste0(abs(fclim), "-fold up"), 2),
+            rep(paste("q <", qvallim), 2)
+          ),
+          x = c(rep(-log2(abs(fclim)), 2), rep(log2(abs(fclim)), 2), xmin, xmax),
+          y = c(ymin, ymax, ymin, ymax, rep(-log10(qvallim), 2))
+        )
+
+        # Use lines dependent on how the fold change filter is applied
+
+        fccard <- getFoldChangeCard()
+
+        if (fccard %in% c(">= or <= -", "<= and >= -")) {
+          lines <- lines
+        } else if (fccard == "<=" && sign(fclim) == "-1") {
+          lines <- droplevels(lines[1, 2, 5, 6, ])
+        } else {
+          lines <- droplevels(lines[1:4, ])
+        }
+        lines
+      })
+    })
+
+    # Extract labels from the volcano table
+
+    volcanoLabels <- reactive({
+      withProgress(message = "Making labels", value = 0, {
+        vt <- volcanoTable()
+        vt$label
+      })
+    })
+
+    # Extract a vector use to make colors by group
+
+    colorBy <- reactive({
       vt <- volcanoTable()
-
-      fclim <- getFoldChange()
-      qvallim <- getQval()
-
-      normal_y <- !is.infinite(vt[, 2])
-      normal_x <- !is.infinite(vt[, 1])
-
-      ymax <- max(vt[normal_y, 2], na.rm = TRUE)
-      ymin <- min(vt[normal_y, 2], na.rm = TRUE)
-
-      xmax <- max(vt[normal_x, 1], na.rm = TRUE)
-      xmin <- min(vt[normal_x, 1], na.rm = TRUE)
-
-      lines <- data.frame(
-        name = c(
-          rep(paste0(abs(fclim), "-fold down"), 2),
-          rep(paste0(abs(fclim), "-fold up"), 2),
-          rep(paste("q <", qvallim), 2)
-        ),
-        x = c(rep(-log2(abs(fclim)), 2), rep(log2(abs(fclim)), 2), xmin, xmax),
-        y = c(ymin, ymax, ymin, ymax, rep(-log10(qvallim), 2))
-      )
-
-      # Use lines dependent on how the fold change filter is applied
-
-      fccard <- getFoldChangeCard()
-
-      if (fccard %in% c(">= or <= -", "<= and >= -")) {
-        lines <- lines
-      } else if (fccard == "<=" && sign(fclim) == "-1") {
-        lines <- droplevels(lines[1, 2, 5, 6, ])
-      } else {
-        lines <- droplevels(lines[1:4, ])
-      }
-      lines
+      vt$colorby
     })
-  })
 
-  # Extract labels from the volcano table
+    # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
 
-  volcanoLabels <- reactive({
-    withProgress(message = "Making labels", value = 0, {
-      vt <- volcanoTable()
-      vt$label
+    volcanoTable <- reactive({
+      withProgress(message = "Compiling volcano plot data", value = 0, {
+        sct <- selectedContrastsTables()
+        ct <- sct[[1]][[1]]
+
+        # q values of 0 cause trouble
+
+        ct$`q value`[ct$`q value` == 0] <- min(ct$`q value`[ct$`q value` != 0]) / 10
+
+        ct <- ct[, c("Fold change", "q value")]
+        ct[["Fold change"]] <- round(sign(ct[["Fold change"]]) * log2(abs(ct[["Fold change"]])), 3)
+        ct[["q value"]] <- round(-log10(ct[["q value"]]), 3)
+
+        cont <- getSelectedContrasts()[[1]][[1]]
+        colnames(ct) <- c(paste(paste0("(higher in ", cont[2], ")"), "log2(fold change)", paste0("(higher in ", cont[3], ")"), sep = "  "), "-log10(q value)")
+
+        fct <- filteredContrastsTables()[[1]][[1]]
+        ct$colorby <- "hidden"
+        ct[rownames(fct), "colorby"] <- "match contrast filters"
+        ct[selectRows(), "colorby"] <- "in highlighted gene set"
+        ct$colorby <- factor(ct$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
+
+        ct$label <- idToLabel(rownames(ct), getExperiment())
+        ct$label[!rownames(ct) %in% c(rownames(fct), selectRows())] <- NA
+      })
+      ct
     })
+
+    # Display the data as a table alongside
+
+    simpletable("volcanotable", downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "volcano", rownames = FALSE, pageLength = 10)
   })
-
-  # Extract a vector use to make colors by group
-
-  colorBy <- reactive({
-    vt <- volcanoTable()
-    vt$colorby
-  })
-
-  # Make a table of values to use in the volcano plot. Round the values to save space in the JSON
-
-  volcanoTable <- reactive({
-    withProgress(message = "Compiling volcano plot data", value = 0, {
-      sct <- selectedContrastsTables()
-      ct <- sct[[1]][[1]]
-
-      # q values of 0 cause trouble
-
-      ct$`q value`[ct$`q value` == 0] <- min(ct$`q value`[ct$`q value` != 0]) / 10
-
-      ct <- ct[, c("Fold change", "q value")]
-      ct[["Fold change"]] <- round(sign(ct[["Fold change"]]) * log2(abs(ct[["Fold change"]])), 3)
-      ct[["q value"]] <- round(-log10(ct[["q value"]]), 3)
-
-      cont <- getSelectedContrasts()[[1]][[1]]
-      colnames(ct) <- c(paste(paste0("(higher in ", cont[2], ")"), "log2(fold change)", paste0("(higher in ", cont[3], ")"), sep = "  "), "-log10(q value)")
-
-      fct <- filteredContrastsTables()[[1]][[1]]
-      ct$colorby <- "hidden"
-      ct[rownames(fct), "colorby"] <- "match contrast filters"
-      ct[selectRows(), "colorby"] <- "in highlighted gene set"
-      ct$colorby <- factor(ct$colorby, levels = c("hidden", "match contrast filters", "in highlighted gene set"))
-
-      ct$label <- idToLabel(rownames(ct), getExperiment())
-      ct$label[!rownames(ct) %in% c(rownames(fct), selectRows())] <- NA
-    })
-    ct
-  })
-
-  # Display the data as a table alongside
-
-  callModule(simpletable, "volcanotable",
-    downloadMatrix = labelledContrastsTable, displayMatrix = linkedLabelledContrastsTable, filename = "volcano", rownames = FALSE,
-    pageLength = 10
-  )
 }

--- a/man/assaydatatable.Rd
+++ b/man/assaydatatable.Rd
@@ -4,26 +4,22 @@
 \alias{assaydatatable}
 \title{The server function of the assaydatatable module}
 \usage{
-assaydatatable(input, output, session, eselist)
+assaydatatable(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example). Essentially this just passes the results of \code{colData()}
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 applied to the specified SummarizedExperiment object to the
 \code{simpletable} module
 }
 \examples{
-callModule(assaydatatable, "assaydatatable", eselist)
+assaydatatable("assaydatatable", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/barplot.Rd
+++ b/man/barplot.Rd
@@ -4,14 +4,10 @@
 \alias{barplot}
 \title{Server function of the \code{barplot} module}
 \usage{
-barplot(input, output, session, getPlotmatrix, getYLabel, barmode = "stack")
+barplot(id, getPlotmatrix, getYLabel, barmode = "stack")
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{getPlotmatrix}{Reactive supplying a matrix to plot}
 

--- a/man/boxplot.Rd
+++ b/man/boxplot.Rd
@@ -4,14 +4,10 @@
 \alias{boxplot}
 \title{The server function of the boxplot module}
 \usage{
-boxplot(input, output, session, eselist)
+boxplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -23,11 +19,11 @@ boxplot produced using \code{ggplot2}. For higher sample numbers, the default is
 a line-based alternative using \code{plotly}.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(boxplot, "boxplot", eselist)
+boxplot("boxplot", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/chipseq.Rd
+++ b/man/chipseq.Rd
@@ -5,24 +5,20 @@
 \title{The server function of the chipseq module. Currently a near-clone of the
 RNA-seq module, with ChIP-seq optimisations planned.}
 \usage{
-chipseq(input, output, session, eselist)
+chipseq(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(chipseq, "chipseq", eselist)
+chipseq("chipseq", eselist)
 
 }
 \keyword{shiny}

--- a/man/clustering.Rd
+++ b/man/clustering.Rd
@@ -4,14 +4,10 @@
 \alias{clustering}
 \title{The server function of the clustering module}
 \usage{
-clustering(input, output, session, eselist)
+clustering(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -26,11 +22,11 @@ partitioning about medoids, is used to produce the clusters. As well as
 defining the input matrix users can decide how the clusters are drawn and how
 many clusters should be generated.
 
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(clustering, "myid", eselist)
+clustering("myid", eselist)
 
 }
 \keyword{shiny}

--- a/man/colormaker.Rd
+++ b/man/colormaker.Rd
@@ -4,14 +4,10 @@
 \alias{colormaker}
 \title{The output function of the colorby module}
 \usage{
-colormaker(input, output, session, getNumberCategories)
+colormaker(id, getNumberCategories)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{getNumberCategories}{A reactive supplying the number of categories
 that require a color.}
@@ -26,11 +22,11 @@ and provides that palette given a reactive which supplied the required
 number of colors.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(colormaker, "myid", getNumberCategories)
+colormaker("myid", getNumberCategories)
 
 }
 \keyword{shiny}

--- a/man/contrasts.Rd
+++ b/man/contrasts.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the contrasts module}
 \usage{
 contrasts(
-  input,
-  output,
-  session,
+  id,
   eselist,
   selectmatrix_reactives = list(),
   multiple = FALSE,
@@ -19,11 +17,7 @@ contrasts(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -50,11 +44,11 @@ differential expression panels. In particular it provides the ability for
 users to add filters to progressively refine a query.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(contrasts, "differential", getExperiment = getExperiment, selectMatrix = selectMatrix, getAssay = getAssay, multiple = TRUE)
+contrasts("differential", getExperiment = getExperiment, selectMatrix = selectMatrix, getAssay = getAssay, multiple = TRUE)
 
 }
 \keyword{shiny}

--- a/man/dendro.Rd
+++ b/man/dendro.Rd
@@ -4,14 +4,10 @@
 \alias{dendro}
 \title{The server function of the dendrogram module}
 \usage{
-dendro(input, output, session, eselist)
+dendro(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -23,11 +19,11 @@ provided by the \code{selectmatrix} module, as well distance matrix
 generation and clustering method.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(dendro, "myid", eselist)
+dendro("myid", eselist)
 
 }
 \keyword{shiny}

--- a/man/dexseqplot.Rd
+++ b/man/dexseqplot.Rd
@@ -4,21 +4,17 @@
 \alias{dexseqplot}
 \title{The server function of the dexseqplot Shiny module}
 \usage{
-dexseqplot(input, output, session, eselist)
+dexseqplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \details{
 This module produces a differential exon usage plot using the \code{plotDEXSeq}
@@ -33,7 +29,7 @@ to the contrasts listed in the \code{contrasts} slot of the
 \code{ExploratorySummarizedExperiment}.
 }
 \examples{
-callModule(dexseqplot, "dexseqplot", eselist)
+dexseqplot("dexseqplot", eselist)
 
 }
 \keyword{shiny}

--- a/man/dexseqtable.Rd
+++ b/man/dexseqtable.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the dexseqtable module}
 \usage{
 dexseqtable(
-  input,
-  output,
-  session,
+  id,
   eselist,
   allow_filtering = TRUE,
   getDEUGeneID = NULL,
@@ -17,11 +15,7 @@ dexseqtable(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -54,11 +48,11 @@ of the input \code{ExploratorySummarizedExperimentList}.
 to the contrasts listed in the \code{contrasts} slot of the
 \code{ExploratorySummarizedExperiment}.
 
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(dexseqtable, "dexseqtable", eselist)
+dexseqtable("dexseqtable", eselist)
 
 }
 \keyword{shiny}

--- a/man/differentialtable.Rd
+++ b/man/differentialtable.Rd
@@ -4,14 +4,10 @@
 \alias{differentialtable}
 \title{The server function of the differentialtable module}
 \usage{
-differentialtable(input, output, session, eselist)
+differentialtable(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -21,14 +17,14 @@ This module provides information on the comparison betwen pairs of groups
 defined in a 'contrasts' slot of a ExploratorySummarizedExperimentList
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 
 Essentially this funnction uses the \code{contrasts} module to group samples
 and calculate fold changes, adding test statistics where available.
 }
 \examples{
-callModule(differentialtable, "differentialtable", eselist)
+differentialtable("differentialtable", eselist)
 
 }
 \keyword{shiny}

--- a/man/experimenttable.Rd
+++ b/man/experimenttable.Rd
@@ -4,26 +4,22 @@
 \alias{experimenttable}
 \title{The server function of the experimenttable module}
 \usage{
-experimenttable(input, output, session, eselist)
+experimenttable(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example). Essentially this just passes the results of \code{colData()}
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 applied to the specified SummarizedExperiment object to the
 \code{simpletable} module
 }
 \examples{
-callModule(experimenttable, "experimenttable", eselist)
+experimenttable("experimenttable", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/foldchangeplot.Rd
+++ b/man/foldchangeplot.Rd
@@ -4,14 +4,10 @@
 \alias{foldchangeplot}
 \title{The server function of the \code{foldchangeplot} module}
 \usage{
-foldchangeplot(input, output, session, eselist)
+foldchangeplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -21,11 +17,11 @@ This module is for making scatter plots comparing pairs of groups defined in
 a 'contrasts' slot of the ExploratorySummarizedExperimentList
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(foldchangeplot, "foldchangeplot", eselist)
+foldchangeplot("foldchangeplot", eselist)
 
 data(zhangneurons)
 app <- prepareApp("foldchangeplot", zhangneurons)

--- a/man/gene.Rd
+++ b/man/gene.Rd
@@ -4,14 +4,10 @@
 \alias{gene}
 \title{The server function of the gene module}
 \usage{
-gene(input, output, session, eselist)
+gene(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -21,11 +17,11 @@ The gene module picks specified rows out the assay data, either simply by id
 or label. This is used to create a gene-centric info page.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(gene, "gene", eselist)
+gene("gene", eselist)
 
 }
 \keyword{shiny}

--- a/man/geneBarplot.Rd
+++ b/man/geneBarplot.Rd
@@ -33,7 +33,7 @@ This function does the actual plotting with plotly. It will produce a plot
 for every row of the input matrix.
 }
 \examples{
-callModule(gene, "gene", ses)
+gene("gene", ses)
 
 }
 \keyword{shiny}

--- a/man/geneselect.Rd
+++ b/man/geneselect.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the geneselect module}
 \usage{
 geneselect(
-  input,
-  output,
-  session,
+  id,
   eselist,
   getExperiment,
   var_n = 50,
@@ -22,11 +20,7 @@ geneselect(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -63,7 +57,7 @@ This module provides controls for selecting genes (matrix rows) by various
 criteria such as variance and gene set.
 }
 \examples{
-geneselect_functions <- callModule(geneselect, "heatmap", getExperiments)
+geneselect_functions <- geneselect("heatmap", getExperiments)
 
 }
 \keyword{shiny}

--- a/man/genesetanalysistable.Rd
+++ b/man/genesetanalysistable.Rd
@@ -4,14 +4,10 @@
 \alias{genesetanalysistable}
 \title{The server function of the genesetanalysistable module}
 \usage{
-genesetanalysistable(input, output, session, eselist)
+genesetanalysistable(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -31,8 +27,8 @@ The module is based on the output of roast() from \code{limma}, but it's
 fairly generic, and assumes only the presence of a 'p value' and 'FDR'
 column, so the output of other methods should be easily adapted to suit.
 
-This function is not called directly, but rather via callModule() (see
-example). Essentially this just passes the results of \code{colData()}
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 applied to the specified SummarizedExperiment object to the
 \code{simpletable} module
 }
@@ -55,7 +51,7 @@ names(zhangneurons$gene@gene_set_analyses$`normalised-filtered`)
 
 names(zhangneurons@gene_sets)
 
-callModule(genesetanalysistable, "genesetanalysistable", eselist)
+genesetanalysistable("genesetanalysistable", eselist)
 
 }
 \keyword{shiny}

--- a/man/genesetbarcodeplot.Rd
+++ b/man/genesetbarcodeplot.Rd
@@ -4,14 +4,10 @@
 \alias{genesetbarcodeplot}
 \title{The server function of the genesetbarcodeplot module}
 \usage{
-genesetbarcodeplot(input, output, session, eselist)
+genesetbarcodeplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -25,11 +21,11 @@ from the \code{gene_set_analyses} slot of the selected
 \code{ExploratorySummarizedExperiment} are displayed where provided.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(genesetbarcodeplot, "genesetbarcodeplot", eselist)
+genesetbarcodeplot("genesetbarcodeplot", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/genesetselect.Rd
+++ b/man/genesetselect.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the genesetselect module}
 \usage{
 genesetselect(
-  input,
-  output,
-  session,
+  id,
   eselist,
   getExperiment,
   multiple = TRUE,
@@ -16,11 +14,7 @@ genesetselect(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{An ExploratorySummarizedExperimentList with its gene_sets
 slot set}
@@ -46,7 +40,7 @@ to thousands of entries. This would be difficult to do client-side using a
 standard select field.
 }
 \examples{
-geneset_functions <- callModule(genesetselect, "heatmap", getExperiment)
+geneset_functions <- genesetselect("heatmap", getExperiment)
 
 }
 \keyword{shiny}

--- a/man/groupby.Rd
+++ b/man/groupby.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the groupby module}
 \usage{
 groupby(
-  input,
-  output,
-  session,
+  id,
   eselist,
   group_label = "Group by",
   multiple = FALSE,
@@ -18,11 +16,7 @@ groupby(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -46,7 +40,7 @@ The groupby module provides a UI element to choose from the
 \code{group_vars} in a SummarizedExperment. Useful for coloring in a PCA etc
 }
 \examples{
-geneset_functions <- callModule(groupby, "heatmap", getExperiment)
+geneset_functions <- groupby("heatmap", getExperiment)
 
 }
 \keyword{shiny}

--- a/man/heatmap.Rd
+++ b/man/heatmap.Rd
@@ -4,14 +4,10 @@
 \alias{heatmap}
 \title{The server function of the heatmap module}
 \usage{
-heatmap(input, output, session, eselist, type = "expression")
+heatmap(id, eselist, type = "expression")
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -28,11 +24,11 @@ A pca heatmap plots the results of anova tests applied to examine the
 associations between principal components and experimental variables.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(heatmap, "heatmap", eselist, type = "pca")
+heatmap("heatmap", eselist, type = "pca")
 
 # Almost certainly used via application creation
 

--- a/man/illuminaarray.Rd
+++ b/man/illuminaarray.Rd
@@ -4,24 +4,20 @@
 \alias{illuminaarray}
 \title{The server function of the illuminaarray module}
 \usage{
-illuminaarray(input, output, session, eselist)
+illuminaarray(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(illuminaarray, "illuminaarray", eselist)
+illuminaarray("illuminaarray", eselist)
 
 }
 \keyword{shiny}

--- a/man/illuminaarrayqc.Rd
+++ b/man/illuminaarrayqc.Rd
@@ -4,14 +4,10 @@
 \alias{illuminaarrayqc}
 \title{The server function of the illuminaarrayqc module}
 \usage{
-illuminaarrayqc(input, output, session, eselist)
+illuminaarrayqc(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -20,11 +16,11 @@ ExploratorySummarizedExperiment objects}
 This module plots control probes from an illumina microarray experiment.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(illuminaarayqc, "myid", eselist)
+illuminaarayqc("myid", eselist)
 
 }
 \keyword{shiny}

--- a/man/labelselectfield.Rd
+++ b/man/labelselectfield.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the \code{labelselectfield} module}
 \usage{
 labelselectfield(
-  input,
-  output,
-  session,
+  id,
   eselist,
   getExperiment = NULL,
   labels_from_all_experiments = FALSE,
@@ -20,11 +18,7 @@ labelselectfield(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -65,6 +59,6 @@ to thousands of entries. This would be difficult to do client-side using a
 standard select field.
 }
 \examples{
-callModule(labelselectfield, "myid", eselist)
+labelselectfield("myid", eselist)
 
 }

--- a/man/maplot.Rd
+++ b/man/maplot.Rd
@@ -4,14 +4,10 @@
 \alias{maplot}
 \title{The server function of the \code{maplot} module}
 \usage{
-maplot(input, output, session, eselist)
+maplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -21,11 +17,11 @@ This module is for making scatter plots comparing pairs of groups defined in
 a 'contrasts' slot of the ExploratorySummarizedExperiment
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(maplot, "maplot", eselist)
+maplot("maplot", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/pca.Rd
+++ b/man/pca.Rd
@@ -4,14 +4,10 @@
 \alias{pca}
 \title{The server function of the pca module}
 \usage{
-pca(input, output, session, eselist)
+pca(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -23,13 +19,13 @@ It uses a common set of controls, generated with the
 and loadings produced by the \code{scatterplots} module.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 
 Matrix and UI selection elements provided by the selectmatrix module
 }
 \examples{
-callModule(pca, "pca", eselist)
+pca("pca", eselist)
 
 # Almost certainly used via application creation
 

--- a/man/plotdownload.Rd
+++ b/man/plotdownload.Rd
@@ -4,22 +4,10 @@
 \alias{plotdownload}
 \title{The server function of the gene set module}
 \usage{
-plotdownload(
-  input,
-  output,
-  session,
-  makePlot,
-  filename = "plot.png",
-  plotHeight,
-  plotWidth
-)
+plotdownload(id, makePlot, filename = "plot.png", plotHeight, plotWidth)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{makePlot}{A reactive for generating the plot}
 
@@ -34,7 +22,7 @@ The plotdownload module provides export functionality for panels with plots.
 This will generally not be called directly, but by other modules
 }
 \examples{
-callModule(plotdownload, "heatmap", makePlot = plotHeatmap, filename = "heatmap.png", plotHeight = plotHeight, plotWidth = plotWidth)
+plotdownload("heatmap", makePlot = plotHeatmap, filename = "heatmap.png", plotHeight = plotHeight, plotWidth = plotWidth)
 
 }
 \keyword{shiny}

--- a/man/readreports.Rd
+++ b/man/readreports.Rd
@@ -4,14 +4,10 @@
 \alias{readreports}
 \title{Server function of the \code{readreports} module}
 \usage{
-readreports(input, output, session, eselist)
+readreports(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperiment with \code{read_distribution}
 slot filled}

--- a/man/rnaseq.Rd
+++ b/man/rnaseq.Rd
@@ -4,24 +4,20 @@
 \alias{rnaseq}
 \title{The server function of the rnaseq module}
 \usage{
-rnaseq(input, output, session, eselist)
+rnaseq(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(rnaseq, "rnaseq", eselist)
+rnaseq("rnaseq", eselist)
 
 }
 \keyword{shiny}

--- a/man/rowmetatable.Rd
+++ b/man/rowmetatable.Rd
@@ -4,26 +4,22 @@
 \alias{rowmetatable}
 \title{The server function of the rowmetatable module}
 \usage{
-rowmetatable(input, output, session, eselist)
+rowmetatable(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example). Essentially this just passes the results of \code{colData()}
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 applied to the specified SummarizedExperiment object to the
 \code{simpletable} module
 }
 \examples{
-callModule(rowmetatable, "rowmetatable", eselist)
+rowmetatable("rowmetatable", eselist)
 
 }
 \keyword{shiny}

--- a/man/sampleselect.Rd
+++ b/man/sampleselect.Rd
@@ -4,21 +4,10 @@
 \alias{sampleselect}
 \title{The server function of the sampleselect module}
 \usage{
-sampleselect(
-  input,
-  output,
-  session,
-  eselist,
-  getExperiment,
-  allow_summarise = TRUE
-)
+sampleselect(id, eselist, getExperiment, allow_summarise = TRUE)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -38,11 +27,11 @@ This module provides controls for selecting matrix columns by sample or
 group name.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-selectSamples <- callModule(sampleselect, "selectmatrix", getExperiment)
+selectSamples <- sampleselect("selectmatrix", getExperiment)
 
 }
 \keyword{shiny}

--- a/man/scatterplot.Rd
+++ b/man/scatterplot.Rd
@@ -5,9 +5,7 @@
 \title{Server function for the scatterplot module}
 \usage{
 scatterplot(
-  input,
-  output,
-  session,
+  id,
   getDatamatrix,
   getThreedee = NULL,
   getXAxis = NULL,
@@ -33,11 +31,7 @@ scatterplot(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{getDatamatrix}{Reactive supplying a matrix. If using external controls
 this should match the one supplied to \code{scatterplotcontrols}}

--- a/man/scatterplotcontrols.Rd
+++ b/man/scatterplotcontrols.Rd
@@ -5,9 +5,7 @@
 \title{Server function for scatterplotcontrols module}
 \usage{
 scatterplotcontrols(
-  input,
-  output,
-  session,
+  id,
   getDatamatrix,
   x = NA,
   y = NA,
@@ -16,11 +14,7 @@ scatterplotcontrols(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{getDatamatrix}{Reactive expression that returns a matrix from which
 coulumn headers will be used to create axis select drop-downs. The same
@@ -48,6 +42,6 @@ This module provides controls (2D/3D, axes etc) for scatter plots, which
 may then be used by one or more instances of the scatterplot module.
 }
 \examples{
-unpack.list(callModule(scatterplotcontrols, "pca", pcaMatrix, x = 1, y = 2)) # To have fixed axes rather than user-selected
+unpack.list(scatterplotcontrols("pca", pcaMatrix, x = 1, y = 2)) # To have fixed axes rather than user-selected
 
 }

--- a/man/selectmatrix.Rd
+++ b/man/selectmatrix.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the selectmatrix module}
 \usage{
 selectmatrix(
-  input,
-  output,
-  session,
+  id,
   eselist,
   var_n = 50,
   var_max = NULL,
@@ -23,11 +21,7 @@ selectmatrix(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -81,11 +75,11 @@ row- and column- selection, respectively.
 This will generally not be called directly, but by other modules such as the
 heatmap module.
 
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-selectSamples <- callModule(sampleselect, "selectmatrix", eselist)
+selectSamples <- sampleselect("selectmatrix", eselist)
 
 }
 \keyword{shiny}

--- a/man/shinyngs.Rd
+++ b/man/shinyngs.Rd
@@ -80,13 +80,14 @@ usage.
 
   \subsection{Usage}{Any application seeking to create dendrograms need only
   call \code{\link{dendroInput}} \code{\link{dendroOutput}} in the parts of
-  their application where inputs and outputs should appear, and then use
-  \code{\link[shiny]{callModule}} (again using the same ID) to activate them.
+  their application where inputs and outputs should appear, and then call
+  \code{\link{dendro}} directly (again using the same ID) to activate them,
+  via \code{\link[shiny]{moduleServer}}.
 
   \preformatted{
   dendroInput(ns('dendro'), eselist)
   dendroOutput(ns('dendro'))
-  callModule(dendro, 'dendro', eselist) }}
+  dendro('dendro', eselist) }}
 
   These module functions are not currently exported, not currenlty being
   intended for use outside \code{shinyngs}. This may change.

--- a/man/simpletable.Rd
+++ b/man/simpletable.Rd
@@ -5,9 +5,7 @@
 \title{The server function of the simpletable module}
 \usage{
 simpletable(
-  input,
-  output,
-  session,
+  id,
   downloadMatrix = NULL,
   displayMatrix,
   pageLength = 15,
@@ -18,11 +16,7 @@ simpletable(
 )
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{downloadMatrix}{Reactive expression for retrieving the plot to supply
 for download (default: NULL, in which case \code{displayMatrix()} will be
@@ -43,11 +37,11 @@ names of the input matrix? (default: FALSE)}
 \item{filter}{Passed to \code{DT::renderDataTable()}}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(simpletable, "simpletable", my_data_frame)
+simpletable("simpletable", my_data_frame)
 
 }
 \keyword{shiny}

--- a/man/summarisematrix.Rd
+++ b/man/summarisematrix.Rd
@@ -4,21 +4,17 @@
 \alias{summarisematrix}
 \title{The server function of the summarisematrix module}
 \usage{
-summarisematrix(input, output, session)
+summarisematrix(id)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 }
 \description{
 This module provides a form element and associated get function for defining
 how a summary statistic is calculated (probably by mean).
 }
 \examples{
-callModule(summarisematrix)
+summarisematrix()
 
 }
 \keyword{shiny}

--- a/man/upset.Rd
+++ b/man/upset.Rd
@@ -4,14 +4,10 @@
 \alias{upset}
 \title{The server function of the upstart module}
 \usage{
-upset(input, output, session, eselist, setlimit = 16)
+upset(id, eselist, setlimit = 16)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
@@ -27,11 +23,11 @@ components, and to allow plotting of all elements in given intersections
 also seems to have sped things up.
 }
 \details{
-This function is not called directly, but rather via callModule() (see
-example).
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example).
 }
 \examples{
-callModule(upstart, "myid", eselist)
+upstart("myid", eselist)
 
 }
 \references{

--- a/man/volcanoplot.Rd
+++ b/man/volcanoplot.Rd
@@ -4,26 +4,22 @@
 \alias{volcanoplot}
 \title{The server function of the \code{volcanoplot} module}
 \usage{
-volcanoplot(input, output, session, eselist)
+volcanoplot(id, eselist)
 }
 \arguments{
-\item{input}{Input object}
-
-\item{output}{Output object}
-
-\item{session}{Session object}
+\item{id}{Module namespace}
 
 \item{eselist}{ExploratorySummarizedExperimentList object containing
 ExploratorySummarizedExperiment objects}
 }
 \description{
-This function is not called directly, but rather via callModule() (see
-example). Essentially this just passes the results of \code{colData()}
+This function is called directly, using the same id as its UI counterpart,
+and wraps its logic in \code{moduleServer()} (see example). Essentially this just passes the results of \code{colData()}
 applied to the specified SummarizedExperiment object to the
 \code{simpletable} module
 }
 \examples{
-callModule(differentialtable, "differentialtable", eselist)
+differentialtable("differentialtable", eselist)
 
 # However, almost certainly called via application creation:
 

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -387,3 +387,24 @@ test_that("check_gene_set_analyses_tool_consistency accepts a custom mapping", {
     )
   )
 })
+
+# cond_log2_transform_matrix()
+
+test_that("cond_log2_transform_matrix guesses reverse (unlog) status correctly", {
+  raw_counts <- matrix(c(10, 2, 4, 181, 14, 12), nrow = 2, byrow = TRUE)
+
+  # Raw counts (max well above threshold) should be left alone when guessing
+  # whether to unlog, not exponentiated.
+  expect_equal(
+    cond_log2_transform_matrix(raw_counts, reverse = TRUE, threshold = 30),
+    raw_counts
+  )
+
+  log_scale <- matrix(c(1, 2, 3, 4, 5, 6), nrow = 2, byrow = TRUE)
+
+  # Small, log-scale-looking values should be unlogged when guessing.
+  expect_equal(
+    cond_log2_transform_matrix(log_scale, reverse = TRUE, threshold = 30),
+    2^log_scale
+  )
+})


### PR DESCRIPTION
## Summary

- Migrates every module server function in the package from the deprecated `function(input, output, session, ...)` form activated via `callModule()` to the modern `moduleServer(id, function(input, output, session) {...})` API. All internal cross-module calls and the app-level call sites in `apps.R` now call the target module function directly instead of going through `callModule()`.
- Updates roxygen docs/examples across all affected modules to reflect the new calling convention, and adds an explicit `shiny (>= 1.5.0)` version constraint (the version that introduced `moduleServer()`).
- Fixes a tautological guess condition in `cond_log2_transform_matrix()` (`R/accessory.R`): when auto-detecting whether to un-log an assay, the logic evaluated `(max > threshold) || (max <= threshold)`, which is true for any value, so un-logging (`2^x`) was applied unconditionally regardless of whether the data actually looked log-scale. This corrupted raw counts into astronomical/`Inf` values, which broke PCA and sample clustering. Found while manually verifying `prepareApp()` in a browser; confirmed reproducible on unmodified `develop` with the same dataset, so unrelated to the module migration itself, but fixed here since it blocked verifying the migration end-to-end. Added a regression test.

## Test plan

- [x] `devtools::document()` / roxygen docs regenerated, package parses and loads cleanly
- [x] `devtools::test()` — all existing tests plus new regression tests pass
- [x] `R CMD check`-equivalent run (`devtools::check`, no vignettes/examples, matching CI) — 0 errors
- [x] Built a real `ExploratorySummarizedExperimentList` from the CI test dataset (SRP254919) and drove `prepareApp("rnaseq")`, `prepareApp("chipseq")`, `prepareApp("illuminaarray")`, and a spread of `simpleApp()` module types through `shiny::testServer()` with no errors
- [x] Ran the live `rnaseq` app in a browser (headless Playwright) and clicked through every panel (PCA, clustering dendrogram, clustering heatmap, feature-wise clustering, heatmaps, fold change/MA/volcano plots, differential set intersection, gene info) with no `shiny-output-error` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)