### PR TITLE
Fix duplicated y-axis range in upset plot layout

### DIFF
--- a/R/upset.R
+++ b/R/upset.R
@@ -415,7 +415,7 @@ upset <- function(id, eselist, setlimit = 16) {
             size = 10
           ), hoverinfo = "text", text = ~name
         ) %>%
-        layout(xaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE), yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, nsets), zeroline = FALSE, range = 1:nsets), margin = list(t = 0, b = 40))
+        layout(xaxis = list(showticklabels = FALSE, showgrid = FALSE, zeroline = FALSE), yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, nsets), zeroline = FALSE), margin = list(t = 0, b = 40))
     })
 
     # Make the bar chart illustrating set sizes


### PR DESCRIPTION
### Problem
In the upset intersection plot, the `layout()` call sets the `yaxis` range twice within a single `list()`:

```r
yaxis = list(showticklabels = FALSE, showgrid = FALSE, range = c(0, nsets), zeroline = FALSE, range = 1:nsets)
```

The second `range = 1:nsets` is a malformed duplicate: it is a length-`nsets` vector, whereas plotly expects a two-element `[min, max]`. With a duplicate key present, the effective y-axis range is ambiguous and depends on how the list is serialized to JSON for plotly, so the intended `[0, nsets]` framing is not reliably applied (and the stray value is not a valid range at all).

### Fix
Drop the malformed duplicate, keeping the well-formed `range = c(0, nsets)`.

### Verification
`devtools::load_all()` succeeds and the existing test suite passes (73 pass, 0 fail). The change is a single-line edit within one `layout()` call.

### Note
This bug was found incidentally during the modernisation review sweep; it exists independently on `develop` (not introduced by any modernisation PR). It touches the same line that #132 converts `1:nsets` to `seq_len(nsets)`, so expect a trivial one-line conflict whichever of the two merges second (resolve by keeping this PR's removal of the duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)