### PR TITLE
Shareable URL bookmarking for app state (part of #115)

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -230,9 +230,124 @@ shinyngsPageNavbar <- function(navbar_menus) {
   navbar_menus$header <- tagList(no_flash, includeCSS(cssfile), includeScript(jsfile), shinyjs::useShinyjs())
   navbar_menus <- c(navbar_menus, list(
     bslib::nav_spacer(),
+    bslib::nav_item(actionButton(
+      "shinyngs_share_view",
+      label = "Share view",
+      icon = icon("share-nodes"),
+      class = "btn-sm",
+      title = "Copy a shareable link that restores the current view"
+    )),
     bslib::nav_item(bslib::input_dark_mode(id = "shinyngs_dark_mode"))
   ))
   do.call(bslib::page_navbar, navbar_menus)
+}
+
+#' Read a bookmarked input value from a restore state
+#'
+#' Server-side selectize inputs hold no options client-side, so their bookmarked
+#' value can't restore itself and must be re-applied when the choices repopulate.
+#' This reads that value from an \code{onRestore} state, trying the module's
+#' namespaced id first and falling back to the bare id.
+#'
+#' @param state The restore state passed to an \code{onRestore} callback
+#' @param session The module session
+#' @param id The unqualified input id
+#'
+#' @return The bookmarked value, or \code{NULL} if absent
+#'
+#' @keywords internal
+#'
+bookmarkedInputValue <- function(state, session, id) {
+  val <- state$input[[session$ns(id)]]
+  if (is.null(val)) {
+    val <- state$input[[id]]
+  }
+  val
+}
+
+#' Configure URL bookmarking for the top-level session
+#'
+#' URL bookmarking serialises every input into the address bar. Some inputs are
+#' either transient (event streams, click counters) or would bloat the URL
+#' beyond usefulness (DataTable row/state inputs can enumerate every row). An
+#' observer keeps the exclude list in sync with those inputs as they appear
+#' (tables load and contrast filter sets are inserted after the initial page).
+#'
+#' On bookmark, the state URL is written to the address bar so it can be copied
+#' and shared directly, with a notification pointing the user there.
+#'
+#' @param input The top-level \code{input} object, which carries all inputs
+#'   across module namespaces under their fully-qualified names
+#' @param session The top-level session
+#' @param nav_input Fully-qualified id of the page navbar's tab input, captured
+#'   and restored explicitly because bslib navsets don't participate in
+#'   bookmarking
+#'
+#' @keywords internal
+#'
+configureBookmarking <- function(input, session, nav_input = NULL) {
+  # Also set here (not just in prepareApp) so bookmarking is active in whichever
+  # process actually runs the app, including harnesses that transport the app
+  # object to a fresh process where prepareApp's option would be lost.
+  enableBookmarking("url")
+
+  patterns <- c(
+    "_rows_current", "_rows_all", "_rows_selected", "_state", "_search",
+    "_cell_clicked", "_cells_selected", "_columns", # DT internals
+    "plotly_", ".clientValue-", # plotly event streams
+    "-link", # help-modal triggers
+    "shinyngs_dark_mode", "shinyngs_share_view", "insertBtn", "removeBtn"
+  )
+
+  # Grep only names that are new since the last fire (inputs stream in as tables
+  # load and filter sets are inserted) and only push the exclude list when it
+  # actually grows, since setBookmarkExclude replaces the whole set.
+  seen <- character(0)
+  excluded <- character(0)
+  observe({
+    nms <- names(input)
+    fresh <- setdiff(nms, seen)
+    seen <<- nms
+    if (length(fresh) == 0) {
+      return()
+    }
+    hits <- unique(unlist(lapply(patterns, grep, x = fresh, fixed = TRUE, value = TRUE)))
+    if (length(hits) > 0) {
+      excluded <<- union(excluded, hits)
+      setBookmarkExclude(excluded, session = session)
+    }
+  })
+
+  observeEvent(input$shinyngs_share_view, {
+    session$doBookmark()
+  })
+
+  if (!is.null(nav_input)) {
+    onBookmark(function(state) {
+      state$values$active_tab <- isolate(input[[nav_input]])
+    })
+    onRestored(function(state) {
+      tab <- state$values$active_tab
+      if (!is.null(tab)) {
+        updateTabsetPanel(session, nav_input, selected = tab)
+        # Selecting a panel that lives in a nav_menu leaves its dropdown
+        # visually open; close any open navbar dropdown once the selection has
+        # applied on the client.
+        shinyjs::runjs(
+          "setTimeout(function(){document.querySelectorAll('.navbar .dropdown-menu.show').forEach(function(e){e.classList.remove('show');});}, 300);"
+        )
+      }
+    })
+  }
+
+  onBookmarked(function(url) {
+    updateQueryString(url)
+    session$sendCustomMessage("shinyngs_copy_link", url)
+    showNotification(
+      "Shareable link copied to your clipboard (and shown in the address bar).",
+      type = "message", duration = 6, session = session
+    )
+  }, session = session)
 }
 
 #' Lay out a module's controls beside its output

--- a/R/apps.R
+++ b/R/apps.R
@@ -98,42 +98,64 @@
 #' # gene set analyses etc.). With those in place the resulting app gains
 #' # additional panels for differential analyses.
 prepareApp <- function(type, eselist, ui_only = FALSE, ...) {
-  if (type %in% c("rnaseq", "chipseq", "illuminaarray")) {
-    inputFunc <- get(paste0(type, "Input"))
+  # URL bookmarking lets a configured view be captured in a shareable link and
+  # restored. Set here (rather than via shinyApp(enableBookmarking=)) because
+  # callers invoke shiny::shinyApp()/runApp() themselves, so this is the only
+  # place the package controls.
+  shiny::enableBookmarking("url")
 
-    app <- list(ui = inputFunc(type, eselist), server = function(input, output, session) {
-      get(type)(type, eselist)
-    })
-  } else {
-    app <- simpleApp(eselist, type, ui_only = ui_only, ...)
+  big <- type %in% c("rnaseq", "chipseq", "illuminaarray")
+
+  # The UI is built afresh on every request so that the restoreInput() calls
+  # inside Shiny input constructors run within the restore context of a
+  # bookmark load and pick up the saved values. A UI built once, ahead of any
+  # request, would bake in defaults and never restore.
+  #
+  # attachDependencies preloads htmlwidget JS/CSS as <script>/<link> tags in the
+  # initial HTML so plugins like jQuery DataTables are attached at page-load.
+  # Otherwise htmlwidgets 1.6.4's shinyBinding.renderValue calls the synchronous
+  # Shiny.renderDependencies() and immediately runs bindingDef.renderValue (e.g.
+  # $().DataTable). The plugin <script> is appended to <head> but not awaited.
+  # Locally that's a <1ms race; behind a reverse proxy (Seqera Studios, Shiny
+  # Server behind nginx, etc.) it consistently loses, surfacing as
+  # "$table.DataTable is not a function" and empty plots/tables.
+  buildUI <- function() {
+    ui <- if (big) {
+      get(paste0(type, "Input"))(type, eselist)
+    } else {
+      simpleApp(eselist, type, ui_only = ui_only, ...)$ui
+    }
+    htmltools::attachDependencies(ui, htmlwidget_preload_deps(), append = TRUE)
   }
 
-  # Preload htmlwidget JS/CSS as <script>/<link> tags in the initial HTML so
-  # plugins like jQuery DataTables are attached at page-load. Otherwise
-  # htmlwidgets 1.6.4's shinyBinding.renderValue calls the synchronous
-  # Shiny.renderDependencies() and immediately runs bindingDef.renderValue
-  # (e.g. $().DataTable). The plugin <script> is appended to <head> but not
-  # awaited. Locally that's a <1ms race; behind a reverse proxy (Seqera
-  # Studios, Shiny Server behind nginx, etc.) it consistently loses, surfacing
-  # as "$table.DataTable is not a function" and empty plots/tables.
-  app$ui <- htmltools::attachDependencies(
-    app$ui,
-    htmlwidget_preload_deps(),
-    append = TRUE
-  )
+  server <- if (big) {
+    function(input, output, session) {
+      configureBookmarking(input, session, nav_input = paste0(type, "-", type))
+      get(type)(type, eselist)
+    }
+  } else {
+    simpleApp(eselist, type, ui_only = ui_only, ...)$server
+  }
 
-  app
+  list(ui = function(request) buildUI(), server = server)
 }
 
 # Dependencies for every htmlwidget type used anywhere in shinyngs, so they
 # load as blocking <script>/<link> tags in the initial HTML rather than lazily
-# via WebSocket-delivered dep messages. See prepareApp() for rationale.
-htmlwidget_preload_deps <- function() {
-  htmltools::resolveDependencies(c(
-    htmltools::findDependencies(DT::datatable(data.frame(a = 1))),
-    htmltools::findDependencies(plotly::plot_ly(x = 1, y = 1))
-  ))
-}
+# via WebSocket-delivered dep messages. See prepareApp() for rationale. The set
+# is constant, so it is computed once and cached (buildUI() runs per page-load).
+htmlwidget_preload_deps <- local({
+  cached <- NULL
+  function() {
+    if (is.null(cached)) {
+      cached <<- htmltools::resolveDependencies(c(
+        htmltools::findDependencies(DT::datatable(data.frame(a = 1))),
+        htmltools::findDependencies(plotly::plot_ly(x = 1, y = 1))
+      ))
+    }
+    cached
+  }
+})
 
 #' Produce a simple app with controls and layout for a single module, in a
 #' shiny \code{sideBarLayout()}.
@@ -170,6 +192,7 @@ simpleApp <- function(eselist, module = NULL, ui_only = FALSE, ...) {
       }
     } else {
       server <- function(input, output, session) {
+        configureBookmarking(input, session, nav_input = "pages")
         get(module)(module, eselist, ...)
       }
     }

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -122,12 +122,38 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
 
     filter_observers <- list()
 
+    # insert_more is a bare counter the insert observer depends on, so restored
+    # filter sets beyond the first can be re-inserted one at a time.
+
+    restored_filtersets <- NULL
+    insert_more <- reactiveVal(0)
+
+    # Seed a freshly-inserted filter set's fields from bookmarked values. The
+    # per-field observers created alongside the set then propagate these into
+    # filterset_values, re-establishing the normal dependency chain.
+
+    applyRestoredFilterSet <- function(index, vals) {
+      if (!is.null(vals$contrasts)) {
+        updateSelectInput(session, paste0("contrasts", index), selected = vals$contrasts)
+      }
+      for (field in c("p_value", "q_value", "fold_change")) {
+        if (!is.null(vals[[field]])) {
+          updateNumericInput(session, paste0(field, index), value = as.numeric(vals[[field]]))
+        }
+        card <- paste0(field, "_card")
+        if (!is.null(vals[[card]])) {
+          updateSelectInput(session, paste0(card, index), selected = vals[[card]])
+        }
+      }
+    }
+
     # This observer adds a set of filters on the first page load and when the assocaited button is clicked.
 
     observeEvent(
       {
         selectmatrix_reactives$selectMatrix()
         input$insertBtn
+        insert_more()
       },
       {
         ese <- selectmatrix_reactives$getExperiment()
@@ -185,6 +211,21 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
             ignoreNULL = FALSE
           )
         })
