### PR TITLE
Fix --deploy_app clobbering the library path before loading shinyngs

### DIFF
--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -285,7 +285,7 @@ if (opt$deploy_app) {
   ood_packages <- ood[grep("bioconductor", ood$Repository), "Package"]
 
   dir.create("libs", showWarnings = FALSE)
-  .libPaths("libs")
+  .libPaths(c("libs", .libPaths()))
 
   BiocManager::install(ood_packages, update = TRUE, ask = FALSE, lib = "libs")
 }


### PR DESCRIPTION
## Summary
- The first live run of the new `deploy-example` workflow (#175) failed with `Error in library(shinyngs) : there is no package called 'shinyngs'`.
- Root cause: `exec/make_app_from_files.R`'s `--deploy_app` branch calls `.libPaths("libs")` to give the pre-deploy Bioconductor update step a writable install location, but that *replaces* the whole library search path instead of prepending to it — so the subsequent `library(shinyngs)` call can no longer see shinyngs or its dependencies wherever they were actually installed.
- Fix: `.libPaths(c("libs", .libPaths()))`, which keeps the existing library paths searchable while still preferring "libs" for anything freshly installed there.

## Test plan
- [x] Confirmed the failure on run https://github.com/pinin4fjords/shinyngs/actions/runs/29621745462 (`deploy-example` workflow, manually dispatched against `develop`)
- [ ] Re-run `deploy-example` against `develop` after merge and confirm it completes and updates https://pinin4fjords.shinyapps.io/shinyngs_example/

🤖 Generated with [Claude Code](https://claude.com/claude-code)