### PR TITLE
Restore zhangneurons as a Suggests/Remotes dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,10 @@ Suggests:
     shinytest2,
     styler,
     testthat (>= 3.0.0),
-    withr
+    withr,
+    zhangneurons
+Remotes:
+    pinin4fjords/zhangneurons
 biocViews: Software
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr


### PR DESCRIPTION
## Summary

- #133 dropped `zhangneurons` (and its `Remotes: pinin4fjords/zhangneurons` entry) from `DESCRIPTION` when it rewrote the roxygen `@examples` to use `airway` instead, so the package's own examples no longer needed it.
- But `vignettes/shinyngs.Rmd` still does `library(zhangneurons)` unconditionally and builds most of its "Building an application from scratch" walkthrough around that package's example dataset.
- Without the dependency declared, any full `R CMD check` (with vignettes) or pkgdown build fails at the vignette step with `there is no package called 'zhangneurons'`. This is what's been failing every `pkgdown.yaml` run since #133 merged (after the earlier `summarytiles` example hang was fixed in #149).

## Test plan

- [x] `read.dcf("DESCRIPTION")` confirms `Suggests`/`Remotes` parse correctly with the restored entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)