### PR TITLE
Fix summarytiles example hanging pkgdown's reference build

### DIFF
--- a/R/summarytiles.R
+++ b/R/summarytiles.R
@@ -20,13 +20,15 @@
 #' @keywords shiny
 #'
 #' @examples
-#' summarytilesInput("summary", eselist)
+#' if (interactive()) {
+#'   data(zhangneurons)
+#'   summarytilesInput("summary", zhangneurons)
 #'
-#' # Almost certainly used via application creation
+#'   # Almost certainly used via application creation
 #'
-#' data(zhangneurons)
-#' app <- prepareApp("summarytiles", zhangneurons)
-#' shiny::shinyApp(ui = app$ui, server = app$server)
+#'   app <- prepareApp("summarytiles", zhangneurons)
+#'   shiny::shinyApp(ui = app$ui, server = app$server)
+#' }
 #'
 summarytilesInput <- function(id, eselist) {
   ns <- NS(id)
@@ -49,13 +51,15 @@ summarytilesInput <- function(id, eselist) {
 #' @keywords shiny
 #'
 #' @examples
-#' summarytilesOutput("summary")
+#' if (interactive()) {
+#'   summarytilesOutput("summary")
 #'
-#' # Almost certainly used via application creation
+#'   # Almost certainly used via application creation
 #'
-#' data(zhangneurons)
-#' app <- prepareApp("summarytiles", zhangneurons)
-#' shiny::shinyApp(ui = app$ui, server = app$server)
+#'   data(zhangneurons)
+#'   app <- prepareApp("summarytiles", zhangneurons)
+#'   shiny::shinyApp(ui = app$ui, server = app$server)
+#' }
 #'
 summarytilesOutput <- function(id) {
   ns <- NS(id)
@@ -79,13 +83,15 @@ summarytilesOutput <- function(id) {
 #' @keywords shiny
 #'
 #' @examples
-#' summarytiles("summary", eselist)
+#' if (interactive()) {
+#'   data(zhangneurons)
+#'   summarytiles("summary", zhangneurons)
 #'
-#' # Almost certainly used via application creation
+#'   # Almost certainly used via application creation
 #'
-#' data(zhangneurons)
-#' app <- prepareApp("summarytiles", zhangneurons)
-#' shiny::shinyApp(ui = app$ui, server = app$server)
+#'   app <- prepareApp("summarytiles", zhangneurons)
+#'   shiny::shinyApp(ui = app$ui, server = app$server)
+#' }
 #'
 summarytiles <- function(id, eselist) {
   moduleServer(id, function(input, output, session) {

--- a/man/summarytiles.Rd
+++ b/man/summarytiles.Rd
@@ -22,13 +22,15 @@ optional content (contrasts, gene sets) are only shown when that content is
 present.
 }
 \examples{
-summarytiles("summary", eselist)
+if (interactive()) {
+  data(zhangneurons)
+  summarytiles("summary", zhangneurons)
 
-# Almost certainly used via application creation
+  # Almost certainly used via application creation
 
-data(zhangneurons)
-app <- prepareApp("summarytiles", zhangneurons)
-shiny::shinyApp(ui = app$ui, server = app$server)
+  app <- prepareApp("summarytiles", zhangneurons)
+  shiny::shinyApp(ui = app$ui, server = app$server)
+}
 
 }
 \keyword{shiny}

--- a/man/summarytilesInput.Rd
+++ b/man/summarytilesInput.Rd
@@ -29,13 +29,15 @@ module is run standalone; in a full application the tiles are placed in a
 main panel via \code{summarytilesOutput()}.
 }
 \examples{
-summarytilesInput("summary", eselist)
+if (interactive()) {
+  data(zhangneurons)
+  summarytilesInput("summary", zhangneurons)
 
-# Almost certainly used via application creation
+  # Almost certainly used via application creation
 
-data(zhangneurons)
-app <- prepareApp("summarytiles", zhangneurons)
-shiny::shinyApp(ui = app$ui, server = app$server)
+  app <- prepareApp("summarytiles", zhangneurons)
+  shiny::shinyApp(ui = app$ui, server = app$server)
+}
 
 }
 \keyword{shiny}

--- a/man/summarytilesOutput.Rd
+++ b/man/summarytilesOutput.Rd
@@ -21,13 +21,15 @@ are rendered server-side from the supplied
 the placeholder into which they are drawn.
 }
 \examples{
-summarytilesOutput("summary")
+if (interactive()) {
+  summarytilesOutput("summary")
 
-# Almost certainly used via application creation
+  # Almost certainly used via application creation
 
-data(zhangneurons)
-app <- prepareApp("summarytiles", zhangneurons)
-shiny::shinyApp(ui = app$ui, server = app$server)
+  data(zhangneurons)
+  app <- prepareApp("summarytiles", zhangneurons)
+  shiny::shinyApp(ui = app$ui, server = app$server)
+}
 
 }
 \keyword{shiny}


### PR DESCRIPTION
## Summary

- `summarytilesInput`, `summarytilesOutput`, and `summarytiles` in `R/summarytiles.R` had `@examples` blocks that called `shiny::shinyApp(ui = app$ui, server = app$server)` without the `if (interactive())` guard every other module in this package uses for the same pattern.
- A bare `shinyApp()` call at the top level auto-prints, which calls `runApp()` and blocks indefinitely. `R-CMD-check` never caught this because it runs with `--no-examples`, but pkgdown's reference-build step always executes `@examples`, so every `pkgdown.yaml` run since #141 merged has hung until manually cancelled, never reaching the deploy step.
- Also fixed `summarytilesInput`/`summarytiles`'s examples referencing an undefined `eselist` instead of the `zhangneurons` object actually loaded a few lines later.
- Regenerated the three affected `man/*.Rd` files via `roxygen2::roxygenise()`.

## Test plan

- [x] `tools::Rd2ex()` + `source()` on the fixed `summarytilesInput.Rd` example confirms it now completes instantly under `Rscript` (non-interactive) instead of hanging
- [x] `git diff` confirms only the intended 3 `R`/`man` files changed, no roxygen version drift in unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)