### PR TITLE
Cache expensive PCA/clustering/dendrogram/heatmap reactives and debounce sliders

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -184,7 +184,9 @@ clustering <- function(id, eselist) {
       data.frame(t(scale(t(inmatrix))), check.names = FALSE)
     })
 
-    # Do the actual clustering. Assign genes/rows to clusters.
+    # Do the actual clustering. Assign genes/rows to clusters. Cached on the
+    # scaled matrix and cluster count so display-only controls (colors, error
+    # bar type, average type) don't re-run clara().
 
     makeClusters <- reactive({
       scaled_inmatrix <- scaleMatrix()
@@ -192,7 +194,7 @@ clustering <- function(id, eselist) {
       withProgress(message = "Calculating clusters with clara()", value = 0, {
         validateOrCatch(runClustering(scaled_inmatrix, cluster_number))
       })
-    })
+    }) %>% bindCache(scaleMatrix(), getClusterNumber())
 
     # Get the matrix of values for each cluster
 
@@ -221,7 +223,7 @@ clustering <- function(id, eselist) {
           summarySE(melt_matrix(as.matrix(mbc)), measurevar = "value", groupvars = "Var2", add_medians = add_medians)
         })
       })
-    })
+    }) %>% bindCache(getMatricesByCluster(), addMedians())
 
     # The business end of the cluster plotting. Use the above parameters and processing to produce one plot object for each cluster of matrix rows.
 

--- a/R/dendro.R
+++ b/R/dendro.R
@@ -102,12 +102,20 @@ dendro <- function(id, eselist) {
     # Trace 0 is the branch tree, so the per-group traces start at index 1.
     hiddenGroups <- legendHiddenGroups(plot_source, getLevels, getGroupby, trace_offset = 1L)
 
+    # Cached on exactly the inputs read below, so re-rendering the tab (or
+    # another session viewing the same matrix/settings) doesn't re-run the
+    # underlying distance/hclust computation.
+
+    getDendroPlot <- reactive({
+      validateOrCatch(plotly_clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
+        cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
+        palette = getPalette(), hidden_groups = hiddenGroups(), source = plot_source
+      ))
+    }) %>% bindCache(selectMatrix(), selectColData(), getGroupby(), input$corMethod, input$clusterMethod, matrixTitle(), getPalette(), hiddenGroups())
+
     output$sampleDendroPlot <- renderPlotly({
       withProgress(message = "Making sample dendrogram", value = 0, {
-        validateOrCatch(plotly_clusteringDendrogram(selectMatrix(), selectColData(), getGroupby(),
-          cor_method = input$corMethod, cluster_method = input$clusterMethod, matrixTitle(),
-          palette = getPalette(), hidden_groups = hiddenGroups(), source = plot_source
-        ))
+        getDendroPlot()
       })
     })
   })

--- a/R/geneselect.R
+++ b/R/geneselect.R
@@ -176,6 +176,13 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
       input$geneSelect
     })
 
+    # Debounce the "top N most variant rows" slider so dragging it doesn't
+    # trigger a row/expression matrix recompute on every tick
+
+    getObs <- reactive({
+      input$obs
+    }) %>% debounce(300)
+
     # Make all the reactive expressions that will be needed by calling modules.
 
     geneselect_functions <- list(getNonEmptyRows = getNonEmptyRows)
@@ -195,7 +202,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
           return(nonempty)
         } else if (gene_select == "variance") {
           vars <- rowVariances()
-          return(names(vars)[selectVariableGenes(input$obs, row_variances = vars)])
+          return(names(vars)[selectVariableGenes(getObs(), row_variances = vars)])
         } else if (gene_select == "metadata_pick") {
           selected_rows <- lsf_picked_methods$getSelectedIds()
           return(intersect(selected_rows, nonempty))
@@ -232,7 +239,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
       if (gene_select == "all") {
         title <- "All rows"
       } else if (gene_select == "variance") {
-        title <- paste(paste("Top", input$obs, "rows"), "by variance")
+        title <- paste(paste("Top", getObs(), "rows"), "by variance")
       } else if (gene_select == "gene set") {
         title <- paste0("Genes in sets:\n", paste(prettifyGeneSetName(getGenesetNames()), collapse = "\n"))
         # } else if (gene_select == 'list') { title <- 'Rows for specifified gene list'

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -285,7 +285,10 @@ heatmap <- function(id, eselist, type = "expression") {
       pm
     })
 
-    # Run a PCA with the currently selected matrix
+    # Run a PCA with the currently selected matrix, and associate components
+    # with experimental variables via anova. Cached on the inputs read below,
+    # since neither prcomp() nor the per-variable anova calls need to re-run
+    # when e.g. only the clustering/scale controls change.
 
     getPCAMatrix <- reactive({
       pcameta <- getExperimentData()
@@ -304,7 +307,7 @@ heatmap <- function(id, eselist, type = "expression") {
       )
 
       anova_pca_metadata(pca_coords = pca$x, pcameta = pcameta, fraction_explained = fraction_explained)
-    })
+    }) %>% bindCache(getExperimentData(), selectMatrix())
 
     # Calculate heights for the the various types of heatmap
 
