### PR TITLE
Wire test coverage reporting into CI

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -62,10 +62,10 @@ jobs:
           # BiocStyle, rmarkdown, rsconnect) are skipped here: CI builds with
           # --no-build-vignettes / checks with --no-vignettes below, and
           # _R_CHECK_FORCE_SUGGESTS_ is false, so they aren't needed. testthat,
-          # optparse, withr and shinytest2 (which pulls in chromote) are explicit
-          # since the "dependencies" restriction below would otherwise exclude
-          # them (they're only Suggests, not Imports).
-          extra-packages: any::rcmdcheck, any::testthat, any::optparse, any::withr, any::shinytest2, local::.
+          # optparse, withr, shinytest2 (which pulls in chromote) and covr are
+          # explicit since the "dependencies" restriction below would otherwise
+          # exclude them (they're only Suggests, not Imports).
+          extra-packages: any::rcmdcheck, any::testthat, any::optparse, any::withr, any::shinytest2, any::covr, local::.
           dependencies: 'c("Imports", "Depends", "LinkingTo")'
 
       - name: Install Chrome for headless shinytest2 tests
@@ -76,6 +76,32 @@ jobs:
           error-on: '"error"'
           args: 'c("--no-manual", "--as-cran", "--no-examples", "--no-vignettes")'
           build_args: 'c("--no-manual", "--no-build-vignettes")'
+
+      - name: Report test coverage
+        # Reporting only: a flaky covr instrumentation run shouldn't fail a PR
+        # that R-CMD-check has already passed on its own.
+        continue-on-error: true
+        run: |
+          Rscript -e '
+            cov <- covr::package_coverage(quiet = FALSE)
+            print(cov)
+
+            overall <- covr::percent_coverage(cov)
+            tallied <- covr::tally_coverage(cov, by = "line")
+            per_file <- aggregate(value ~ filename, data = tallied, FUN = function(v) round(100 * mean(v > 0), 1))
+            per_file <- per_file[order(per_file$value), ]
+
+            summary_lines <- c(
+              sprintf("## Test coverage: %.1f%%", overall),
+              "",
+              "| File | Coverage |",
+              "| --- | --- |",
+              sprintf("| %s | %.1f%% |", per_file$filename, per_file$value)
+            )
+            summary_md <- paste(summary_lines, collapse = "\n")
+            cat(summary_md, "\n", file = Sys.getenv("GITHUB_STEP_SUMMARY"), append = TRUE)
+            cat(summary_md, "\n")
+          '
 
       - name: Download test data from nf-core tests data repo
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     BiocStyle,
     BiocManager,
     biomaRt,
+    covr,
     devtools,
     DEXSeq,
     Gviz,


### PR DESCRIPTION
## Summary
- Adds a `covr`-based coverage step to `check-release.yaml`, run right after `R CMD check` in the same job so it reuses the dependencies already set up earlier (Rhtslib preinstall, headless Chrome for the shinytest2 tests) rather than duplicating that setup in a separate workflow.
- Reports overall and per-file line coverage as a GitHub Actions job summary (and to the log), sorted worst-file-first so gaps are easy to spot.
- No external service — no Codecov account/token, no badge. Purely local-to-the-run reporting, per discussion on #108 (this was explicitly the lightest of three options considered: tokenless Codecov, token-based Codecov, or a local summary — local summary was chosen).
- The step is `continue-on-error: true` since it's reporting only; `R CMD check` already gates correctness, so a flaky covr instrumentation run shouldn't block a PR.

Ran locally against the current test suite for a sanity check: 53.7% overall, with several still-untested modules (`barplot.R`, `chipseq.R`, `dexseqplot.R`, `dexseqtable.R`, `illuminaarray.R`, `illuminaarrayqc.R`, `plotdownload.R`, `readreports.R`, `upset.R` all at 0%) — a genuinely useful signal matching the "module server logic... effectively untested" problem #108 set out to address, and a natural worklist for further coverage PRs.

Closes #108 — the last of its four proposal items (unit tests #143, exec smoke tests #146, shinytest2 #148, coverage reporting here).

## Test plan
- [x] Ran the exact coverage script locally against the full test suite (`covr::package_coverage()` + summary generation) — completes successfully, produces the expected table
- [x] Validated the workflow YAML parses correctly