### PR TITLE
Install shinyngs via remotes::install_github, not a pak extra-packages spec

### DIFF
--- a/.github/workflows/deploy-example.yaml
+++ b/.github/workflows/deploy-example.yaml
@@ -46,12 +46,17 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # rsconnect refuses to bundle a package installed from an untracked
-          # local source (no reproducible origin to reinstall from
-          # server-side), so shinyngs itself is installed as a GitHub remote
-          # pinned to the commit being deployed, rather than via local::.
-          extra-packages: any::rsconnect, pinin4fjords/shinyngs@${{ github.sha }}
+          extra-packages: any::rsconnect, any::remotes
           dependencies: 'c("Imports", "Depends", "LinkingTo")'
+
+      - name: Install shinyngs as a pinned GitHub remote
+        # rsconnect refuses to bundle a package with no reproducible install
+        # origin, which a pak-resolved extra-packages spec doesn't reliably
+        # provide (shinyapps.io rejected the resulting manifest with "Unknown
+        # repository for package source: deps"). A plain remotes::install_github
+        # call records proper GitHub remote metadata instead.
+        run: |
+          Rscript -e 'remotes::install_github("pinin4fjords/shinyngs", ref = "${{ github.sha }}", upgrade = "never")'
 
       - name: Build and deploy the shinyapps.io example app
         run: |

--- a/.github/workflows/deploy-example.yaml
+++ b/.github/workflows/deploy-example.yaml
@@ -46,7 +46,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rsconnect, local::.
+          # rsconnect refuses to bundle a package installed from an untracked
+          # local source (no reproducible origin to reinstall from
+          # server-side), so shinyngs itself is installed as a GitHub remote
+          # pinned to the commit being deployed, rather than via local::.
+          extra-packages: any::rsconnect, pinin4fjords/shinyngs@${{ github.sha }}
           dependencies: 'c("Imports", "Depends", "LinkingTo")'
 
       - name: Build and deploy the shinyapps.io example app


### PR DESCRIPTION
## Summary
- Follow-up to #178. That fix let `deploy-example` build the app, bundle it, and upload to shinyapps.io, but the server-side deploy then failed: `Error parsing manifest: Unknown repository for package source: deps`.
- Root cause: passing `pinin4fjords/shinyngs@<sha>` as one of several comma-separated `extra-packages` entries makes `setup-r-dependencies` resolve it through pak's composite dependency graph, which doesn't reliably record clean GitHub remote provenance on the installed package - rsconnect's manifest ends up with an unrecognized package source.
- Fix: install `remotes` alongside `rsconnect` via `setup-r-dependencies` as before, then install `shinyngs` itself in its own explicit step via `remotes::install_github("pinin4fjords/shinyngs", ref = "<sha>")`, which records proper `RemoteType: github` metadata.

## Test plan
- [x] Confirmed the failure on run https://github.com/pinin4fjords/shinyngs/actions/runs/29622382720
- [ ] Re-run `deploy-example` against `develop` after merge and confirm it completes and updates https://pinin4fjords.shinyapps.io/shinyngs_example/

🤖 Generated with [Claude Code](https://claude.com/claude-code)