### PR TITLE
Add software credits: README and in-app Credits modal

### DIFF
--- a/R/accessory.R
+++ b/R/accessory.R
@@ -205,10 +205,12 @@ pushToList <- function(input_list, element) {
 #' Build the top-level bslib page shell shared by the app modules
 #'
 #' Applies the package's Bootstrap 5 theme and dark navbar styling, injects
-#' the package CSS/JS and shinyjs, adds a light/dark mode toggle to the
-#' navbar, and constructs the resulting \code{bslib::page_navbar()}. The
-#' accent colour is defined once here, on the theme, and everything else
-#' (CSS, plots) derives from the resulting Bootstrap variables.
+#' the package CSS/JS and shinyjs, adds a light/dark mode toggle and a
+#' "Credits" link (software acknowledgements, via the \code{shinyngs_credits}
+#' modal wired up in \code{configureBookmarking()}) to the navbar, and
+#' constructs the resulting \code{bslib::page_navbar()}. The accent colour is
+#' defined once here, on the theme, and everything else (CSS, plots) derives
+#' from the resulting Bootstrap variables.
 #'
 #' @param navbar_menus A named list of arguments accepted by
 #' \code{bslib::page_navbar()} (\code{id}, \code{title}, \code{window_title},
@@ -259,6 +261,11 @@ shinyngsPageNavbar <- function(navbar_menus) {
       label = "Plot download format: PNG. Click to switch to SVG.",
       tooltip = "Format used by each plot's camera/download button - click to toggle PNG/SVG",
       placement = "bottom"
+    )),
+    bslib::nav_item(modalInput(
+      "shinyngs_credits", "Credits",
+      class = "btn btn-sm",
+      tooltip = "Software this app is built on"
     ))
   ))
   do.call(bslib::page_navbar, navbar_menus)
