### PR TITLE
Apply the Cosmo bootswatch theme to the pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,7 @@ url: https://pinin4fjords.github.io/shinyngs/
 
 template:
   bootstrap: 5
+  bootswatch: cosmo
 
 development:
   mode: auto


### PR DESCRIPTION
## Summary

- The pkgdown site was using the completely unstyled default Bootstrap 5 template.
- #150 already moved the Shiny app itself to `bslib::bs_theme(version = 5, bootswatch = "cosmo")`. Add `bootswatch: cosmo` to `_pkgdown.yml`'s template so the docs site matches.
- I also tried overriding the navbar background/foreground to match the app's forced dark navbar (`navbar_options(bg = "dark", theme = "dark")`), but Bootstrap 5's navbar background isn't driven by a themable Sass variable pkgdown/bslib exposes this way, so that part didn't take effect and I dropped it rather than ship something unverified. The Cosmo palette/typography match is confirmed working.

## Test plan

- [x] Local `pkgdown::build_home()` confirms Cosmo's fonts (`Source Sans Pro`) appear in the compiled CSS
- [x] `pkgdown::check_pkgdown()` reports no config problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)