### PR TITLE
Bump actions/checkout to v4 across all workflows

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -23,7 +23,7 @@ jobs:
       TREATMENT_LEVEL: "hND6"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.R_CI }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/vignette.yaml
+++ b/.github/workflows/vignette.yaml
@@ -15,7 +15,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v2` -> `@v4` in `check-release.yaml`, `lint.yaml`, `pkgdown.yaml`, and `vignette.yaml`, removing the last deprecated-Node-16 action in CI.

Closes #111. The other parts of #111 are already in place on `develop`: `lint.yaml` runs lintr, and `check-release.yaml` already reports `covr` coverage to the job summary. Per discussion on the issue, an R/OS test matrix and a real Codecov upload are being deferred (matrix adds meaningful CI time/flakiness for this package's Bioconductor system deps; Codecov needs a codecov.io account + `CODECOV_TOKEN` secret that only the repo owner can set up).

## Test plan
- [ ] CI passes on this PR (R-CMD-check, lint)