### PR TITLE
Add a navbar toggle for Plotly download image format (PNG/SVG)

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -246,6 +246,18 @@ shinyngsPageNavbar <- function(navbar_menus) {
       bslib::input_dark_mode(id = "shinyngs_dark_mode"),
       label = "Toggle light or dark mode",
       placement = "bottom"
+    )),
+    bslib::nav_item(a11yControl(
+      tags$button(
+        id = "shinyngs_plot_format_toggle",
+        type = "button",
+        class = "btn btn-link shinyngs-navbar-icon-btn",
+        `data-format` = "png",
+        icon("file-image")
+      ),
+      label = "Plot download format: PNG. Click to switch to SVG.",
+      tooltip = "Format used by each plot's camera/download button - click to toggle PNG/SVG",
+      placement = "bottom"
     ))
   ))
   do.call(bslib::page_navbar, navbar_menus)
@@ -300,12 +312,20 @@ configureBookmarking <- function(input, session, nav_input = NULL) {
   # object to a fresh process where prepareApp's option would be lost.
   enableBookmarking("url")
 
+  # session$userData is shared with every nested module session, so plot
+  # modules can read the chosen download format without each one taking it
+  # as an extra constructor argument.
+  session$userData$plotFormat <- reactive({
+    fmt <- input$shinyngs_plot_format
+    if (is.null(fmt)) "png" else fmt
+  })
+
   patterns <- c(
     "_rows_current", "_rows_all", "_rows_selected", "_state", "_search",
     "_cell_clicked", "_cells_selected", "_columns", # DT internals
     "plotly_", ".clientValue-", # plotly event streams
     "-link", # help-modal triggers
-    "shinyngs_dark_mode", "shinyngs_share_view", "insertBtn", "removeBtn"
+    "shinyngs_dark_mode", "shinyngs_plot_format", "shinyngs_share_view", "insertBtn", "removeBtn"
   )
 
   # Grep only names that are new since the last fire (inputs stream in as tables
@@ -428,23 +448,25 @@ shinyngsSpinnerColor <- function() {
 #'
 #' Gives every interactive plot the same modebar: the plotly logo is dropped,
 #' the noisier selection buttons are removed, and the "download plot" button
-#' produces a PNG named after the plot rather than the generic
-#' \code{newplot.png}. Call once on the assembled plotly object before
-#' returning it from a \code{renderPlotly()}.
+#' produces an image named after the plot (rather than the generic
+#' \code{newplot.png}) in the user's chosen format. Call once on the assembled
+#' plotly object before returning it from a \code{renderPlotly()}.
 #'
 #' @param p A plotly object
-#' @param filename Base name (no extension) for the PNG download
+#' @param filename Base name (no extension) for the downloaded image
+#' @param format Image format for the download button, e.g. \code{"png"} or
+#'   \code{"svg"}
 #'
 #' @return The plotly object with a shared \code{config()} applied
 #'
 #' @keywords internal
 #'
-shinyngsPlotlyConfig <- function(p, filename = "shinyngs_plot") {
+shinyngsPlotlyConfig <- function(p, filename = "shinyngs_plot", format = "png") {
   plotly::config(
     p,
     displaylogo = FALSE,
     modeBarButtonsToRemove = c("sendDataToCloud", "lasso2d", "select2d"),
-    toImageButtonOptions = list(format = "png", filename = filename)
+    toImageButtonOptions = list(format = format, filename = filename)
   )
 }
 

--- a/R/barplot.R
+++ b/R/barplot.R
@@ -72,7 +72,7 @@ barplot <- function(id, getPlotmatrix, getYLabel, barmode = "stack") {
           margin = list(b = 100), barmode = input$barMode, xaxis = list(title = " "),
           yaxis = list(title = getYLabel())
         ) %>%
-        shinyngsPlotlyConfig("barplot")
+        shinyngsPlotlyConfig("barplot", format = session$userData$plotFormat())
     })
   })
 }

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -153,12 +153,12 @@ boxplot <- function(id, eselist) {
       selected_matrix <- selectmatrix_reactives$selectMatrix()
       ese <- selectmatrix_reactives$getExperiment()
       plotly_quartiles(selected_matrix, idToLabel(rownames(selected_matrix), ese), selectmatrix_reactives$getAssayMeasure(), whisker_distance = input$whiskerDistance) %>%
-        shinyngsPlotlyConfig("quartiles")
+        shinyngsPlotlyConfig("quartiles", format = session$userData$plotFormat())
     })
 
     output$densityPlotly <- renderPlotly({
       plotly_densityplot(selectmatrix_reactives$selectMatrix(), selectmatrix_reactives$selectColData(), groupby_reactives$getGroupby(), expressiontype = selectmatrix_reactives$getAssayMeasure(), palette = groupby_reactives$getPalette()) %>%
-        shinyngsPlotlyConfig("density")
+        shinyngsPlotlyConfig("density", format = session$userData$plotFormat())
     })
 
     plot_source <- session$ns("sampleBoxplot")
