### PR TITLE
Install shinyngs as a pinned GitHub remote for the example deploy

### DIFF
--- a/.github/workflows/deploy-example.yaml
+++ b/.github/workflows/deploy-example.yaml
@@ -46,7 +46,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rsconnect, local::.
+          # rsconnect refuses to bundle a package installed from an untracked
+          # local source (no reproducible origin to reinstall from
+          # server-side), so shinyngs itself is installed as a GitHub remote
+          # pinned to the commit being deployed, rather than via local::.
+          extra-packages: any::rsconnect, pinin4fjords/shinyngs@${{ github.sha }}
           dependencies: 'c("Imports", "Depends", "LinkingTo")'
 
       - name: Build and deploy the shinyapps.io example app


### PR DESCRIPTION
## Summary
- Follow-up to #177. With the `.libPaths()` fix, `deploy-example` got as far as building the app and starting the rsconnect deploy, then failed: `Can't re-install packages installed from source: shinyngs` — rsconnect refuses to bundle a package it can't reinstall from a known, reproducible location, and `local::.` gives shinyngs none.
- Fix: install `shinyngs` via `pinin4fjords/shinyngs@${{ github.sha }}` (a pak/remotes GitHub spec pinned to the exact commit being deployed) instead of `local::.`, so it carries GitHub remote metadata rsconnect recognises as reproducible.

## Test plan
- [x] Confirmed the failure on run https://github.com/pinin4fjords/shinyngs/actions/runs/29622105494
- [ ] Re-run `deploy-example` against `develop` after merge and confirm it completes and updates https://pinin4fjords.shinyapps.io/shinyngs_example/

🤖 Generated with [Claude Code](https://claude.com/claude-code)