+
+        # Re-seed this set from bookmarked values on every (re)creation while a
+        # restore is pending. The assay-change reset (priority 2) rebuilds the
+        # sets whenever selectMatrix() changes as inputs restore, so applying
+        # once would be wiped; re-applying here survives that churn until
+        # onRestored clears the pending state.
+
+        if (!is.null(restored_filtersets)) {
+          if (btn < length(restored_filtersets)) {
+            applyRestoredFilterSet(btn, restored_filtersets[[btn + 1]])
+          }
+          if (length(inserted) < length(restored_filtersets)) {
+            insert_more(insert_more() + 1)
+          }
+        }
       },
       ignoreNULL = FALSE,
       priority = 1
@@ -802,6 +843,32 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
       }
 
       list(tags$br(), do.call(wellPanel, summary_bits))
+    })
+
+    ########################################################################### Bookmarking of the dynamically-built filter sets
+
+    # The filter-set inputs are inserted at runtime, so a bookmark URL cannot
+    # capture or restore them by itself. Snapshot filterset_values on bookmark
+    # and stash it on restore for the insert observer to replay. Keys are
+    # namespaced so multiple contrasts instances in one app don't collide.
+
+    onBookmark(function(state) {
+      state$values[[session$ns("contrast_filtersets")]] <- filterset_values
+    })
+
+    onRestore(function(state) {
+      saved <- state$values[[session$ns("contrast_filtersets")]]
+      if (!is.null(saved) && length(saved) > 0) {
+        restored_filtersets <<- unname(saved)
+      }
+    })
+
+    # Close the restore window once the restore flush has settled, so later
+    # user-driven filter sets start from defaults rather than the bookmarked
+    # values.
+
+    onRestored(function(state) {
+      restored_filtersets <<- NULL
     })
 
     ########################################################################### Return the reactive that allow other modules to interact with this one