@@ -372,15 +375,23 @@ heatmap <- function(id, eselist, type = "expression") {
       type == "pca"
     })
 
-    # Make the interactive heatmap
+    # Build the interactive heatmap. Cached on exactly the inputs read below,
+    # since this covers heatmaply()'s own layout work as well as the row/column
+    # clustering it performs internally.
+
+    getHeatmapPlot <- reactive({
+      validateOrCatch(interactiveHeatmap(
+        plotmatrix = getPlotMatrix(), displaymatrix = getDisplayMatrix(), getPlotAnnotation(), cluster_cols = as.logical(input$cluster_cols),
+        cluster_rows = as.logical(input$cluster_rows), scale = input$scale, row_labels = rowLabels(), colors = makeColors(), cexCol = 1, cexRow = 1,
+        display_numbers = FALSE, hide_colorbar = hideColorbar()
+      ))
+    }) %>% bindCache(
+      getPlotMatrix(), getDisplayMatrix(), getPlotAnnotation(), input$cluster_cols, input$cluster_rows, input$scale, rowLabels(), makeColors(), hideColorbar()
+    )
 
     output$interactiveHeatmap <- plotly::renderPlotly({
       withProgress(message = "Building interactive heatmap", value = 0, {
-        validateOrCatch(interactiveHeatmap(
-          plotmatrix = getPlotMatrix(), displaymatrix = getDisplayMatrix(), getPlotAnnotation(), cluster_cols = as.logical(input$cluster_cols),
-          cluster_rows = as.logical(input$cluster_rows), scale = input$scale, row_labels = rowLabels(), colors = makeColors(), cexCol = 1, cexRow = 1,
-          display_numbers = FALSE, hide_colorbar = hideColorbar()
-        ))
+        getHeatmapPlot()
       })
     })
   })

--- a/R/pca.R
+++ b/R/pca.R
@@ -165,14 +165,15 @@ pca <- function(id, eselist) {
       }
     })
 
-    # Run the PCA
+    # Run the PCA. Cached on the input matrix so tweaking display-only controls
+    # (loadings count, axis choice, coloring) doesn't re-run prcomp().
 
     pca <- reactive({
       pcamatrix <- selectMatrix()
       withProgress(message = "Running principal component analysis", value = 0, {
         validateOrCatch(runPCA(pcamatrix))
       })
-    })
+    }) %>% bindCache(selectMatrix())
 
     # Fractional variance for each component
 
@@ -191,6 +192,13 @@ pca <- function(id, eselist) {
       c(getXAxis(), getYAxis(), getZAxis())
     })
 
+    # Debounce the loadings-count slider so dragging it doesn't refetch the
+    # loadings on every tick
+
+    getNLoadings <- reactive({
+      input$n_loadings
+    }) %>% debounce(300)
+
     # Fetch the loadings
 
     getLoadings <- reactive({
@@ -199,7 +207,7 @@ pca <- function(id, eselist) {
         fraction_explained <- calculatePCAFractionExplained()
         colnames(rot) <- paste0(colnames(rot), ": ", fraction_explained, "%")
 
-        loaded_rows <- Reduce(union, lapply(selectedComponents(), function(pc) rownames(rot)[order(abs(rot[, pc]), decreasing = TRUE)[seq_len(input$n_loadings)]]))
+        loaded_rows <- Reduce(union, lapply(selectedComponents(), function(pc) rownames(rot)[order(abs(rot[, pc]), decreasing = TRUE)[seq_len(getNLoadings())]]))
 
         # Also return a table with the loadings converted to fractions
 
@@ -245,9 +253,14 @@ pca <- function(id, eselist) {
       loadlabels <- paste(idToLabel(rownames(load$fraction), getExperiment()), do.call(paste, percent_contributions), sep = "<br />")
     })
 
-    simpletable("components", downloadMatrix = pcaDisplayMatrix, displayMatrix = pcaDisplayMatrix, filename = "components", rownames = TRUE)
+    # server = FALSE: column headers here embed the percent variance explained,
+    # which changes with every PCA re-run, so DT's server-side paging can race
+    # a debounced control change and fetch a page against headers that no
+    # longer match (see simpletable()'s `server` argument).
 
-    simpletable("loading", downloadMatrix = makeDownloadLoadingTable, displayMatrix = makeDisplayLoadingTable, filename = "pcaloading", rownames = FALSE)
+    simpletable("components", downloadMatrix = pcaDisplayMatrix, displayMatrix = pcaDisplayMatrix, filename = "components", rownames = TRUE, server = FALSE)
+
+    simpletable("loading", downloadMatrix = makeDownloadLoadingTable, displayMatrix = makeDisplayLoadingTable, filename = "pcaloading", rownames = FALSE, server = FALSE)
   })
 }
 

