### PR TITLE
Add unit tests for pure functions (runPCA, foldChange, read_matrix/metadata, contrasts, colour scaling)

### DIFF
--- a/R/colormaker.R
+++ b/R/colormaker.R
@@ -83,7 +83,7 @@ makeColorScale <- function(ncolors, palette = "Set1") {
     cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(ncolors)
   } else if (ncolors < 3) {
     cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(3)
-    cols[seq_len(ncolors)]
+    cols <- cols[seq_len(ncolors)]
   } else {
     cols <- RColorBrewer::brewer.pal(ncolors, palette)
   }

--- a/R/pca.R
+++ b/R/pca.R
@@ -294,7 +294,7 @@ compilePCAData <- function(matrix, ntop = NULL) {
   }
 
   # perform a PCA on the data in assay(x) for the selected genes
-  pca <- runPCA(matrix, do_log = FALSE)
+  pca <- runPCA(matrix[select, , drop = FALSE], do_log = FALSE)
 
   # the contribution to the total variance for each component
   percentVar <- calculatePCAFractionExplained(pca)

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -408,3 +408,244 @@ test_that("cond_log2_transform_matrix guesses reverse (unlog) status correctly",
     2^log_scale
   )
 })
+
+# checkListIsSubset()
+
+test_that("checkListIsSubset returns TRUE when the test list is a subset", {
+  expect_true(checkListIsSubset(c("a", "b"), c("a", "b", "c"), "test", "reference"))
+})
+
+test_that("checkListIsSubset errors with a descriptive message when values are missing", {
+  expect_error(
+    checkListIsSubset(c("a", "z"), c("a", "b", "c"), "contrast variables", "sample metadata"),
+    paste0(
+      "Not all contrast variables are available in the sample metadata.\n",
+      "Missing contrast variables: z\n",
+      "Available sample metadata: a, b, c"
+    ),
+    fixed = TRUE
+  )
+})
+
+# read_matrix()
+
+test_that("read_matrix reads a tsv file and matches columns to sample metadata", {
+  matrix_content <- "id\tSample1\tSample2\tSample3\ngene1\t1\t2\t3\ngene2\t4\t5\t6\n"
+  matrix_file <- tempfile(fileext = ".tsv")
+  writeLines(matrix_content, matrix_file)
+  on.exit(unlink(matrix_file))
+
+  samples <- data.frame(row.names = c("Sample1", "Sample2", "Sample3"))
+
+  result <- read_matrix(matrix_file, samples)
+
+  expect_true(is.matrix(result))
+  expect_equal(colnames(result), c("Sample1", "Sample2", "Sample3"))
+  expect_equal(rownames(result), c("gene1", "gene2"))
+  expect_equal(result["gene1", "Sample2"], 2)
+})
+
+test_that("read_matrix errors when sample metadata names are absent from the matrix", {
+  matrix_content <- "id\tSample1\tSample2\ngene1\t1\t2\n"
+  matrix_file <- tempfile(fileext = ".tsv")
+  writeLines(matrix_content, matrix_file)
+  on.exit(unlink(matrix_file))
+
+  samples <- data.frame(row.names = c("Sample1", "SampleMissing"))
+
+  expect_error(
+    read_matrix(matrix_file, samples),
+    "SampleMissing.*absent from the matrix"
+  )
+})
+
+test_that("read_matrix falls back to the first column for feature identifiers", {
+  matrix_content <- "row_id\tfeature\tSample1\tSample2\n1\tgeneA\t1\t2\n2\tgeneB\t3\t4\n"
+  matrix_file <- tempfile(fileext = ".tsv")
+  writeLines(matrix_content, matrix_file)
+  on.exit(unlink(matrix_file))
+
+  samples <- data.frame(row.names = c("Sample1", "Sample2"))
+  features <- data.frame(row.names = c("geneA", "geneB"))
+
+  result <- read_matrix(matrix_file, samples, feature_metadata = features)
+
+  expect_equal(colnames(result), c("Sample1", "Sample2"))
+})
+
+# read_metadata()
+
+test_that("read_metadata reads a csv file", {
+  metadata_content <- "sample,condition\nSample1,Control\nSample2,Treated\n"
+  metadata_file <- tempfile(fileext = ".csv")
+  writeLines(metadata_content, metadata_file)
+  on.exit(unlink(metadata_file))
+
+  result <- read_metadata(metadata_file)
+
+  expect_equal(result$sample, c("Sample1", "Sample2"))
+  expect_equal(result$condition, c("Control", "Treated"))
+})
+
+test_that("read_metadata sets row names and de-duplicates using id_col", {
+  metadata_content <- "sample,condition\nSample1,Control\nSample1,Control\nSample2,Treated\n"
+  metadata_file <- tempfile(fileext = ".csv")
+  writeLines(metadata_content, metadata_file)
+  on.exit(unlink(metadata_file))
+
+  result <- read_metadata(metadata_file, id_col = "sample")
+
+  expect_equal(nrow(result), 2)
+  expect_equal(rownames(result), c("Sample1", "Sample2"))
+})
+
+test_that("read_metadata errors when the file does not exist", {
+  expect_error(
+    read_metadata(tempfile(fileext = ".csv")),
+    "does not exist"
+  )
+})
+
+test_that("read_metadata errors when id_col is not a column in the file", {
+  metadata_content <- "sample,condition\nSample1,Control\n"
+  metadata_file <- tempfile(fileext = ".csv")
+  writeLines(metadata_content, metadata_file)
+  on.exit(unlink(metadata_file))
+
+  expect_error(
+    read_metadata(metadata_file, id_col = "missing_col"),
+    "does not exist in metadata"
+  )
+})
+
+# read_contrasts() additional validation coverage
+
+test_that("read_contrasts parses a CSV contrasts file", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2", "Sample3", "Sample4"),
+    treatment = c("Control", "Control", "Treated", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  csv_content <- "id,variable,reference,target\ntreatment_effect,treatment,Control,Treated\n"
+  csv_file <- tempfile(fileext = ".csv")
+  writeLines(csv_content, csv_file)
+  on.exit(unlink(csv_file))
+
+  contrasts <- read_contrasts(csv_file, samples)
+
+  expect_equal(nrow(contrasts), 1)
+  expect_equal(contrasts$variable, "treatment")
+  expect_equal(contrasts$reference, "Control")
+  expect_equal(contrasts$target, "Treated")
+})
+
+test_that("read_contrasts errors on duplicate contrast ids in a CSV file", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2"),
+    treatment = c("Control", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  csv_content <- "id,variable,reference,target\ndup,treatment,Control,Treated\ndup,treatment,Control,Treated\n"
+  csv_file <- tempfile(fileext = ".csv")
+  writeLines(csv_content, csv_file)
+  on.exit(unlink(csv_file))
+
+  expect_error(
+    read_contrasts(csv_file, samples),
+    "Duplicate contrast ids found in CSV contrasts file."
+  )
+})
+
+test_that("read_contrasts errors when a blocking variable is absent from sample metadata", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2", "Sample3", "Sample4"),
+    treatment = c("Control", "Control", "Treated", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: treatment_effect
+    comparison: [\"treatment\", \"Control\", \"Treated\"]
+    blocking_factors: [\"nonexistent_batch\"]
+"
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+  on.exit(unlink(yaml_file))
+
+  expect_error(
+    read_contrasts(yaml_file, samples),
+    "Not all blocking variables are available in the sample metadata."
+  )
+})
+
+test_that("read_contrasts errors when the design matrix is not full rank", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2", "Sample3", "Sample4"),
+    treatment = c("Control", "Control", "Treated", "Treated"),
+    duplicate_of_treatment = c("Control", "Control", "Treated", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: treatment_effect
+    comparison: [\"treatment\", \"Control\", \"Treated\"]
+    blocking_factors: [\"duplicate_of_treatment\"]
+"
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+  on.exit(unlink(yaml_file))
+
+  expect_error(
+    read_contrasts(yaml_file, samples),
+    "Design matrix is not full rank."
+  )
+})
+
+test_that("read_contrasts warns when reference and target levels are identical", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2"),
+    treatment = c("Control", "Control"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: same_level_contrast
+    comparison: [\"treatment\", \"Control\", \"Control\"]
+"
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+  on.exit(unlink(yaml_file))
+
+  expect_warning(
+    read_contrasts(yaml_file, samples, validate_design = FALSE),
+    "identical reference and target levels"
+  )
+})
+
+test_that("read_contrasts requires both exclude_samples_col and exclude_samples_values together", {
+  samples <- data.frame(
+    row.names = c("Sample1", "Sample2"),
+    treatment = c("Control", "Treated"),
+    stringsAsFactors = FALSE
+  )
+
+  yaml_content <- "
+contrasts:
+  - id: missing_exclude_values
+    comparison: [\"treatment\", \"Control\", \"Treated\"]
+    exclude_samples_col: \"treatment\"
+"
+  yaml_file <- tempfile(fileext = ".yaml")
+  writeLines(yaml_content, yaml_file)
+  on.exit(unlink(yaml_file))
+
+  expect_error(
+    read_contrasts(yaml_file, samples),
+    "must provide both 'exclude_samples_col' and 'exclude_samples_values'"
+  )
+})

--- a/tests/testthat/test-colormaker.R
+++ b/tests/testthat/test-colormaker.R
@@ -1,0 +1,34 @@
+# makeColorScale()
+
+test_that("makeColorScale returns the requested number of colors for a mid-range value", {
+  cols <- makeColorScale(5, palette = "Set1")
+
+  expect_length(cols, 5)
+  expect_true(all(grepl("^#[0-9A-Fa-f]{6,8}$", cols)))
+})
+
+test_that("makeColorScale interpolates when ncolors exceeds the palette maximum", {
+  cols <- makeColorScale(20, palette = "Set1")
+
+  expect_length(cols, 20)
+  expect_equal(length(unique(cols)), 20)
+})
+
+test_that("makeColorScale still returns the requested count when ncolors is below 3", {
+  cols1 <- makeColorScale(1, palette = "Set1")
+  cols2 <- makeColorScale(2, palette = "Set1")
+
+  expect_length(cols1, 1)
+  expect_length(cols2, 2)
+
+  ramp <- colorRampPalette(RColorBrewer::brewer.pal(9, "Set1"))(3)
+  expect_equal(cols1, rev(ramp[1]))
+  expect_equal(cols2, rev(ramp[1:2]))
+})
+
+test_that("makeColorScale reverses the underlying palette order", {
+  cols <- makeColorScale(3, palette = "Set1")
+  expected <- rev(RColorBrewer::brewer.pal(3, "Set1"))
+
+  expect_equal(cols, expected)
+})

--- a/tests/testthat/test-contrasts.R
+++ b/tests/testthat/test-contrasts.R
@@ -1,0 +1,20 @@
+# foldChange()
+
+test_that("foldChange returns 1 where the two vectors are equal", {
+  expect_equal(foldChange(c(2, 2, 2), c(2, 2, 2)), c(1, 1, 1))
+})
+
+test_that("foldChange returns a plain ratio when vec2 exceeds vec1", {
+  expect_equal(foldChange(c(2, 2, 2), c(2, 4, 8)), c(1, 2, 4))
+})
+
+test_that("foldChange returns a negative reciprocal when vec2 is smaller than vec1", {
+  expect_equal(foldChange(c(4, 8), c(2, 2)), c(-2, -4))
+})
+
+test_that("foldChange handles a mix of increases, decreases and no change", {
+  vec1 <- c(10, 10, 10)
+  vec2 <- c(10, 20, 5)
+
+  expect_equal(foldChange(vec1, vec2), c(1, 2, -2))
+})

--- a/tests/testthat/test-geneselect.R
+++ b/tests/testthat/test-geneselect.R
@@ -1,0 +1,39 @@
+# selectVariableGenes()
+
+test_that("selectVariableGenes selects the indices of the most variable rows", {
+  mat <- matrix(
+    c(
+      1, 1, 1, 1, # no variance
+      1, 2, 3, 4, # some variance
+      1, 100, 1, 100, # highest variance
+      1, 1, 2, 1 # low variance
+    ),
+    nrow = 4, byrow = TRUE
+  )
+
+  expect_equal(selectVariableGenes(ntop = 1, matrix = mat), 3)
+  expect_equal(selectVariableGenes(ntop = 2, matrix = mat), c(3, 2))
+})
+
+test_that("selectVariableGenes caps ntop at the number of available rows", {
+  mat <- matrix(c(1, 2, 3, 4, 5, 6), nrow = 2, byrow = TRUE)
+
+  result <- selectVariableGenes(ntop = 10, matrix = mat)
+
+  expect_equal(sort(result), c(1, 2))
+})
+
+test_that("selectVariableGenes accepts precalculated row variances", {
+  row_variances <- c(gene1 = 0.1, gene2 = 5, gene3 = 1)
+
+  result <- selectVariableGenes(ntop = 2, row_variances = row_variances)
+
+  expect_equal(result, c(2, 3))
+})
+
+test_that("selectVariableGenes errors when neither matrix nor row_variances is supplied", {
+  expect_error(
+    selectVariableGenes(ntop = 2),
+    "a value must be provided for either matrix or row_variances"
+  )
+})

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -28,3 +28,50 @@ test_that("runPCA scales variables before running prcomp", {
   unscaled <- prcomp(t(as.matrix(logged)), scale. = FALSE)
   expect_false(isTRUE(all.equal(pca$sdev, unscaled$sdev)))
 })
+
+# compilePCAData()
+
+test_that("compilePCAData returns coordinates and percent variance for all genes when ntop is NULL", {
+  set.seed(1)
+  mat <- matrix(rexp(200, rate = .1), nrow = 20)
+  rownames(mat) <- paste0("gene", 1:20)
+  colnames(mat) <- paste0("sample", 1:10)
+
+  result <- compilePCAData(mat)
+
+  expect_true(is.data.frame(result$coords))
+  expect_equal(nrow(result$coords), ncol(mat))
+  expect_equal(ncol(result$coords), ncol(mat))
+  expect_equal(sum(result$percentVar), 100)
+})
+
+test_that("compilePCAData restricts the PCA to the ntop most variable genes", {
+  set.seed(1)
+  mat <- matrix(rexp(200, rate = .1), nrow = 20)
+  rownames(mat) <- paste0("gene", 1:20)
+  colnames(mat) <- paste0("sample", 1:10)
+
+  result <- compilePCAData(mat, ntop = 5)
+  full <- compilePCAData(mat)
+
+  # Using fewer genes changes the PCA result relative to using them all
+  expect_false(isTRUE(all.equal(result$coords, full$coords)))
+
+  # The selected genes should be exactly the 5 most variable ones
+  top5 <- selectVariableGenes(matrix = mat, ntop = 5)
+  expected <- compilePCAData(mat[top5, , drop = FALSE])
+  expect_equal(result$coords, expected$coords)
+})
+
+# calculatePCAFractionExplained()
+
+test_that("calculatePCAFractionExplained returns percentages that sum to 100", {
+  set.seed(1)
+  mat <- matrix(rnorm(40), nrow = 4)
+  pca <- prcomp(mat, scale. = TRUE)
+
+  fraction <- calculatePCAFractionExplained(pca)
+
+  expect_equal(sum(fraction), 100)
+  expect_equal(length(fraction), length(pca$sdev))
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for the pure functions named in #108: `compilePCAData`/`calculatePCAFractionExplained`, `selectVariableGenes`, `foldChange`, `makeColorScale`, `read_matrix`/`read_metadata`, `checkListIsSubset`, and expanded `read_contrasts` validation coverage (CSV parsing, duplicate IDs, blocking variables, full-rank checks, identical reference/target warning, exclude-samples pairing).
- Fixes two bugs surfaced while writing these tests:
  - `compilePCAData()` computed its `ntop` gene selection but never applied it before running PCA, silently no-opping the `--n_genes` option in `exec/exploratory_plots.R`.
  - `makeColorScale()` computed a subset for `ncolors < 3` but never assigned it back, so requesting 1 or 2 colors always returned 3.

Part of #108.

## Test plan
- [x] `devtools::test()` — full suite passes
- [x] Confirmed both new/changed tests fail against the pre-fix code (via `git stash` of the two one-line fixes) and pass with it
- [x] `lintr::lint_package()` shows no new lints on changed files