--- a/R/genesetselect.R
+++ b/R/genesetselect.R
@@ -53,6 +53,19 @@ genesetselectInput <- function(id, multiple = TRUE) {
 #'
 genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by_type = FALSE, require_select = TRUE) {
   moduleServer(id, function(input, output, session) {
+    # The gene-set picker is a server-side selectize, so a bookmarked selection
+    # can't restore itself; stash it here and apply it when the list is next
+    # populated (see updateGeneSetsList).
+
+    restored_geneset <- NULL
+
+    onRestore(function(state) {
+      val <- bookmarkedInputValue(state, session, "geneSets")
+      if (!is.null(val)) {
+        restored_geneset <<- val
+      }
+    })
+
     # Fetch the gene sets keyed for the current experiment's label field,
     # guarding against experiments with no gene sets available for that field
 
@@ -109,7 +122,9 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
     # the calling module.
 
     updateGeneSetsList <- reactive({
-      updateSelectizeInput(session, "geneSets", choices = getGeneSetNames(), server = TRUE)
+      selected <- restored_geneset
+      restored_geneset <<- NULL
+      updateSelectizeInput(session, "geneSets", choices = getGeneSetNames(), selected = selected, server = TRUE)
     })
 
     # Get gene sets with the proper label field keying

--- a/R/labelselectfield.R
+++ b/R/labelselectfield.R
@@ -146,11 +146,26 @@ labelselectfield <- function(id, eselist, getExperiment = NULL, labels_from_all_
       }
     })
 
+    # A server-side selectize holds no options client-side, so a bookmarked
+    # input$label can't restore itself. Capture the value from the bookmark and
+    # re-apply it as the selection once choices are populated below.
+
+    restored_label <- NULL
+
+    onRestore(function(state) {
+      val <- bookmarkedInputValue(state, session, "label")
+      if (!is.null(val)) {
+        restored_label <<- val
+      }
+    })
+
     # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list
 
     observeEvent(input$metaField, {
       if (!list_input) {
-        updateSelectizeInput(session, "label", choices = getValidLabels(), server = TRUE)
+        selected <- restored_label
+        restored_label <<- NULL
+        updateSelectizeInput(session, "label", choices = getValidLabels(), selected = selected, server = TRUE)
       }
     })
 

--- a/inst/www/shinyngs.js
+++ b/inst/www/shinyngs.js
@@ -69,4 +69,15 @@
   $(document).on("shiny:connected", function () {
     setTimeout(themeAllPlots, 300);
   });
+
+  // The URL is generated server-side, so it arrives as a message; the "Share
+  // view" click is recent enough to still count as a user gesture for the
+  // clipboard write.
+  if (window.Shiny && Shiny.addCustomMessageHandler) {
+    Shiny.addCustomMessageHandler("shinyngs_copy_link", function (url) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).catch(function () {});
+      }
+    });
+  }
 })();

