### PR TITLE
Fix dead rawgit.com vignette link in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -237,7 +237,7 @@ Technical information can be accessed via the package documentation:
 ?shinyngs
 ```
 
-More user-oriented documentation and examples of how to build your own apps in the [vignette](https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html). 
+More user-oriented documentation and examples of how to build your own apps in the [vignette](https://pinin4fjords.github.io/shinyngs/articles/shinyngs.html).
 
 This is also accessible via the `vignette` command:
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Technical information can be accessed via the package documentation:
 
 More user-oriented documentation and examples of how to build your own
 apps in the
-[vignette](https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html).
+[vignette](https://pinin4fjords.github.io/shinyngs/articles/shinyngs.html).
 
 This is also accessible via the `vignette` command:
 


### PR DESCRIPTION
## Summary

- rawgit.com shut down in 2019, so the README's link to the vignette (`[vignette](https://rawgit.com/...)`) has 404'd for years.
- Point it at the vignette's new home on the pkgdown site instead: https://pinin4fjords.github.io/shinyngs/articles/shinyngs.html

## Test plan

- [x] Confirmed the old rawgit.com link 404s
- [x] Confirmed the new pkgdown-hosted link is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)