@@ -298,6 +305,10 @@ bookmarkedInputValue <- function(state, session, id) {
 #' On bookmark, the state URL is written to the address bar so it can be copied
 #' and shared directly, with a notification pointing the user there.
 #'
+#' Also wires up the \code{shinyngs_credits} modal server, since this is the
+#' one place called once per top-level session across every app type
+#' (rnaseq, chipseq, illuminaarray, simpleApp).
+#'
 #' @param input The top-level \code{input} object, which carries all inputs
 #'   across module namespaces under their fully-qualified names
 #' @param session The top-level session
@@ -312,6 +323,8 @@ configureBookmarking <- function(input, session, nav_input = NULL) {
   # process actually runs the app, including harnesses that transport the app
   # object to a fresh process where prepareApp's option would be lost.
   enableBookmarking("url")
+
+  modalServer("shinyngs_credits", "Credits")
 
   # session$userData is shared with every nested module session, so plot
   # modules can read the chosen download format without each one taking it

--- a/R/modal.R
+++ b/R/modal.R
@@ -82,5 +82,5 @@ help_modal_ids <- c(
   "dexseqplot", "dexseqtable", "differentialtable", "experimenttable",
   "expressionheatmap", "foldchangeplot", "gene", "genesetanalysistable",
   "genesetbarcodeplot", "illuminaarrayqc", "maplot", "pca", "pcavsexperiment",
-  "readreports", "rowmetatable", "upset", "volcanoplot"
+  "readreports", "rowmetatable", "shinyngs_credits", "upset", "volcanoplot"
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -258,13 +258,13 @@ vignette('shinyngs')
 
 Shinyngs combines a number of other open-source packages to do its work. Deployed apps also carry a "Credits" link in the navbar crediting these directly, but for reference:
 
-* [Shiny](https://shiny.posit.co/) and [bslib](https://rstudio.github.io/bslib/) - the application framework and Bootstrap 5 theming.
-* [DT](https://rstudio.github.io/DT/), wrapping the [DataTables](https://datatables.net/) jQuery plugin - interactive tables.
-* [plotly](https://plotly.com/r/), wrapping [plotly.js](https://plotly.com/javascript/) - interactive plots.
-* [heatmaply](https://talgalili.github.io/heatmaply/) - interactive heatmaps.
-* [ggplot2](https://ggplot2.tidyverse.org/) and [ggdendro](https://cran.r-project.org/package=ggdendro) - static plotting.
-* [igvShiny](https://github.com/gladkia/igvShiny), wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene model browser.
-* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/), [limma](https://bioconductor.org/packages/limma/) and [DEXSeq](https://bioconductor.org/packages/DEXSeq/) from Bioconductor.
+* [Shiny](https://shiny.posit.co/) (Winston Chang, Joe Cheng, JJ Allaire, Carson Sievert et al., Posit Software) and [bslib](https://rstudio.github.io/bslib/) (Carson Sievert, Joe Cheng, Garrick Aden-Buie) - the application framework and Bootstrap 5 theming.
+* [DT](https://rstudio.github.io/DT/) (Yihui Xie, Joe Cheng, Xianying Tan, Garrick Aden-Buie), wrapping the [DataTables](https://datatables.net/) jQuery plugin (SpryMedia Ltd) - interactive tables.
+* [plotly](https://plotly.com/r/) (Carson Sievert, Chris Parmer, Toby Hocking, Scott Chamberlain, Karthik Ram, Marianne Corvellec, Pedro Despouy), wrapping [plotly.js](https://plotly.com/javascript/) (Plotly Technologies Inc.) - interactive plots.
+* [heatmaply](https://talgalili.github.io/heatmaply/) (Tal Galili, Alan O'Callaghan) - interactive heatmaps.
+* [ggplot2](https://ggplot2.tidyverse.org/) (Hadley Wickham et al.) and [ggdendro](https://cran.r-project.org/package=ggdendro) (Andrie de Vries) - static plotting.
+* [igvShiny](https://github.com/gladkia/igvShiny) (Paul Shannon, Arkadiusz Gladki, Karolina Ścigocka), wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js, Broad Institute) - the gene model browser.
+* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/) (Martin Morgan, Valerie Obenchain, Jim Hester, Hervé Pagès), [limma](https://bioconductor.org/packages/limma/) (Gordon Smyth et al.) and [DEXSeq](https://bioconductor.org/packages/DEXSeq/) (Simon Anders, Alejandro Reyes) from Bioconductor.
 
 The full dependency list, with versions, is in [DESCRIPTION](DESCRIPTION).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -252,7 +252,21 @@ vignette('shinyngs')
 
 # TODO
 
-* More useful non-RNAseq functionality to be added 
+* More useful non-RNAseq functionality to be added
+
+# Credits
+
+Shinyngs combines a number of other open-source packages to do its work. Deployed apps also carry a "Credits" link in the navbar crediting these directly, but for reference:
+
+* [Shiny](https://shiny.posit.co/) and [bslib](https://rstudio.github.io/bslib/) - the application framework and Bootstrap 5 theming.
+* [DT](https://rstudio.github.io/DT/), wrapping the [DataTables](https://datatables.net/) jQuery plugin - interactive tables.
+* [plotly](https://plotly.com/r/), wrapping [plotly.js](https://plotly.com/javascript/) - interactive plots.
+* [heatmaply](https://talgalili.github.io/heatmaply/) - interactive heatmaps.
+* [ggplot2](https://ggplot2.tidyverse.org/) and [ggdendro](https://cran.r-project.org/package=ggdendro) - static plotting.
+* [igvShiny](https://github.com/gladkia/igvShiny), wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene model browser.
+* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/), [limma](https://bioconductor.org/packages/limma/) and [DEXSeq](https://bioconductor.org/packages/DEXSeq/) from Bioconductor.
+
+The full dependency list, with versions, is in [DESCRIPTION](DESCRIPTION).
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -332,25 +332,33 @@ Shinyngs combines a number of other open-source packages to do its work.
 Deployed apps also carry a “Credits” link in the navbar crediting these
 directly, but for reference:
 
-- [Shiny](https://shiny.posit.co/) and
-  [bslib](https://rstudio.github.io/bslib/) - the application framework
-  and Bootstrap 5 theming.
-- [DT](https://rstudio.github.io/DT/), wrapping the
-  [DataTables](https://datatables.net/) jQuery plugin - interactive
-  tables.
-- [plotly](https://plotly.com/r/), wrapping
-  [plotly.js](https://plotly.com/javascript/) - interactive plots.
-- [heatmaply](https://talgalili.github.io/heatmaply/) - interactive
-  heatmaps.
-- [ggplot2](https://ggplot2.tidyverse.org/) and
-  [ggdendro](https://cran.r-project.org/package=ggdendro) - static
-  plotting.
-- [igvShiny](https://github.com/gladkia/igvShiny), wrapping the
-  [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene
-  model browser.
-- [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/),
-  [limma](https://bioconductor.org/packages/limma/) and
-  [DEXSeq](https://bioconductor.org/packages/DEXSeq/) from Bioconductor.
+- [Shiny](https://shiny.posit.co/) (Winston Chang, Joe Cheng, JJ
+  Allaire, Carson Sievert et al., Posit Software) and
+  [bslib](https://rstudio.github.io/bslib/) (Carson Sievert, Joe Cheng,
+  Garrick Aden-Buie) - the application framework and Bootstrap 5
+  theming.
+- [DT](https://rstudio.github.io/DT/) (Yihui Xie, Joe Cheng, Xianying
+  Tan, Garrick Aden-Buie), wrapping the
+  [DataTables](https://datatables.net/) jQuery plugin (SpryMedia Ltd) -
+  interactive tables.
+- [plotly](https://plotly.com/r/) (Carson Sievert, Chris Parmer, Toby
+  Hocking, Scott Chamberlain, Karthik Ram, Marianne Corvellec, Pedro
+  Despouy), wrapping [plotly.js](https://plotly.com/javascript/) (Plotly
+  Technologies Inc.) - interactive plots.
+- [heatmaply](https://talgalili.github.io/heatmaply/) (Tal Galili, Alan
+  O’Callaghan) - interactive heatmaps.
+- [ggplot2](https://ggplot2.tidyverse.org/) (Hadley Wickham et al.) and
+  [ggdendro](https://cran.r-project.org/package=ggdendro) (Andrie de
+  Vries) - static plotting.
+- [igvShiny](https://github.com/gladkia/igvShiny) (Paul Shannon,
+  Arkadiusz Gladki, Karolina Ścigocka), wrapping the [Integrative
+  Genomics Viewer](https://igv.org/) (igv.js, Broad Institute) - the
+  gene model browser.
+- [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/)
+  (Martin Morgan, Valerie Obenchain, Jim Hester, Hervé Pagès),
+  [limma](https://bioconductor.org/packages/limma/) (Gordon Smyth et
+  al.) and [DEXSeq](https://bioconductor.org/packages/DEXSeq/) (Simon
+  Anders, Alejandro Reyes) from Bioconductor.
 
 The full dependency list, with versions, is in
 [DESCRIPTION](DESCRIPTION).

--- a/README.md
+++ b/README.md
@@ -326,6 +326,35 @@ vignette('shinyngs')
 
 - More useful non-RNAseq functionality to be added
 
+# Credits
+
+Shinyngs combines a number of other open-source packages to do its work.
+Deployed apps also carry a “Credits” link in the navbar crediting these
+directly, but for reference:
+
+- [Shiny](https://shiny.posit.co/) and
+  [bslib](https://rstudio.github.io/bslib/) - the application framework
+  and Bootstrap 5 theming.
+- [DT](https://rstudio.github.io/DT/), wrapping the
+  [DataTables](https://datatables.net/) jQuery plugin - interactive
+  tables.
+- [plotly](https://plotly.com/r/), wrapping
+  [plotly.js](https://plotly.com/javascript/) - interactive plots.
+- [heatmaply](https://talgalili.github.io/heatmaply/) - interactive
+  heatmaps.
+- [ggplot2](https://ggplot2.tidyverse.org/) and
+  [ggdendro](https://cran.r-project.org/package=ggdendro) - static
+  plotting.
+- [igvShiny](https://github.com/gladkia/igvShiny), wrapping the
+  [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene
+  model browser.
+- [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/),
+  [limma](https://bioconductor.org/packages/limma/) and
+  [DEXSeq](https://bioconductor.org/packages/DEXSeq/) from Bioconductor.
+
+The full dependency list, with versions, is in
+[DESCRIPTION](DESCRIPTION).
+
 # Contributors
 
 I can be reached on @pinin4fjords with any queries. Other contributors

--- a/inst/inlinehelp/shinyngs_credits.md
+++ b/inst/inlinehelp/shinyngs_credits.md
@@ -6,22 +6,25 @@ This application is built with [shinyngs](https://github.com/pinin4fjords/shinyn
 
 ##### Application framework
 
-* [Shiny](https://shiny.posit.co/) - Chang W, Cheng J, Allaire J, Sievert C, Schloerke B, Xie Y, Allen J, McPherson J, Dipert A, Borges B (2024). _shiny: Web Application Framework for R_.
-* [bslib](https://rstudio.github.io/bslib/) - Bootstrap 5 theming for Shiny.
-* [shinyjs](https://deanattali.com/shinyjs/), [shinycssloaders](https://github.com/daattali/shinycssloaders) - client-side interactivity and loading spinners.
+* [Shiny](https://shiny.posit.co/) - Winston Chang, Joe Cheng, JJ Allaire, Carson Sievert, Barret Schloerke, Garrick Aden-Buie, Yihui Xie, Jeff Allen, Jonathan McPherson, Alan Dipert, Barbara Borges (Posit Software).
+* [bslib](https://rstudio.github.io/bslib/) - Carson Sievert, Joe Cheng, Garrick Aden-Buie (Posit Software) - Bootstrap 5 theming for Shiny.
+* [shinyjs](https://deanattali.com/shinyjs/) - Dean Attali.
+* [shinycssloaders](https://github.com/daattali/shinycssloaders) - Andras Sali (original author), maintained by Dean Attali.
 
 ##### Tables and plots
 
-* [DT](https://rstudio.github.io/DT/), wrapping the [DataTables](https://datatables.net/) jQuery plugin - interactive tables.
-* [plotly](https://plotly.com/r/), wrapping [plotly.js](https://plotly.com/javascript/) - interactive plots.
-* [heatmaply](https://talgalili.github.io/heatmaply/) - interactive heatmaps.
-* [ggplot2](https://ggplot2.tidyverse.org/), [ggdendro](https://cran.r-project.org/package=ggdendro), [scatterplot3d](https://cran.r-project.org/package=scatterplot3d) - static plotting.
-* [igvShiny](https://github.com/gladkia/igvShiny), wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene model browser.
+* [DT](https://rstudio.github.io/DT/) - Yihui Xie, Joe Cheng, Xianying Tan, Garrick Aden-Buie, wrapping the [DataTables](https://datatables.net/) jQuery plugin (SpryMedia Ltd) - interactive tables.
+* [plotly](https://plotly.com/r/) - Carson Sievert, Chris Parmer, Toby Hocking, Scott Chamberlain, Karthik Ram, Marianne Corvellec, Pedro Despouy, wrapping [plotly.js](https://plotly.com/javascript/) (Plotly Technologies Inc.) - interactive plots.
+* [heatmaply](https://talgalili.github.io/heatmaply/) - Tal Galili, Alan O'Callaghan - interactive heatmaps.
+* [ggplot2](https://ggplot2.tidyverse.org/) - Hadley Wickham, Winston Chang, Lionel Henry, Thomas Lin Pedersen and contributors (Posit Software) - static plotting.
+* [ggdendro](https://cran.r-project.org/package=ggdendro) - Andrie de Vries.
+* [scatterplot3d](https://cran.r-project.org/package=scatterplot3d) - Uwe Ligges, Martin Mächler, Sarah Schnackenberg.
+* [igvShiny](https://github.com/gladkia/igvShiny) - Paul Shannon, Arkadiusz Gladki, Karolina Ścigocka, wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js, Broad Institute) - the gene model browser.
 
 ##### Bioconductor
 
-* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/) - the underlying data structure for expression matrices and metadata.
-* [limma](https://bioconductor.org/packages/limma/) - used for some of the plotting and gene set utilities.
-* [DEXSeq](https://bioconductor.org/packages/DEXSeq/) - differential exon usage table and plots, where supplied.
+* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/) - Martin Morgan, Valerie Obenchain, Jim Hester, Hervé Pagès - the underlying data structure for expression matrices and metadata.
+* [limma](https://bioconductor.org/packages/limma/) - Gordon Smyth and contributors - used for some of the plotting and gene set utilities.
+* [DEXSeq](https://bioconductor.org/packages/DEXSeq/) - Simon Anders, Alejandro Reyes - differential exon usage table and plots, where supplied.
 
-Full package versions and licenses for a given installation can be listed with `sessionInfo()`; the complete dependency list is in shinyngs' [DESCRIPTION](https://github.com/pinin4fjords/shinyngs/blob/develop/DESCRIPTION) file.
+Full package versions, licenses and complete author/contributor lists for a given installation can be listed with `sessionInfo()`; the complete dependency list is in shinyngs' [DESCRIPTION](https://github.com/pinin4fjords/shinyngs/blob/develop/DESCRIPTION) file.

--- a/inst/inlinehelp/shinyngs_credits.md
+++ b/inst/inlinehelp/shinyngs_credits.md
@@ -1,0 +1,27 @@
+#### About
+
+This application is built with [shinyngs](https://github.com/pinin4fjords/shinyngs), an R package for interactive exploration of NGS/array expression data. shinyngs itself does no analysis - it visualises matrices, metadata and differential results computed elsewhere, using the packages below.
+
+#### Credits
+
+##### Application framework
+
+* [Shiny](https://shiny.posit.co/) - Chang W, Cheng J, Allaire J, Sievert C, Schloerke B, Xie Y, Allen J, McPherson J, Dipert A, Borges B (2024). _shiny: Web Application Framework for R_.
+* [bslib](https://rstudio.github.io/bslib/) - Bootstrap 5 theming for Shiny.
+* [shinyjs](https://deanattali.com/shinyjs/), [shinycssloaders](https://github.com/daattali/shinycssloaders) - client-side interactivity and loading spinners.
+
+##### Tables and plots
+
+* [DT](https://rstudio.github.io/DT/), wrapping the [DataTables](https://datatables.net/) jQuery plugin - interactive tables.
+* [plotly](https://plotly.com/r/), wrapping [plotly.js](https://plotly.com/javascript/) - interactive plots.
+* [heatmaply](https://talgalili.github.io/heatmaply/) - interactive heatmaps.
+* [ggplot2](https://ggplot2.tidyverse.org/), [ggdendro](https://cran.r-project.org/package=ggdendro), [scatterplot3d](https://cran.r-project.org/package=scatterplot3d) - static plotting.
+* [igvShiny](https://github.com/gladkia/igvShiny), wrapping the [Integrative Genomics Viewer](https://igv.org/) (igv.js) - the gene model browser.
+
+##### Bioconductor
+
+* [SummarizedExperiment](https://bioconductor.org/packages/SummarizedExperiment/) - the underlying data structure for expression matrices and metadata.
+* [limma](https://bioconductor.org/packages/limma/) - used for some of the plotting and gene set utilities.
+* [DEXSeq](https://bioconductor.org/packages/DEXSeq/) - differential exon usage table and plots, where supplied.
+
+Full package versions and licenses for a given installation can be listed with `sessionInfo()`; the complete dependency list is in shinyngs' [DESCRIPTION](https://github.com/pinin4fjords/shinyngs/blob/develop/DESCRIPTION) file.

--- a/man/configureBookmarking.Rd
+++ b/man/configureBookmarking.Rd
@@ -26,5 +26,9 @@ observer keeps the exclude list in sync with those inputs as they appear
 \details{
 On bookmark, the state URL is written to the address bar so it can be copied
 and shared directly, with a notification pointing the user there.
+
+Also wires up the \code{shinyngs_credits} modal server, since this is the
+one place called once per top-level session across every app type
+(rnaseq, chipseq, illuminaarray, simpleApp).
 }
 \keyword{internal}

--- a/man/modalServer.Rd
+++ b/man/modalServer.Rd
@@ -15,7 +15,8 @@ stay current.}
 
 \item{content}{Content to include in the modal. May be a function, called
 each time the modal opens. When \code{NULL} (the default), Markdown is
-loaded once from \code{inst/inlinehelp/<id>.md}.}
+loaded from \code{inst/inlinehelp/<id>.md} the first time the modal is
+opened, then cached for the life of the session.}
 }
 \description{
 This module uses Shiny's \code{modalDialog()} to create overlaid text for the

--- a/man/shinyngsPageNavbar.Rd
+++ b/man/shinyngsPageNavbar.Rd
@@ -17,9 +17,11 @@ A \code{bslib::page_navbar()}
 }
 \description{
 Applies the package's Bootstrap 5 theme and dark navbar styling, injects
-the package CSS/JS and shinyjs, adds a light/dark mode toggle to the
-navbar, and constructs the resulting \code{bslib::page_navbar()}. The
-accent colour is defined once here, on the theme, and everything else
-(CSS, plots) derives from the resulting Bootstrap variables.
+the package CSS/JS and shinyjs, adds a light/dark mode toggle and a
+"Credits" link (software acknowledgements, via the \code{shinyngs_credits}
+modal wired up in \code{configureBookmarking()}) to the navbar, and
+constructs the resulting \code{bslib::page_navbar()}. The accent colour is
+defined once here, on the theme, and everything else (CSS, plots) derives
+from the resulting Bootstrap variables.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- Adds a "Credits" link to the shared app navbar (next to Share view / dark mode / plot format toggle) that opens a modal acknowledging the open-source packages shinyngs builds on (Shiny, bslib, DT/DataTables, plotly, heatmaply, ggplot2, igvShiny, SummarizedExperiment, limma, DEXSeq), using the existing help-modal (`modalInput`/`modalServer`) pattern.
- Adds a matching "Credits" section to the README with the same acknowledgements and a pointer to DESCRIPTION for the full dependency list.

## Test plan
- [x] `testthat` suite passes (`devtools::load_all()` + `test_dir()`)
- [x] `lintr::lint_package()` - no lints
- [x] Installed the branch into a local env, launched the rnaseq app against `zhangneurons` test data, and clicked through the new Credits link in a headless browser to confirm the modal opens with correctly rendered content and the Close button dismisses it