--- a/tests/testthat/helper-shinytest2.R
+++ b/tests/testthat/helper-shinytest2.R
@@ -83,3 +83,41 @@ shinytest2_app_driver <- function(type, name, ...) {
     ...
   )
 }
+
+# shinytest2_bookmark_app_driver()
+#
+# Launch an AppDriver against an on-disk app.R rather than a shinyApp object.
+# URL bookmarking must be enabled when the session is constructed (that is when
+# module onBookmark hooks register and Shiny decides whether to keep the share
+# button), which prepareApp() does. Passing a shinyApp object to AppDriver runs
+# it in a fresh process that never called prepareApp, so bookmarking would be
+# off; running from an app.R that calls prepareApp in that process mirrors real
+# use. Requires shinyngs to be installed (it is under R CMD check).
+
+shinytest2_bookmark_app_driver <- function(type, name, ...) {
+  testthat::skip_if_not_installed("shinytest2")
+  testthat::skip_if_not_installed("shinyngs")
+  testthat::skip_if(
+    is.na(tryCatch(chromote::find_chrome(), error = function(e) NA)),
+    "No Chrome/Chromium binary found for headless testing"
+  )
+
+  dir <- withr::local_tempdir(.local_envir = parent.frame())
+  saveRDS(shinytest2_eselist(), file.path(dir, "eselist.rds"))
+  writeLines(
+    c(
+      "library(shinyngs)",
+      "eselist <- readRDS('eselist.rds')",
+      sprintf("app <- prepareApp('%s', eselist)", type),
+      "shiny::shinyApp(app$ui, app$server)"
+    ),
+    file.path(dir, "app.R")
+  )
+
+  shinytest2::AppDriver$new(
+    dir,
+    name = name,
+    height = 900, width = 1400, seed = 42, load_timeout = 90000,
+    ...
+  )
+}

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -55,6 +55,54 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
 # scope covers. testServer exercises the same server-side reactive graph
 # directly and deterministically.
 