@@ -177,7 +177,7 @@ boxplot <- function(id, eselist) {
           expressiontype = selectmatrix_reactives$getAssayMeasure(), whisker_distance = input$whiskerDistance,
           palette = groupby_reactives$getPalette(), hidden_groups = hiddenGroups(), source = plot_source
         ) %>%
-          shinyngsPlotlyConfig("boxplot")
+          shinyngsPlotlyConfig("boxplot", format = session$userData$plotFormat())
       })
     })
   })

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -310,7 +310,7 @@ clustering <- function(id, eselist) {
           plots <- makeClusterPlots()
         })
         do.call(function(...) subplot(..., titleX = TRUE, titleY = TRUE, shareY = TRUE, shareX = TRUE, nrows = ceiling(length(plots) / 3)), plots) %>%
-          shinyngsPlotlyConfig("clustering")
+          shinyngsPlotlyConfig("clustering", format = session$userData$plotFormat())
       })
     })
 

--- a/R/dendro.R
+++ b/R/dendro.R
@@ -122,7 +122,7 @@ dendro <- function(id, eselist) {
 
     output$sampleDendroPlot <- renderPlotly({
       withProgress(message = "Making sample dendrogram", value = 0, {
-        getDendroPlot() %>% shinyngsPlotlyConfig("dendrogram")
+        getDendroPlot() %>% shinyngsPlotlyConfig("dendrogram", format = session$userData$plotFormat())
       })
     })
   })

--- a/R/gene.R
+++ b/R/gene.R
@@ -188,7 +188,7 @@ gene <- function(id, eselist) {
         palette <- groupby_reactives$getPalette()
 
         p <- geneBarplot(barplot_expression, coldata, groupby, assaymeasure, palette = palette) %>%
-          shinyngsPlotlyConfig("gene_expression")
+          shinyngsPlotlyConfig("gene_expression", format = session$userData$plotFormat())
       })
     })
 

--- a/R/genesetbarcodeplot.R
+++ b/R/genesetbarcodeplot.R
@@ -232,7 +232,7 @@ genesetbarcodeplot <- function(id, eselist) {
         fold_changes = getFoldChanges(), gene_ids = getGeneIDs(), set_gene_ids = names(set_genes), labels = getLabels(),
         plot_title = barcodeplotTitle()
       ) %>%
-        shinyngsPlotlyConfig("barcodeplot")
+        shinyngsPlotlyConfig("barcodeplot", format = session$userData$plotFormat())
     })
 
     # Make a table of contrast data for the gene set Subset the linked contrasts table for the gene set genes

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -402,7 +402,7 @@ heatmap <- function(id, eselist, type = "expression") {
 
     output$interactiveHeatmap <- plotly::renderPlotly({
       withProgress(message = "Building interactive heatmap", value = 0, {
-        getHeatmapPlot() %>% shinyngsPlotlyConfig("heatmap")
+        getHeatmapPlot() %>% shinyngsPlotlyConfig("heatmap", format = session$userData$plotFormat())
       })
     })
   })

--- a/R/illuminaarrayqc.R
+++ b/R/illuminaarrayqc.R
@@ -109,7 +109,7 @@ illuminaarrayqc <- function(id, eselist) {
           categoryarray = rownames(experiment),
           categoryorder = "array", title = ""
         ), yaxis = list(title = "Intensity"), margin = list(b = 200)) %>%
-        shinyngsPlotlyConfig("array_qc")
+        shinyngsPlotlyConfig("array_qc", format = session$userData$plotFormat())
     })
 
     # Render the table and provide for download, using the simpletable module.

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -222,7 +222,7 @@ scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, 
           show_labels = getShowLabels(), lines = getLines(), showlegend = showLegend(),
           point_size = getPointSize()
         ) %>%
-          shinyngsPlotlyConfig("scatterplot")
+          shinyngsPlotlyConfig("scatterplot", format = session$userData$plotFormat())
       })
     })
   })

--- a/R/upset.R
+++ b/R/upset.R
@@ -369,7 +369,7 @@ upset <- function(id, eselist, setlimit = 16) {
       )
       s2 <- subplot(intersect_size_chart, grid, nrows = 2, shareX = TRUE) %>% layout(showlegend = FALSE)
 
-      subplot(s1, s2, widths = c(0.3, 0.7)) %>% shinyngsPlotlyConfig("upset")
+      subplot(s1, s2, widths = c(0.3, 0.7)) %>% shinyngsPlotlyConfig("upset", format = session$userData$plotFormat())
     })
 
     # Calculate the maximum number of sets in an intersection

--- a/inst/www/shinyngs.css
+++ b/inst/www/shinyngs.css
@@ -264,6 +264,22 @@ h3{
   box-shadow: none;
 }
 
