### PR TITLE
Add shinytest2 coverage for the rnaseq app, PCA, and heatmap; wire into CI

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -61,11 +61,15 @@ jobs:
           # Vignette-only Suggests (biomaRt, Gviz, DEXSeq, zhangneurons, devtools,
           # BiocStyle, rmarkdown, rsconnect) are skipped here: CI builds with
           # --no-build-vignettes / checks with --no-vignettes below, and
-          # _R_CHECK_FORCE_SUGGESTS_ is false, so they aren't needed. testthat and
-          # optparse are explicit since the "dependencies" restriction below would
-          # otherwise exclude them (they're only Suggests, not Imports).
-          extra-packages: any::rcmdcheck, any::testthat, any::optparse, local::.
+          # _R_CHECK_FORCE_SUGGESTS_ is false, so they aren't needed. testthat,
+          # optparse, withr and shinytest2 (which pulls in chromote) are explicit
+          # since the "dependencies" restriction below would otherwise exclude
+          # them (they're only Suggests, not Imports).
+          extra-packages: any::rcmdcheck, any::testthat, any::optparse, any::withr, any::shinytest2, local::.
           dependencies: 'c("Imports", "Depends", "LinkingTo")'
+
+      - name: Install Chrome for headless shinytest2 tests
+        uses: browser-actions/setup-chrome@v1
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Suggests:
     pkgdown,
     rmarkdown,
     rsconnect,
+    shinytest2,
     styler,
     testthat (>= 3.0.0),
     withr

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -141,7 +141,7 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
         # Restrict contrasts to those valid for the input matrix
 
         valid_contrasts <- unlist(lapply(contrasts, function(cont) {
-          all(c(cont["Group.1"], cont["Group.2"]) %in% coldata[[cont["Variable"]]])
+          all(c(cont[["Group.1"]], cont[["Group.2"]]) %in% coldata[[cont[["Variable"]]]])
         }))
         contrasts <- contrasts[valid_contrasts]
         contrast_numbers <- contrast_numbers[valid_contrasts]
@@ -382,7 +382,7 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
       contrasts <- getAllContrasts()
 
       lapply(contrasts, function(c) {
-        list(colnames(ese)[coldata[c["Variable"]] == c["Group.1"]], colnames(ese)[coldata[c["Variable"]] == c["Group.2"]])
+        list(colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.1"]]], colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.2"]]])
       })
     })
 
