### PR TITLE
Increase hex logo size by 50% in README and pkgdown site

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# shinyngs <img src="man/figures/logo.png" align="right" height="139" alt="shinyngs hex logo" />
+# shinyngs <img src="man/figures/logo.png" align="right" height="209" alt="shinyngs hex logo" />
 
 # Synopsis
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# shinyngs <img src="man/figures/logo.png" align="right" height="139" alt="shinyngs hex logo" />
+# shinyngs <img src="man/figures/logo.png" align="right" height="209" alt="shinyngs hex logo" />
 
 # Synopsis
 

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -1,0 +1,15 @@
+// Bump the package logo 50% over pkgdown's defaults (100px / 120px on the
+// home page / 80px on narrow screens), keeping the same proportions between
+// contexts.
+img.logo {
+  width: 150px;
+}
+.template-home img.logo {
+  width: 180px;
+}
+
+@include media-breakpoint-down(sm) {
+  img.logo {
+    width: 120px;
+  }
+}


### PR DESCRIPTION
## Summary
- README: logo `<img>` height 139 -> 209 (+50%)
- pkgdown site: adds `pkgdown/extra.scss` overriding pkgdown's default `img.logo` widths (100px/120px-home/80px-mobile -> 150px/180px/120px), keeping the same relative proportions between contexts

## Test plan
- [x] Rebuilt the site locally with `pkgdown::build_site()`; verified in a headless browser that the logo renders larger with no overlap/clipping on both the home page and a reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)