### PR TITLE
Lazy-load help modal markdown and add a Home tab spinner

### DIFF
--- a/R/hometab.R
+++ b/R/hometab.R
@@ -102,7 +102,7 @@ homeTab <- function(ns, eselist, platform = "RNA-seq") {
     class = "shinyngs-home",
     h2(class = "shinyngs-study-title", eselist@title),
     h3(class = "shinyngs-study-author", eselist@author),
-    div(class = "shinyngs-overview", summarytilesOutput(ns("summarytiles"))),
+    div(class = "shinyngs-overview", shinycssloaders::withSpinner(summarytilesOutput(ns("summarytiles")), color = shinyngsSpinnerColor())),
     div(
       class = "shinyngs-desc",
       h2(class = "shinyngs-eyebrow", "About this study"),

--- a/R/modal.R
+++ b/R/modal.R
@@ -47,18 +47,22 @@ modalInput <- function(id, label, class, icon = "info-circle", tooltip = "Open d
 #'   stay current.
 #' @param content Content to include in the modal. May be a function, called
 #'   each time the modal opens. When \code{NULL} (the default), Markdown is
-#'   loaded once from \code{inst/inlinehelp/<id>.md}.
+#'   loaded from \code{inst/inlinehelp/<id>.md} the first time the modal is
+#'   opened, then cached for the life of the session.
 #'
 #' @examples
 #' modalServer("dendro", "Sample clustering dendrogram")
 #'
 modalServer <- function(id, title, content = NULL) {
   moduleServer(id, function(input, output, session) {
-    default_body <- if (is.null(content)) {
-      includeMarkdown(system.file("inlinehelp", paste0(id, ".md"), package = packageName()))
-    }
+    default_body <- NULL
     observeEvent(input$link, {
-      body <- if (is.null(content)) default_body else if (is.function(content)) content() else content
+      body <- if (is.null(content)) {
+        if (is.null(default_body)) {
+          default_body <<- includeMarkdown(system.file("inlinehelp", paste0(id, ".md"), package = packageName()))
+        }
+        default_body
+      } else if (is.function(content)) content() else content
       dialog_title <- if (is.function(title)) title() else title
       showModal(modalDialog(body, title = dialog_title, size = "l", easyClose = TRUE, footer = modalButton("Close")))
     })


### PR DESCRIPTION
## Summary
- Loads each help modal's Markdown (`inst/inlinehelp/<id>.md`) lazily on first click instead of eagerly at session connect, and caches it for the rest of the session. There are ~20 of these across the app, so this avoids ~20 unnecessary file reads/parses on every new session.
- Wraps the Home tab's summary tiles in a `shinycssloaders::withSpinner()`, matching the existing convention used elsewhere in the app (heatmap, PCA, gene panels), so the initial load shows a visible loading state instead of a blank area.

Both are aimed at the few-seconds delay before the app's front page is populated on startup.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-modal.R")` passes (5/5)
- [x] `lintr::lint()` clean on both changed files
- [x] Verified manually in the browser against the zhangneurons dataset: Home tab tiles render correctly with the spinner in place, and clicking a help link (e.g. PCA panel) opens the modal with its Markdown content rendered as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)