@@ -405,10 +405,10 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
         contrast_tables <- lapply(names(contrasts), function(c) {
           cont <- contrasts[[c]]
 
-          smry1 <- summaries[[cont["Variable"]]][, cont["Group.1"]]
-          smry2 <- summaries[[cont["Variable"]]][, cont["Group.2"]]
+          smry1 <- summaries[[cont[["Variable"]]]][, cont[["Group.1"]]]
+          smry2 <- summaries[[cont[["Variable"]]]][, cont[["Group.2"]]]
 
-          ct <- data.frame(cont["Variable"], cont["Group.1"], cont["Group.2"], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
+          ct <- data.frame(cont[["Variable"]], cont[["Group.1"]], cont[["Group.2"]], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
           names(ct) <- c("Variable", "Condition 1", "Condition 2", "Average 1", "Average 2")
 
           # Use pre-computed fold changes where provided.

--- a/tests/testthat/helper-shinytest2.R
+++ b/tests/testthat/helper-shinytest2.R
@@ -1,0 +1,85 @@
+# shinytest2_eselist()
+#
+# A small synthetic ExploratorySummarizedExperimentList with contrasts and
+# contrast_stats populated, so PCA/heatmap/differential-table paths all have
+# something to render. Built once per test session and cached.
+
+shinytest2_eselist <- local({
+  eselist <- NULL
+  function() {
+    if (is.null(eselist)) {
+      set.seed(42)
+
+      n_genes <- 60
+      n_samples <- 12
+
+      counts <- matrix(
+        stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+        nrow = n_genes, ncol = n_samples
+      )
+      rownames(counts) <- paste0("gene", seq_len(n_genes))
+      colnames(counts) <- paste0("sample", seq_len(n_samples))
+
+      coldata <- S4Vectors::DataFrame(
+        row.names = colnames(counts),
+        condition = rep(c("control", "treated"), each = n_samples / 2),
+        batch = rep(c("batch1", "batch2"), times = n_samples / 2)
+      )
+
+      annotation <- data.frame(
+        gene_id = rownames(counts),
+        gene_name = paste0("Gene", seq_len(n_genes)),
+        row.names = rownames(counts)
+      )
+
+      pvals <- matrix(stats::runif(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+      qvals <- matrix(stats::p.adjust(pvals[, 1], method = "BH"), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+      fold_changes <- matrix(stats::rnorm(n_genes, sd = 2), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+
+      ese <- ExploratorySummarizedExperiment(
+        assays = S4Vectors::SimpleList(counts = counts),
+        colData = coldata,
+        annotation = annotation,
+        idfield = "gene_id",
+        labelfield = "gene_name",
+        contrast_stats = list(counts = list(pvals = pvals, qvals = qvals, fold_changes = fold_changes))
+      )
+
+      new_eselist <- ExploratorySummarizedExperimentList(
+        eses = list(counts = ese),
+        title = "shinytest2 smoke test study",
+        author = "shinytest2",
+        description = "Synthetic dataset for shinytest2 smoke tests",
+        group_vars = c("condition", "batch"),
+        default_groupvar = "condition"
+      )
+      new_eselist@contrasts <- list(
+        list(id = "condition_control_treated", Variable = "condition", Group.1 = "control", Group.2 = "treated")
+      )
+
+      eselist <<- new_eselist
+    }
+    eselist
+  }
+})
+
+# shinytest2_app_driver()
+#
+# Launch a shinytest2::AppDriver for a prepareApp() type against the shared
+# synthetic dataset, skipping the test if no headless Chrome is available.
+
+shinytest2_app_driver <- function(type, name, ...) {
+  testthat::skip_if_not_installed("shinytest2")
+  testthat::skip_if(
+    is.na(tryCatch(chromote::find_chrome(), error = function(e) NA)),
+    "No Chrome/Chromium binary found for headless testing"
+  )
+
+  app <- prepareApp(type, shinytest2_eselist())
+  shinytest2::AppDriver$new(
+    shiny::shinyApp(ui = app$ui, server = app$server),
+    name = name,
+    height = 900, width = 1400, seed = 42, load_timeout = 60000,
+    ...
+  )
+}

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -1,0 +1,77 @@
+# The full rnaseq app
+
+test_that("the rnaseq app boots and shows its home tab", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("rnaseq", "rnaseq-boot")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+
+  expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
+})
+
+# pca module (exercises selectmatrix internally)
+
+test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("rnaseq", "rnaseq-pca")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+  app$set_inputs(`rnaseq-rnaseq` = "pca")
+  app$wait_for_idle(timeout = 20000)
+
+  outputs <- names(app$get_values()$output)
+  expect_true("rnaseq-pca-pca-scatter" %in% outputs)
+  expect_true("rnaseq-pca-components-datatable" %in% outputs)
+  expect_true("rnaseq-pca-pca-selectmatrix-geneSelect" %in% outputs)
+})
+
+# heatmap module
+
+test_that("the Clustering Heatmap tab renders an interactive heatmap", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("rnaseq", "rnaseq-heatmap")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+  app$set_inputs(`rnaseq-rnaseq` = "Clustering Heatmap")
+  app$wait_for_idle(timeout = 20000)
+
+  outputs <- names(app$get_values()$output)
+  expect_true("rnaseq-heatmap-clustering-interactiveHeatmap" %in% outputs)
+  expect_true("rnaseq-heatmap-clustering-heatmap-selectmatrix-geneSelect" %in% outputs)
+})
+
+# selectmatrix + contrasts modules, as composed by differentialtable()
+#
+# Driven via shiny::testServer() rather than AppDriver: the differential
+# table tab's contrast filter is inserted client-side via insertUI(), and
+# reliably reproducing that DOM insertion under headless chromote (including
+# its selectize.js-backed dropdown) needs more investigation than this PR's
+# scope covers. testServer exercises the same server-side reactive graph
+# directly and deterministically.
+
+test_that("differentialtable computes a table without error given a real contrast", {
+  skip_on_cran()
+
+  eselist <- shinytest2_eselist()
+
+  shiny::testServer(differentialtable, args = list(id = "differential", eselist = eselist), {
+    session$setInputs(
+      "expression-assay" = "counts",
+      "expression-experiment" = "counts",
+      "expression-selectmatrix-obs" = 60,
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    Sys.sleep(0.5)
+
+    rendered <- output$differentialtable
+    expect_type(rendered, "list")
+    expect_match(rendered[[1]], "Differential expression in assay: counts")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `shinytest2::AppDriver`-based smoke tests for: the full `rnaseq` app booting to its home tab, the PCA tab (which exercises `selectmatrix` internally), and the Clustering Heatmap tab — run against a small synthetic `ExploratorySummarizedExperimentList` built directly via the class constructors (no external test-data dependency).
- Wires `shinytest2`/`chromote` and a headless Chrome install (`browser-actions/setup-chrome`) into `check-release.yaml` so these run in CI.
- Covers `selectmatrix`/`contrasts` module logic via a `shiny::testServer()`-based test on `differentialtable()` rather than full `AppDriver` end-to-end testing of the Differential-menu tabs — see below.
- Fixes two real bugs in `contrasts()` (`R/contrasts.R`) found while building this coverage: several places subset a contrast's named list with a single bracket (e.g. `cont["Variable"]`) where the scalar value is needed. This throws inside the `observeEvent()` that inserts the contrast filter row via `insertUI()`, but the error is silent in a live session — so the filter row, and everything downstream (differential tables, fold change/MA/volcano plots), never appeared. Confirmed via `shiny::testServer()` that the fix resolves it, and the new test fails against the pre-fix code.

While tracking this down I found a second, separate issue: even after the fix, navigating to a Differential-menu tab via a real `AppDriver` click still leaves its content empty indefinitely, while PCA/Heatmap render fine under the same conditions. I couldn't fully root-cause this (ruled out several hypotheses — see the issue for details) so I've filed it as #147 for follow-up, and used `testServer()` for the contrasts/selectmatrix coverage in the meantime rather than block this PR on it.

Closes #108. Follow-up tracked in #147.

## Test plan
- [x] `devtools::test()` (`NOT_CRAN=true`) — full suite passes, including 3 real headless-Chrome sessions (~40s total)
- [x] Confirmed the new `differentialtable` regression test fails against the pre-fix `contrasts.R` (via `git stash`) with the exact `invalid subscript type 'list'` error, and passes with the fix
- [x] `lintr::lint_package()` shows no new lints on changed/added files