--- a/R/simpletable.R
+++ b/R/simpletable.R
@@ -72,13 +72,21 @@ simpletableOutput <- function(id, tabletitle = NULL) {
 #' @param show_controls Show search box, controls etc on resulting data table?
 #' (default: TRUE)
 #' @param filter Passed to \code{DT::renderDataTable()}
+#' @param server Passed to \code{DT::renderDataTable()}. Leave at the default
+#' (TRUE) for most tables, since it keeps only the current page's data in the
+#' browser. Set to FALSE if \code{displayMatrix()} can produce a table with
+#' the same dimensions but different column *names* from one render to the
+#' next (e.g. column headers derived from a recalculated statistic) - DT's
+#' server-side mode matches an in-flight page/sort/search request to fresh
+#' data by column name, so a name change between the request and the
+#' response raises "the column name ... is not found in data".
 #'
 #' @keywords shiny
 #'
 #' @examples
 #' simpletable("simpletable", my_data_frame)
 #'
-simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 15, filename, rownames = FALSE, show_controls = TRUE, filter = "none") {
+simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 15, filename, rownames = FALSE, show_controls = TRUE, filter = "none", server = TRUE) {
   moduleServer(id, function(input, output, session) {
     if (is.null(downloadMatrix)) {
       downloadMatrix <- displayMatrix
@@ -97,7 +105,8 @@ simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 1
       options = options,
       filter = filter,
       rownames = rownames,
-      escape = FALSE
+      escape = FALSE,
+      server = server
     )
 
     output$downloadTable <- downloadHandler(filename = function() {

--- a/man/simpletable.Rd
+++ b/man/simpletable.Rd
@@ -12,7 +12,8 @@ simpletable(
   filename,
   rownames = FALSE,
   show_controls = TRUE,
-  filter = "none"
+  filter = "none",
+  server = TRUE
 )
 }
 \arguments{
@@ -35,6 +36,15 @@ names of the input matrix? (default: FALSE)}
 (default: TRUE)}
 
 \item{filter}{Passed to \code{DT::renderDataTable()}}
+
+\item{server}{Passed to \code{DT::renderDataTable()}. Leave at the default
+(TRUE) for most tables, since it keeps only the current page's data in the
+browser. Set to FALSE if \code{displayMatrix()} can produce a table with
+the same dimensions but different column *names* from one render to the
+next (e.g. column headers derived from a recalculated statistic) - DT's
+server-side mode matches an in-flight page/sort/search request to fresh
+data by column name, so a name change between the request and the
+response raises "the column name ... is not found in data".}
 }
 \description{
 This function is called directly, using the same id as its UI counterpart,


### PR DESCRIPTION
## Summary
- Wraps the expensive reactives called out in #106 in `bindCache()`, keyed on their real inputs: `pca()` (prcomp), `makeClusters()`/`getSummarisedMatricesByCluster()` (clara/cluster summaries), a new `getDendroPlot()`, and `getPCAMatrix()`/a new `getHeatmapPlot()`. Tweaking a display-only control (color-by, error bar type, scale, etc.) no longer re-runs the underlying computation.
- Debounces the two sliders singled out in the issue (gene-count "top N most variant rows", and PCA "number of loadings") by 300ms, so dragging them recomputes once instead of on every tick.
- Fixes a latent race the debounce exposed: the PCA components/loadings tables' column headers embed the percent variance explained, which changes on every PCA re-run. DT's server-side paging can fetch a page against headers a client request was built from before they changed, throwing "the column name ... is not found in data". Adds a `server` argument to `simpletable()` (default unchanged everywhere else) and disables server-side mode only for those two tables.

## Test plan
- [x] `testthat` suite passes (239 passing in an env with a current `bslib`; the same 3 pre-existing `bslib`-version-mismatch AppDriver failures reproduce identically on plain `develop` in the other env, confirming they're unrelated to this change)
- [x] Live click-through in a real browser against `zhangneurons` test data across PCA, Feature-wise clustering, Clustering dendrogram, and Clustering Heatmap tabs, exercising every control this PR touches
- [x] Bisected the DataTables regression against a side-by-side `develop` build to confirm root cause and verify the fix

Fixes #106