+# URL bookmarking round-trip
+#
+# Runs from an on-disk app.R (see shinytest2_bookmark_app_driver) so bookmarking
+# is enabled at session construction, as in real use. Restored values are read
+# from the DOM: updateNumericInput() etc. set the control's value on restore but
+# the client input registry only reflects it once the input reports.
+
+test_that("a bookmark URL restores the active tab and a contrast filter value", {
+  skip_on_cran()
+
+  app <- shinytest2_bookmark_app_driver("rnaseq", "rnaseq-bookmark")
+  withr::defer(app$stop())
+  app$wait_for_idle(timeout = 40000)
+
+  expect_true(app$get_js("!!document.getElementById('shinyngs_share_view')"))
+
+  app$set_inputs(`rnaseq-rnaseq` = "diff_tables")
+  app$wait_for_idle(timeout = 40000)
+  app$set_inputs(`rnaseq-differential-differential-fold_change0` = 7)
+  Sys.sleep(2)
+
+  app$click("shinyngs_share_view")
+  Sys.sleep(3)
+  url <- app$get_js("window.location.href")
+
+  expect_match(url, "\\?", info = "bookmark should put state in the address bar")
+  expect_true(grepl("contrast_filtersets", utils::URLdecode(url)))
+  expect_false(grepl("plotly_", url), info = "transient plotly inputs are excluded")
+  expect_false(grepl("_rows_", url), info = "transient DataTable inputs are excluded")
+
+  app$run_js(sprintf("window.location.href = %s;", jsonlite::toJSON(url, auto_unbox = TRUE)))
+
+  restored <- NA_character_
+  for (i in seq_len(20)) {
+    Sys.sleep(2)
+    val <- app$get_js("(function(){var e=document.getElementById('rnaseq-differential-differential-fold_change0'); return e ? String(e.value) : 'NOEL';})()")
+    if (!is.null(val) && val == "7") {
+      restored <- val
+      break
+    }
+  }
+  expect_equal(restored, "7")
+  expect_equal(
+    app$get_js("(window.Shiny && Shiny.shinyapp) ? String(Shiny.shinyapp.$inputValues['rnaseq-rnaseq']) : 'NA'"),
+    "diff_tables"
+  )
+})
+
 test_that("differentialtable computes a table without error given a real contrast", {
   skip_on_cran()
 

--- a/vignettes/shinyngs.Rmd
+++ b/vignettes/shinyngs.Rmd
@@ -24,7 +24,8 @@ It's not always trivial to quickly assess the results of next-generation sequenc
 
 * A variety of single and multiple-panel Shiny applications- currently heatmap, pca, boxplot, dendrogram, gene-wise barplot, various tables and an RNA-seq app combining all of these.
 * Leveraging of libraries such as [DataTables](https://rstudio.github.io/DT/) and [Plotly](https://plot.ly/) for rich interactivity.
-* Takes input in an extension of the commonly used `SummarizedExperiment` format, called `ExploratorySummarizedExperiment` 
+* Takes input in an extension of the commonly used `SummarizedExperiment` format, called `ExploratorySummarizedExperiment`
+* A **Share view** button in the navbar that captures the current selections (experiment, matrix, samples, genes, contrast filters, colouring and active panel) in the page URL and copies a shareable link to the clipboard, so a configured view can be shared or revisited by opening that link.
 * Interface kept simple where possible, with complexity automatically added where required:
     * Input field clutter reduced with the use of collapses from [shinyBS](https://ebailey78.github.io/shinyBS/index.html) (when installed).
     * If a list of `ExploratorySummarizedExperiment`s is supplied (useful in situations where the features are different beween matrices - e.g. from transcript- and gene- level analyses), a selection field will be provided.


### PR DESCRIPTION
Part of #115.

Adds Shiny URL bookmarking so a configured view can be captured in a link and
restored, the first of the reproducible-export features in #115. The downloadable
report and publication-quality static export will follow as separate PRs.

## What this does
- A **Share view** button in the navbar copies a shareable link to the clipboard
  and writes it to the address bar.
- Opening that link restores the view: selected experiment, matrix, samples,
  genes, colour-by, contrast filters, and the active panel.

## How it works
- `prepareApp()` enables URL bookmarking and returns a per-request UI function,
  so the `restoreInput()` calls inside Shiny input constructors run in the
  restore context of a bookmark load.
- `configureBookmarking()` keeps transient inputs (plotly event streams,
  DataTable row/state) out of the URL, wires the button to `doBookmark()`, and
  captures/restores the active navbar tab (bslib navsets don't bookmark
  themselves), closing the nav-menu dropdown that programmatic selection would
  otherwise leave open.
- Server-side selectize pickers (gene/label and gene-set) and the contrasts
  dynamic filter builder round-trip via `onBookmark`/`onRestore`.

## Testing
- shinytest2 round-trip test covering active-tab and contrast-filter restore,
  driven from an on-disk app so bookmarking is enabled at session construction.
- Existing shinytest2 and unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
