### PR TITLE
Deploy the shinyapps.io example app automatically from CI

### DIFF
--- a/.github/workflows/deploy-example.yaml
+++ b/.github/workflows/deploy-example.yaml
@@ -1,0 +1,72 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+name: deploy-example
+
+concurrency:
+  group: deploy-example
+  cancel-in-progress: false
+
+jobs:
+  deploy-example:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.R_CI }}
+      SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
+      SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+      FIXTURES: tests/testthat/fixtures/exec-smoke
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          r-version: '4.4.0'
+
+      - name: Install system libraries required by Rhtslib
+        # Per Rhtslib's DESCRIPTION: SystemRequirements: libbz2 & liblzma &
+        # libcurl (with header files), GNU make. Normally provided by
+        # setup-r-dependencies' own sysreqs resolution, but that step runs
+        # after this one (see next step), so install them explicitly here.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev liblzma-dev zlib1g-dev
+
+      - name: Pre-install Rhtslib directly (works around a pak parallel-install bug)
+        run: |
+          Rscript -e '
+            if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager")
+            BiocManager::install("Rhtslib", update = FALSE, ask = FALSE)
+          '
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rsconnect, local::.
+          dependencies: 'c("Imports", "Depends", "LinkingTo")'
+
+      - name: Build and deploy the shinyapps.io example app
+        run: |
+          # The contrasts fixture has two rows; --differential_results expects
+          # one file per row, so a second copy stands in for the second
+          # contrast, matching tests/testthat/test-exec-smoke.R.
+          second_differential_file=$(mktemp --suffix .tsv)
+          cp "${FIXTURES}/SRP254919.salmon.merged.deseq2.results.tsv" "$second_differential_file"
+
+          ./exec/make_app_from_files.R \
+            --title "Shinyngs example" \
+            --author "shinyngs" \
+            --sample_metadata "${FIXTURES}/SRP254919.samplesheet.csv" \
+            --feature_metadata "${FIXTURES}/SRP254919.gene_meta.tsv" \
+            --assay_files "${FIXTURES}/SRP254919.salmon.merged.gene_counts.top1000cov.tsv" \
+            --contrast_file "${FIXTURES}/SRP254919.contrasts.csv" \
+            --contrast_stats_assay 1 \
+            --differential_results "${FIXTURES}/SRP254919.salmon.merged.deseq2.results.tsv,${second_differential_file}" \
+            --output_directory app \
+            --deploy_app \
+            --shinyapps_account pinin4fjords \
+            --shinyapps_name shinyngs_example


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-example.yaml`, a new workflow that builds and deploys the `shinyngs_example` shinyapps.io app on every push to `master`, or on demand via `workflow_dispatch` against any branch.
- Reuses the `SRP254919` fixtures already committed under `tests/testthat/fixtures/exec-smoke/` (the same small dataset proven in `check-release.yaml`) as input to `exec/make_app_from_files.R --deploy_app`, the deployment path already documented in the README.
- `SHINYAPPS_TOKEN`/`SHINYAPPS_SECRET` repo secrets have been added so the workflow can authenticate with rsconnect.

## Test plan
- [ ] Merge and confirm the workflow runs cleanly on a push to `master`
- [ ] Confirm https://pinin4fjords.shinyapps.io/shinyngs_example/ updates after the run
- [ ] Confirm manual `workflow_dispatch` runs succeed off other branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)