+/* Plain icon-style navbar buttons (e.g. the plot download format toggle):
+   blend into the dark navbar like the light/dark toggle does. Deliberately
+   NOT `.nav-link` - that class puts an element into the navbar's tablist
+   roving-tabindex behaviour, which set tabindex="-1" on a control that isn't
+   actually one of the page tabs. */
+.navbar .shinyngs-navbar-icon-btn {
+  color: var(--bs-navbar-color, rgba(255, 255, 255, 0.85));
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+}
+.navbar .shinyngs-navbar-icon-btn:hover,
+.navbar .shinyngs-navbar-icon-btn:focus {
+  color: var(--bs-navbar-hover-color, #fff);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .shinyngs-tilebox, .shinyngs-tile-hint .fa, .shinyngs-tile-hint svg { transition: none; }
   .shinyngs-drawer-in { animation: none; }

--- a/inst/www/shinyngs.js
+++ b/inst/www/shinyngs.js
@@ -117,4 +117,26 @@
       }
     });
   }
+
+  // Plot download format toggle: a plain icon button (styled like the
+  // light/dark toggle) that flips between PNG and SVG. R never binds to this
+  // element directly; it just reads the resulting Shiny input value once, via
+  // session$userData in configureBookmarking(), so every renderPlotly() picks
+  // it up without taking it as an extra module argument.
+  var PLOT_FORMAT_ICON_CLASS = { png: "far fa-file-image", svg: "fas fa-bezier-curve" };
+
+  function setPlotFormatButtonState(btn, format) {
+    btn.setAttribute("data-format", format);
+    var i = btn.querySelector("i");
+    if (i) i.className = PLOT_FORMAT_ICON_CLASS[format];
+    var next = format === "png" ? "SVG" : "PNG";
+    btn.setAttribute("aria-label", "Plot download format: " + format.toUpperCase() + ". Click to switch to " + next + ".");
+  }
+
+  $(document).on("click", "#shinyngs_plot_format_toggle", function () {
+    var btn = this;
+    var next = btn.getAttribute("data-format") === "png" ? "svg" : "png";
+    setPlotFormatButtonState(btn, next);
+    if (window.Shiny) Shiny.setInputValue("shinyngs_plot_format", next, { priority: "event" });
+  });
 })();

--- a/man/shinyngsPlotlyConfig.Rd
+++ b/man/shinyngsPlotlyConfig.Rd
@@ -4,12 +4,15 @@
 \alias{shinyngsPlotlyConfig}
 \title{Apply shinyngs' shared plotly toolbar configuration}
 \usage{
-shinyngsPlotlyConfig(p, filename = "shinyngs_plot")
+shinyngsPlotlyConfig(p, filename = "shinyngs_plot", format = "png")
 }
 \arguments{
 \item{p}{A plotly object}
 
-\item{filename}{Base name (no extension) for the PNG download}
+\item{filename}{Base name (no extension) for the downloaded image}
+
+\item{format}{Image format for the download button, e.g. \code{"png"} or
+\code{"svg"}}
 }
 \value{
 The plotly object with a shared \code{config()} applied
@@ -17,8 +20,8 @@ The plotly object with a shared \code{config()} applied
 \description{
 Gives every interactive plot the same modebar: the plotly logo is dropped,
 the noisier selection buttons are removed, and the "download plot" button
-produces a PNG named after the plot rather than the generic
-\code{newplot.png}. Call once on the assembled plotly object before
-returning it from a \code{renderPlotly()}.
+produces an image named after the plot (rather than the generic
+\code{newplot.png}) in the user's chosen format. Call once on the assembled
+plotly object before returning it from a \code{renderPlotly()}.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary

- Adds a single icon toggle to the navbar, next to the light/dark switch, that lets users pick PNG or SVG for every Plotly panel's camera/download button.
- The choice is published once via `session$userData` in `configureBookmarking()` and read by each of the 12 `renderPlotly()` call sites (barplot, boxplot, clustering, dendro, gene, genesetbarcodeplot, heatmap, illuminaarrayqc, scatterplot, upset), so no module server signature needs to carry it as an argument.
- `shinyngsPlotlyConfig()` gains a `format` parameter (default `"png"`, unchanged behaviour if unset).
- Styled as a plain icon button rather than a dropdown, matching the visual weight of the existing light/dark toggle; deliberately avoids the `nav-link` class since that pulls an element into the navbar's tablist roving-tabindex behaviour, which would make it unreachable via keyboard Tab.

## Related

Addresses part of #179 (publication-quality static plot export): specifically the "no vector export option" gap for the 12 Plotly-rendered panels. The issue's other threads - a proper `ggsave`-based rewrite of `plotdownload()`, wiring the existing static ggplot builders into their Shiny modules, the orphaned UpSet download button, and static export for heatmap/dendrogram/barplot/barcode plots - are still open and out of scope here.

## Test plan

- [x] `R CMD INSTALL` + full `testthat` suite (`pkgload::load_all()` + `test_dir()`): 226 passed, 0 failed
- [x] Manually verified in a running app (zhangneurons dataset): toggle renders next to the dark-mode switch with even spacing, click flips the icon, and the Plotly div's live `toImageButtonOptions.format` updates from `png` to `svg` with no console errors
- [x] Confirmed the button is a normal keyboard-focusable control (`tabindex="0"`), not swept into the tab-panel roving-tabindex group