### PR TITLE
Design tokens, dark mode and theme-aware tables/plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ BugReports: https://github.com/pinin4fjords/shinyngs/issues
 Encoding: UTF-8
 LazyData: true
 Imports:
-    bslib,
+    bslib (>= 0.9.0),
     cluster,
     cpp11,
     data.table,

--- a/R/accessory.R
+++ b/R/accessory.R
@@ -194,8 +194,10 @@ pushToList <- function(input_list, element) {
 #' Build the top-level bslib page shell shared by the app modules
 #'
 #' Applies the package's Bootstrap 5 theme and dark navbar styling, injects
-#' the package CSS and shinyjs, and constructs the resulting
-#' \code{bslib::page_navbar()}.
+#' the package CSS/JS and shinyjs, adds a light/dark mode toggle to the
+#' navbar, and constructs the resulting \code{bslib::page_navbar()}. The
+#' accent colour is defined once here, on the theme, and everything else
+#' (CSS, plots) derives from the resulting Bootstrap variables.
 #'
 #' @param navbar_menus A named list of arguments accepted by
 #' \code{bslib::page_navbar()} (\code{id}, \code{title}, \code{window_title},
@@ -208,9 +210,22 @@ pushToList <- function(input_list, element) {
 #'
 shinyngsPageNavbar <- function(navbar_menus) {
   cssfile <- system.file("www", paste0(packageName(), ".css"), package = packageName())
-  navbar_menus$theme <- bslib::bs_theme(version = 5, bootswatch = "cosmo")
+  jsfile <- system.file("www", paste0(packageName(), ".js"), package = packageName())
+  navbar_menus$theme <- bslib::bs_theme(version = 5, bootswatch = "cosmo", primary = "#2780e3")
   navbar_menus$navbar_options <- bslib::navbar_options(bg = "dark", theme = "dark")
-  navbar_menus$header <- tagList(includeCSS(cssfile), shinyjs::useShinyjs())
+
+  # Resolve the light/dark theme in <head> before first paint. input_dark_mode
+  # only sets data-bs-theme once its web component hydrates, so a dark-resolved
+  # load (dark OS scheme) would otherwise paint the default light theme for a
+  # frame or two first, flashing white (most visibly across large plots).
+  no_flash <- tags$head(tags$script(HTML(
+    "(function(){try{var d=document.documentElement;if(!d.getAttribute('data-bs-theme')){var m=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;d.setAttribute('data-bs-theme',m?'dark':'light');}}catch(e){}})();"
+  )))
+  navbar_menus$header <- tagList(no_flash, includeCSS(cssfile), includeScript(jsfile), shinyjs::useShinyjs())
+  navbar_menus <- c(navbar_menus, list(
+    bslib::nav_spacer(),
+    bslib::nav_item(bslib::input_dark_mode(id = "shinyngs_dark_mode"))
+  ))
   do.call(bslib::page_navbar, navbar_menus)
 }
 

--- a/inst/www/shinyngs.css
+++ b/inst/www/shinyngs.css
@@ -1,5 +1,5 @@
 .tab-pane .tab-pane{
-  margin-top:1em; 
+  margin-top:1em;
 }
 
 .navbar-brand{
@@ -47,13 +47,13 @@
    and consistent with each other regardless of open/collapsed state. */
 .accordion-button,
 .accordion-button:not(.collapsed){
-  background-color: #f5f5f5;
-  color: #333333;
+  background-color: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
   box-shadow: none;
 }
 .accordion-button:focus{
   box-shadow: none;
-  border-color: rgba(0, 0, 0, .125);
+  border-color: var(--bs-border-color);
 }
 
 .well{
@@ -65,7 +65,7 @@ h3{
 }
 
 .helptrigger{
-  padding:0 .5em 0 0; 
+  padding:0 .5em 0 0;
   font-size: large;
   float:left;
 }
@@ -86,7 +86,7 @@ h3{
 }
 
 .dataTables_wrapper{
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 /* DT's own bundled CSS (jquery.dataTables.min.css) sets a flat 4px padding
@@ -98,13 +98,54 @@ h3{
   padding-right: 2.25rem;
 }
 
+/* DataTables ships fixed light-theme text/border/stripe colours that do not
+   follow Bootstrap's data-bs-theme, so tables render dark-on-dark (unreadable)
+   in dark mode. Map them onto theme variables. Selectors are scoped under
+   .dataTables_wrapper so they outrank DataTables' own rules on specificity
+   without !important, and the (already theme-correct) pagination is left
+   untouched so the active-page button keeps its contrasting text. */
+.dataTables_wrapper{
+  color: var(--bs-body-color);
+}
+.dataTables_wrapper table.dataTable,
+.dataTables_wrapper table.dataTable thead th,
+.dataTables_wrapper table.dataTable thead td,
+.dataTables_wrapper table.dataTable tbody th,
+.dataTables_wrapper table.dataTable tbody td,
+.dataTables_wrapper table.dataTable tfoot th,
+.dataTables_wrapper table.dataTable tfoot td{
+  color: var(--bs-body-color);
+  border-color: var(--bs-border-color);
+}
+.dataTables_wrapper table.dataTable tbody tr:nth-of-type(odd){
+  background-color: rgba(var(--bs-emphasis-color-rgb), 0.04);
+}
+.dataTables_wrapper table.dataTable tbody tr:hover{
+  background-color: rgba(var(--bs-emphasis-color-rgb), 0.075);
+}
+.dataTables_wrapper .dataTables_filter input,
+.dataTables_wrapper .dataTables_length select{
+  color: var(--bs-body-color);
+  background-color: var(--bs-body-bg);
+  border-color: var(--bs-border-color);
+}
+
+/* Plotly paints its paper/plot background opaque white on first render,
+   before the theming hook (shinyngs.js) relayouts it to transparent, which
+   flashes white in dark mode. Force the SVG background rects transparent from
+   first paint (author !important beats plotly's inline style) so the page
+   colour shows through immediately; the hook still handles text/axis colours. */
+.js-plotly-plot rect.bg{
+  fill: transparent !important;
+}
+
 /* Contrast field sets */
 
 .shinyngs-and{
   text-align: center;
-  background-color:#F5F5F5;
-  border-color:#DDDDDD;
-  color:#333333;
+  background-color: var(--bs-tertiary-bg);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
 }
 
 .shinyngs-cardinalfield .row div:nth-child(2){
@@ -114,7 +155,7 @@ h3{
 
 .shinyngs-cardinalfield .row div:nth-child(3) input{
   padding:0 6px;
-} 
+}
 
 .shinyngs-cardinalfield .row div:nth-child(2) .selectize-input,
 .shinyngs-cardinalfield .row div:nth-child(3) input{
@@ -126,12 +167,12 @@ h3{
 
 .shinyngs-home { padding-top: 0.5em; }
 .shinyngs-study-title { font-weight: 700; text-wrap: balance; }
-.shinyngs-study-author { color: #7b8794; font-weight: 400; margin-top: 0.25em; }
-.shinyngs-eyebrow { font-size: 11px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: #7b8794; margin: 0 0 10px; }
-.shinyngs-muted { color: #7b8794; }
+.shinyngs-study-author { color: var(--bs-secondary-color); font-weight: 400; margin-top: 0.25em; }
+.shinyngs-eyebrow { font-size: 11px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--bs-secondary-color); margin: 0 0 10px; }
+.shinyngs-muted { color: var(--bs-secondary-color); }
 
 /* Overview panel grouping the tiles + drawer into one unit */
-.shinyngs-overview { background: #f4f6f8; border: 1px solid #e2e7ec; border-radius: 8px; padding: 18px 20px; margin: 18px 0 6px; }
+.shinyngs-overview { background: var(--bs-tertiary-bg); border: 1px solid var(--bs-border-color); border-radius: 8px; padding: 18px 20px; margin: 18px 0 6px; }
 
 /* Tile clusters, stacked (data then analysis), not side-by-side */
 .shinyngs-clusters { display: flex; flex-direction: column; gap: 16px; }
@@ -144,55 +185,55 @@ h3{
   align-items: flex-start;
   gap: 11px;
   padding: 14px 15px;
-  background-color: #ffffff;
-  border: 1px solid #dfe4e8;
+  background-color: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
   border-radius: 7px;
-  color: #2c3e50;
+  color: var(--bs-body-color);
   text-decoration: none;
   cursor: pointer;
   transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease;
 }
-.shinyngs-tile:hover { transform: translateY(-2px); box-shadow: 0 4px 14px rgba(0,0,0,.09); border-color: #2780e3; text-decoration: none; color: #2c3e50; }
-.shinyngs-tile:focus-visible { outline: 2px solid #2780e3; outline-offset: 2px; }
-.shinyngs-tile.active { border-color: #2780e3; box-shadow: inset 0 0 0 1px #2780e3; }
+.shinyngs-tile:hover { transform: translateY(-2px); box-shadow: 0 4px 14px rgba(0,0,0,.09); border-color: var(--bs-primary); text-decoration: none; color: var(--bs-body-color); }
+.shinyngs-tile:focus-visible { outline: 2px solid var(--bs-primary); outline-offset: 2px; }
+.shinyngs-tile.active { border-color: var(--bs-primary); box-shadow: inset 0 0 0 1px var(--bs-primary); }
 
-.shinyngs-tile-icon { color: #2780e3; font-size: 20px; flex: 0 0 auto; margin-top: 2px; }
+.shinyngs-tile-icon { color: var(--bs-primary); font-size: 20px; flex: 0 0 auto; margin-top: 2px; }
 .shinyngs-tile-body { min-width: 0; flex: 1; padding-right: 16px; }
-.shinyngs-tile-value { display: block; font-size: 26px; font-weight: 700; line-height: 1.05; color: #1c2833; font-variant-numeric: tabular-nums; }
-.shinyngs-tile-label { display: block; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; color: #7b8794; margin-top: 3px; }
-.shinyngs-tile-chev { position: absolute; top: 12px; right: 12px; color: #9aa7b2; font-size: 12px; transition: transform .15s ease; }
-.shinyngs-tile:hover .shinyngs-tile-chev { color: #2780e3; }
-.shinyngs-tile.active .shinyngs-tile-chev { transform: rotate(180deg); color: #2780e3; }
+.shinyngs-tile-value { display: block; font-size: 26px; font-weight: 700; line-height: 1.05; color: var(--bs-emphasis-color); font-variant-numeric: tabular-nums; }
+.shinyngs-tile-label { display: block; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; color: var(--bs-secondary-color); margin-top: 3px; }
+.shinyngs-tile-chev { position: absolute; top: 12px; right: 12px; color: var(--bs-secondary-color); font-size: 12px; transition: transform .15s ease; }
+.shinyngs-tile:hover .shinyngs-tile-chev { color: var(--bs-primary); }
+.shinyngs-tile.active .shinyngs-tile-chev { transform: rotate(180deg); color: var(--bs-primary); }
 
 /* Detail drawer */
-.shinyngs-drawer { margin: 14px 0 2px; border: 1px solid #dfe4e8; background: #ffffff; border-radius: 7px; }
+.shinyngs-drawer { margin: 14px 0 2px; border: 1px solid var(--bs-border-color); background: var(--bs-body-bg); border-radius: 7px; }
 .shinyngs-drawer-in { padding: 18px 20px; animation: shinyngs-fade .18s ease; }
 @keyframes shinyngs-fade { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
 .shinyngs-drawer-head { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 13px; flex-wrap: wrap; }
-.shinyngs-drawer-title { font-size: 15px; font-weight: 700; color: #1c2833; margin: 0; }
-.shinyngs-drawer-title span { color: #7b8794; font-weight: 400; }
-.shinyngs-goto { font-size: 13.5px; font-weight: 600; color: #2780e3; white-space: nowrap; }
+.shinyngs-drawer-title { font-size: 15px; font-weight: 700; color: var(--bs-emphasis-color); margin: 0; }
+.shinyngs-drawer-title span { color: var(--bs-secondary-color); font-weight: 400; }
+.shinyngs-goto { font-size: 13.5px; font-weight: 600; color: var(--bs-primary); white-space: nowrap; }
 
 /* Bar breakdown */
 .shinyngs-bars { display: flex; flex-direction: column; gap: 7px; max-width: 560px; }
 .shinyngs-bar-row { display: grid; grid-template-columns: 160px 1fr 34px; align-items: center; gap: 10px; font-size: 13px; }
-.shinyngs-bar-name { color: #2c3e50; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.shinyngs-bar-track { background: #dfe4e8; border-radius: 4px; height: 12px; }
-.shinyngs-bar-fill { display: block; background: #2780e3; height: 12px; border-radius: 4px; min-width: 4px; }
-.shinyngs-bar-val { text-align: right; color: #7b8794; font-variant-numeric: tabular-nums; }
+.shinyngs-bar-name { color: var(--bs-body-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.shinyngs-bar-track { background: var(--bs-border-color); border-radius: 4px; height: 12px; }
+.shinyngs-bar-fill { display: block; background: var(--bs-primary); height: 12px; border-radius: 4px; min-width: 4px; }
+.shinyngs-bar-val { text-align: right; color: var(--bs-secondary-color); font-variant-numeric: tabular-nums; }
 
 /* Key-value lists, pills and contrast table */
 .shinyngs-kv { display: grid; grid-template-columns: max-content 1fr; gap: 6px 18px; font-size: 13.5px; max-width: 640px; margin: 0; }
-.shinyngs-kv dt { color: #1c2833; font-weight: 600; }
-.shinyngs-kv dd { margin: 0; color: #7b8794; }
+.shinyngs-kv dt { color: var(--bs-emphasis-color); font-weight: 600; }
+.shinyngs-kv dd { margin: 0; color: var(--bs-secondary-color); }
 .shinyngs-pills { display: flex; flex-wrap: wrap; gap: 8px; }
-.shinyngs-pill { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 9px; border-radius: 20px; background: #e9f1fb; color: #2780e3; margin-left: 6px; }
+.shinyngs-pill { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 9px; border-radius: 20px; background: rgba(var(--bs-primary-rgb), .12); color: var(--bs-primary); margin-left: 6px; }
 .shinyngs-kv dt .shinyngs-pill { vertical-align: middle; }
 .shinyngs-ctable { border-collapse: collapse; font-size: 13px; width: 100%; max-width: 640px; }
-.shinyngs-ctable th { text-align: left; font-size: 11px; letter-spacing: .05em; text-transform: uppercase; color: #7b8794; font-weight: 700; padding: 0 16px 7px 0; border-bottom: 1px solid #dfe4e8; }
-.shinyngs-ctable td { padding: 6px 16px 6px 0; border-bottom: 1px solid #dfe4e8; color: #2c3e50; }
+.shinyngs-ctable th { text-align: left; font-size: 11px; letter-spacing: .05em; text-transform: uppercase; color: var(--bs-secondary-color); font-weight: 700; padding: 0 16px 7px 0; border-bottom: 1px solid var(--bs-border-color); }
+.shinyngs-ctable td { padding: 6px 16px 6px 0; border-bottom: 1px solid var(--bs-border-color); color: var(--bs-body-color); }
 .shinyngs-ctable tr:last-child td { border-bottom: 0; }
-.shinyngs-avail { color: #2e9e57; font-weight: 600; }
+.shinyngs-avail { color: var(--bs-success); font-weight: 600; }
 
 /* Description: flows in newspaper columns to fill the width below the tiles */
 .shinyngs-desc { margin-top: 26px; }
@@ -201,13 +242,13 @@ h3{
 @media (max-width: 767px) { .shinyngs-desc-body { column-count: 1; } }
 
 /* Sidebar: jump-to-analysis links + interface note (sits inside the sidebar well) */
-.shinyngs-jump a { display: flex; align-items: center; gap: 9px; padding: 8px 0; color: #2c3e50; text-decoration: none; font-size: 14px; border-bottom: 1px solid #e0e0e0; }
+.shinyngs-jump a { display: flex; align-items: center; gap: 9px; padding: 8px 0; color: var(--bs-body-color); text-decoration: none; font-size: 14px; border-bottom: 1px solid var(--bs-border-color); }
 .shinyngs-jump a:last-child { border-bottom: 0; }
-.shinyngs-jump a:hover { color: #2780e3; text-decoration: none; }
-.shinyngs-jump a .fa, .shinyngs-jump a svg { color: #2780e3; width: 15px; text-align: center; }
-.shinyngs-aside-note { margin-top: 16px; padding-top: 14px; border-top: 1px solid #e0e0e0; font-size: 12.5px; color: #8a97a3; line-height: 1.55; }
+.shinyngs-jump a:hover { color: var(--bs-primary); text-decoration: none; }
+.shinyngs-jump a .fa, .shinyngs-jump a svg { color: var(--bs-primary); width: 15px; text-align: center; }
+.shinyngs-aside-note { margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--bs-border-color); font-size: 12.5px; color: var(--bs-secondary-color); line-height: 1.55; }
 .shinyngs-aside-note p { margin: 0 0 8px; }
-.shinyngs-aside-note a { color: #6a7a88; }
+.shinyngs-aside-note a { color: var(--bs-secondary-color); }
 
 @media (prefers-reduced-motion: reduce) {
   .shinyngs-tile, .shinyngs-tile-chev { transition: none; }

--- a/inst/www/shinyngs.js
+++ b/inst/www/shinyngs.js
@@ -1,0 +1,72 @@
+// Keep plotly charts in step with the active Bootstrap light/dark theme.
+//
+// The charts are created by many independent modules with their own layouts,
+// so rather than thread the current theme through every renderPlotly() this
+// restyles them from the client: backgrounds are made transparent (the card
+// or page background shows through) and text/axis/grid colours are read from
+// the live Bootstrap CSS variables, which flip when the navbar's light/dark
+// toggle changes data-bs-theme on <html>.
+
+(function () {
+  function themeColors() {
+    var s = getComputedStyle(document.body);
+    return {
+      fg: s.getPropertyValue("--bs-body-color").trim() || "#333333",
+      grid: s.getPropertyValue("--bs-border-color").trim() || "#dee2e6"
+    };
+  }
+
+  function themeOnePlot(gd) {
+    if (typeof Plotly === "undefined" || !gd || !gd.classList) return;
+    if (!gd.classList.contains("js-plotly-plot")) return;
+    var c = themeColors();
+    try {
+      Plotly.relayout(gd, {
+        paper_bgcolor: "rgba(0,0,0,0)",
+        plot_bgcolor: "rgba(0,0,0,0)",
+        "font.color": c.fg,
+        "xaxis.color": c.fg,
+        "yaxis.color": c.fg,
+        "xaxis.gridcolor": c.grid,
+        "yaxis.gridcolor": c.grid,
+        "legend.font.color": c.fg
+      });
+    } catch (e) {
+      /* a plot mid-render can reject relayout; the next trigger will catch it */
+    }
+  }
+
+  function themeAllPlots() {
+    document.querySelectorAll(".js-plotly-plot").forEach(themeOnePlot);
+  }
+
+  // Re-theme when the user toggles light/dark (bslib sets data-bs-theme on <html>).
+  new MutationObserver(function (muts) {
+    for (var i = 0; i < muts.length; i++) {
+      if (muts[i].attributeName === "data-bs-theme") {
+        themeAllPlots();
+        return;
+      }
+    }
+  }).observe(document.documentElement, { attributes: true });
+
+  // Re-theme each plot as Shiny (re)renders it. The output element id is
+  // e.name; the plotly widget is that element or a descendant of it.
+  $(document).on("shiny:value", function (e) {
+    setTimeout(function () {
+      var el = document.getElementById(e.name);
+      if (!el) {
+        themeAllPlots();
+        return;
+      }
+      var plot = el.classList.contains("js-plotly-plot") ? el : el.querySelector(".js-plotly-plot");
+      if (plot) {
+        themeOnePlot(plot);
+      }
+    }, 50);
+  });
+
+  $(document).on("shiny:connected", function () {
+    setTimeout(themeAllPlots, 300);
+  });
+})();


### PR DESCRIPTION
Closes #151.

Turns the bslib migration (#150) into an actual theming system rather than a like-for-like reproduction of the old Cosmo look: the accent colour is defined once, the whole UI follows a light/dark toggle, and the surfaces that don't natively honour Bootstrap's `data-bs-theme` (DataTables, plotly) are made theme-aware.

## What this does

- **Design tokens.** The accent is defined once on `bs_theme(primary = ...)`; `inst/www/shinyngs.css` now reads Bootstrap variables (`--bs-primary`, `--bs-body-bg`, `--bs-body-color`, `--bs-secondary-color`, `--bs-border-color`, `--bs-tertiary-bg`, `--bs-success`) instead of hardcoded hex. The landing page, summary tiles, drawer, accordions, contrast table and pills all follow the active theme. Light mode is visually unchanged.
- **Dark mode.** A light/dark toggle (`input_dark_mode()`) in the navbar. A small client-side hook (`inst/www/shinyngs.js`) keeps plotly charts in step with the theme: transparent backgrounds and theme-derived text/axis/grid colours, re-applied on render and on toggle.
- **Readable DataTables in dark mode.** DataTables ships fixed light-theme colours that ignore `data-bs-theme`, so tables were dark-on-dark and unreadable. Cell/header text, borders, zebra striping, the search input and the length select are mapped onto theme variables (scoped under `.dataTables_wrapper` so they outrank DataTables' own rules without `!important`; pagination is left untouched so the active-page button keeps its contrast).
- **No white flash.** plotly's SVG background rects are forced transparent from first paint via CSS (author `!important` beats plotly's inline style), and `data-bs-theme` is resolved from the system preference in a `<head>` script before first paint, so a dark-resolved load doesn't paint the light theme first.
- `overflow-x: auto` on the DataTables wrapper (was a permanent scrollbar); `bslib` floor bumped to `>= 0.9.0` for `navbar_options(theme=)` and `input_dark_mode()`.

## Test plan

- [x] `test_dir` suite: 0 failures, 194 pass (exec-smoke / shinytest2 skip off-CI).
- [x] Verified in-browser on `zhangneurons`: light unchanged; toggling dark flips the whole app coherently (tiles, accordions, tables, plots); DataTables readable in both themes; plotly text/axes track the theme; no console errors.

Known limitation: two base-R plots (dexseq exon-usage, gene-model) still render on white in dark mode - the plotly hook doesn't cover them; left as a follow-up under #151.
