### PR TITLE
Fix matrix/data.frame subsetting silently dropping dimensions

### DIFF
--- a/R/ExploratorySummarizedExperiment-class.R
+++ b/R/ExploratorySummarizedExperiment-class.R
@@ -92,10 +92,10 @@ ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield
 
   # Subset colData to remove any samples not present in the first assay
 
-  colData <- colData[rownames(colData) %in% colnames(assays[[1]]), ]
+  colData <- colData[rownames(colData) %in% colnames(assays[[1]]), , drop = FALSE]
 
   assays <- SimpleList(lapply(assays, function(as) {
-    round(add_missing_rows(as)[, rownames(colData)], 2)
+    round(add_missing_rows(as)[, rownames(colData), drop = FALSE], 2)
   }))
 
   # The same fix for contrast_stats

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -311,7 +311,7 @@ ggplotify <- function(plotmatrices, experiment, colorby = NULL, value_type = "ex
         data.frame(name = s, value = dens$x, density = dens$y)
       }))
     } else {
-      plotdata <- melt_matrix(as.matrix(plotmatrices[[pm]][, rownames(experiment)]))
+      plotdata <- melt_matrix(as.matrix(plotmatrices[[pm]][, rownames(experiment), drop = FALSE]))
       plotdata <- plotdata[which(plotdata$value > 0), ]
       colnames(plotdata) <- c("gene", "name", "value")
       plotdata$value <- cond_log2_transform_matrix(plotdata$value, should_transform = should_transform)
@@ -923,7 +923,7 @@ read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, s
     }
   }
 
-  as.matrix(matrix_data[, rownames(sample_metadata)])
+  as.matrix(matrix_data[, rownames(sample_metadata), drop = FALSE])
 }
 
 #' Read a metadata file

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -433,7 +433,7 @@ bootstrapMedian <- function(data, num) {
 
 madScore <- function(matrix, sample_sheet = NULL, groupby = NULL, outlier_threshold = -5) {
   # Double-check the matrix/ sample sheet synch
-  matrix <- matrix[, rownames(sample_sheet)]
+  matrix <- matrix[, rownames(sample_sheet), drop = FALSE]
 
   group_sizes <- table(sample_sheet[[groupby]])
   mad_valid_groups <- group_sizes[group_sizes > 2]
@@ -444,13 +444,13 @@ madScore <- function(matrix, sample_sheet = NULL, groupby = NULL, outlier_thresh
   } else {
     mad_valid_samples <- which(sample_sheet[[groupby]] %in% names(mad_valid_groups))
 
-    matrix <- matrix[, mad_valid_samples]
-    sample_sheet <- sample_sheet[mad_valid_samples, ]
+    matrix <- matrix[, mad_valid_samples, drop = FALSE]
+    sample_sheet <- sample_sheet[mad_valid_samples, , drop = FALSE]
 
     if (is.null(groupby)) {
       matrices <- list(all = matrix)
     } else {
-      matrices <- lapply(split(rownames(sample_sheet), sample_sheet[[groupby]]), function(x) matrix[, x])
+      matrices <- lapply(split(rownames(sample_sheet), sample_sheet[[groupby]]), function(x) matrix[, x, drop = FALSE])
     }
 
     # The following intentionally verbose to highlight logic

--- a/R/dexseqtable.R
+++ b/R/dexseqtable.R
@@ -166,7 +166,7 @@ dexseqtable <- function(id, eselist, allow_filtering = TRUE, getDEUGeneID = NULL
           selected_contrast_samples <- contrast_samples[[contrast]]
 
           mean_counts <- lapply(selected_contrast_samples, function(scs) {
-            rowMeans(counts[, scs])
+            rowMeans(counts[, scs, drop = FALSE])
           })
 
           d$mean1 <- round(mean_counts[[1]], 2)

--- a/R/pca.R
+++ b/R/pca.R
@@ -138,7 +138,7 @@ pca <- function(id, eselist) {
 
     pcaDisplayMatrix <- reactive({
       pcam <- pcaMatrix()
-      pcam <- apply(pcam[, seq_len(min(ncol(pcam), 10))], 2, function(x) round(x, 2))
+      pcam <- apply(pcam[, seq_len(min(ncol(pcam), 10)), drop = FALSE], 2, function(x) round(x, 2))
       pcam
     })
 
@@ -256,7 +256,7 @@ runPCA <- function(matrix, do_log = TRUE) {
     matrix <- log2(matrix + 1)
   }
 
-  matrix <- matrix[apply(matrix, 1, function(x) length(unique(x))) > 1, ]
+  matrix <- matrix[apply(matrix, 1, function(x) length(unique(x))) > 1, , drop = FALSE]
 
   prcomp(t(as.matrix(matrix)), scale. = TRUE)
 }


### PR DESCRIPTION
## Summary
- Adds `drop = FALSE` to matrix/data.frame subsetting in several places where a single-row or single-column result would otherwise silently coerce to a plain vector, losing row/column names.
- Supersedes #85, which fixed the same class of bug in `madScore()` (`R/clustering.R`) but has since drifted out of sync with `develop` and can't be merged as-is. The `madScore` fix here is functionally identical to #85's.
- Extends the same fix to other call sites carrying the same risk: `ExploratorySummarizedExperiment()` constructor, `read_matrix()`, `ggplotify()`, `runPCA()`/`pcaDisplayMatrix`, and the DEXSeq contrast table's per-contrast mean counts. Most of these affect single-sample/single-replicate or single-passing-feature edge cases.

## Test plan
- [x] `devtools::test()` - all 76 tests pass, 0 failures