### PR TITLE
Hygiene batch: remove stale biomaRt example/dependency, naming-convention drift, CLI shape

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Naming convention
+
+New code should use `snake_case` for function and variable names. This is
+already the convention for I/O and validation helpers (`read_matrix()`,
+`guess_foldchange_scale()`, `validate_inputs()`).
+
+Existing exported, user-facing functions use a mix of `camelCase` and
+`snake_case` (e.g. `eselistFromYAML()` vs. `eselistfromConfig()`). Renaming
+these is a breaking change for anyone scripting against the package, so they
+are left as-is; don't mass-rename exported functions to fit this convention.
+Internal helpers and new code are not subject to that constraint and should
+use `snake_case`.
+
+Where a Shiny module passes a reactive as an argument, prefix its parameter
+name with `get` (`getTitle`, `getPalette`, `getColorby`) to distinguish it
+from a plain value of the same concept (e.g. the `colorby` column-name string
+parameter used by the plotting/builder functions those modules call). Don't
+let the same name mean "a reactive" in one layer and "a plain value" in
+another.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Suggests:
     airway,
     BiocStyle,
     BiocManager,
-    biomaRt,
     covr,
     devtools,
     DEXSeq,

--- a/R/apps.R
+++ b/R/apps.R
@@ -59,23 +59,22 @@
 #'
 #' # 2: AUGMENT WITH ANNOTATION INFO FOR MORE INFORMATIVE APP
 #'
-#' # Use Biomart to retrieve some annotation, add it to the object, then choose a
-#' # different default grouping variable and re-make the app.
+#' # Add row metadata (gene symbol, genomic coordinates) so plots and tables
+#' # are labelled meaningfully, then choose a different default grouping
+#' # variable and re-make the app. Any source of per-gene annotation works
+#' # here (a GTF, an annotation package, a pre-built CSV); the requirement is
+#' # a data.frame keyed by the same IDs as rownames(ese). Adding
+#' # chromosome_name/start_position/end_position columns plus ensembl_species
+#' # also enables the igv.js gene model view on the gene page.
 #'
 #' if (interactive()) {
-#'   library(biomaRt)
-#'   attributes <- c(
-#'     "ensembl_gene_id", # The sort of ID your results are keyed by
-#'     "entrezgene", # Could be used for gene sets keyed by Entrez ID
-#'     "external_gene_name" # Used to annotate gene names on the plot
+#'   annotation <- data.frame(
+#'     ensembl_gene_id = rownames(ese),
+#'     external_gene_name = rownames(ese), # substitute real gene symbols
+#'     chromosome_name = "1", # substitute real coordinates
+#'     start_position = seq_along(rownames(ese)),
+#'     end_position = seq_along(rownames(ese)) + 1000
 #'   )
-#'
-#'   mart <- useMart(
-#'     biomart = "ENSEMBL_MART_ENSEMBL",
-#'     dataset = "hsapiens_gene_ensembl", host = "www.ensembl.org"
-#'   )
-#'   annotation <- getBM(attributes = attributes, mart = mart)
-#'   annotation <- annotation[order(annotation$entrezgene), ]
 #'
 #'   mcols(ese) <- annotation[match(rownames(ese), annotation$ensembl_gene_id), ]
 #'   ese@labelfield <- "external_gene_name"
@@ -85,7 +84,8 @@
 #'     title = expinfo$Title,
 #'     author = expinfo$Author,
 #'     description = expinfo$Description,
-#'     default_groupvar = "dex"
+#'     default_groupvar = "dex",
+#'     ensembl_species = "hsapiens" # enables the igv.js gene model view
 #'   )
 #'   app <- prepareApp("rnaseq", eselist)
 #'   shiny::shinyApp(ui = app$ui, server = app$server)

--- a/R/foldchangeplot.R
+++ b/R/foldchangeplot.R
@@ -144,7 +144,7 @@ foldchangeplot <- function(id, eselist) {
 
     # Pass the matrix to the scatterplot module for display
 
-    scatterplot("foldchange", getDatamatrix = foldchangeTable, getTitle = getTitle, allow_3d = FALSE, getLabels = foldchangeLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
+    scatterplot("foldchange", getDatamatrix = foldchangeTable, getTitle = getTitle, allow_3d = FALSE, getLabels = foldchangeLabels, x = 1, y = 2, getColorby = getColorby, getLines = plotLines)
 
     # Make a title by selecting the single contrast name of the single filter set
 
@@ -201,7 +201,7 @@ foldchangeplot <- function(id, eselist) {
 
     # Extract a vector use to make colors by group
 
-    colorBy <- reactive({
+    getColorby <- reactive({
       fct <- foldchangeTable()
       fct$colorby
     })

--- a/R/maplot.R
+++ b/R/maplot.R
@@ -150,7 +150,7 @@ maplot <- function(id, eselist) {
 
     # Pass the matrix to the scatterplot module for display
 
-    scatterplot("ma", getDatamatrix = maTable, getTitle = getTitle, allow_3d = FALSE, getLabels = maLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
+    scatterplot("ma", getDatamatrix = maTable, getTitle = getTitle, allow_3d = FALSE, getLabels = maLabels, x = 1, y = 2, getColorby = getColorby, getLines = plotLines)
 
 
     # Make a title by selecting the single contrast name of the single filter set
@@ -205,7 +205,7 @@ maplot <- function(id, eselist) {
 
     # Extract a vector use to make colors by group
 
-    colorBy <- reactive({
+    getColorby <- reactive({
       fct <- maTable()
       fct$colorby
     })

--- a/R/pca.R
+++ b/R/pca.R
@@ -138,7 +138,7 @@ pca <- function(id, eselist) {
     scatterplot("pca",
       getDatamatrix = pcaMatrix, getThreedee = scatterplotcontrols_reactives$getThreedee, getXAxis = scatterplotcontrols_reactives$getXAxis,
       getYAxis = scatterplotcontrols_reactives$getYAxis, getZAxis = scatterplotcontrols_reactives$getZAxis, getShowLabels = scatterplotcontrols_reactives$getShowLabels,
-      getPointSize = scatterplotcontrols_reactives$getPointSize, getTitle = getComponentsTitle, colorBy = pcaColorBy, getPalette = groupby_reactives$getPalette
+      getPointSize = scatterplotcontrols_reactives$getPointSize, getTitle = getComponentsTitle, getColorby = pcaGetColorby, getPalette = groupby_reactives$getPalette
     )
     scatterplot("loading",
       getDatamatrix = loadingMatrix, getThreedee = scatterplotcontrols_reactives$getThreedee, getXAxis = scatterplotcontrols_reactives$getXAxis,
@@ -173,7 +173,7 @@ pca <- function(id, eselist) {
       pcam
     })
 
-    pcaColorBy <- reactive({
+    pcaGetColorby <- reactive({
       if (is.null(groupby_reactives$getGroupby())) {
 
       } else {

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -78,10 +78,10 @@ scatterplotOutput <- function(id) {
 #' @param getTitle A reactive expression supplying a title.
 #' @param getLabels A reactive supplying a list of labels to use instead of row
 #' names from \code{getDatamatrix()}
-#' @param colorBy A reactive returning a factor definining the groups in which
-#' points should be colored.
+#' @param getColorby A reactive returning a factor definining the groups in
+#' which points should be colored.
 #' @param getPalette An optional palette of colors, one for each level of
-#' colorBy.
+#' getColorby.
 #
 #' @param allow_3d Passed to \code{\link{scatterplotcontrolsInput}} to dermine
 #' if the user will be allowed to create 3D plots.
@@ -104,7 +104,7 @@ scatterplotOutput <- function(id) {
 #' Three columns required: name, x and y, with two rows for every value of
 #' name. These two rows represent the start and end of a line.
 
-scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, getYAxis = NULL, getZAxis = NULL, getShowLabels = NULL, getPointSize = NULL, getPalette = NULL, colorBy = NULL, getTitle = reactive({
+scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, getYAxis = NULL, getZAxis = NULL, getShowLabels = NULL, getPointSize = NULL, getPalette = NULL, getColorby = NULL, getTitle = reactive({
                           ""
                         }), getLabels = reactive({
                           rownames(getDatamatrix())
@@ -119,9 +119,9 @@ scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, 
     # If no colors are provided, make our own if necessary. This will cause the 'getPalette' reactive to be passed back from scatterplotcontrols.
 
     getNumberColors <- reactive({
-      make_colors <- is.null(getPalette) && !is.null(colorBy)
+      make_colors <- is.null(getPalette) && !is.null(getColorby)
       if (make_colors) {
-        cb <- colorBy()
+        cb <- getColorby()
         nlevels(cb)
       } else {
         NULL
@@ -190,7 +190,7 @@ scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, 
     # Only show a legend if we're coloring points
 
     showLegend <- reactive({
-      if (is.null(colorBy)) {
+      if (is.null(getColorby)) {
         FALSE
       } else {
         TRUE
@@ -201,8 +201,8 @@ scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, 
 
     output$scatter <- renderPlotly({
       withProgress(message = "Drawing scatter plot", value = 0, {
-        if (!is.null(colorBy)) {
-          cb <- colorBy()
+        if (!is.null(getColorby)) {
+          cb <- getColorby()
 
           # If a palette was supplied, or if we made our own...
 

--- a/R/volcanoplot.R
+++ b/R/volcanoplot.R
@@ -157,7 +157,7 @@ volcanoplot <- function(id, eselist) {
 
     # Pass the matrix to the scatterplot module for display
 
-    scatterplot("volcano", getDatamatrix = volcanoTable, getTitle = getTitle, allow_3d = FALSE, getLabels = volcanoLabels, x = 1, y = 2, colorBy = colorBy, getLines = plotLines)
+    scatterplot("volcano", getDatamatrix = volcanoTable, getTitle = getTitle, allow_3d = FALSE, getLabels = volcanoLabels, x = 1, y = 2, getColorby = getColorby, getLines = plotLines)
 
     # Make a title by selecting the single contrast name of the single filter set
 
@@ -220,7 +220,7 @@ volcanoplot <- function(id, eselist) {
 
     # Extract a vector use to make colors by group
 
-    colorBy <- reactive({
+    getColorby <- reactive({
       vt <- volcanoTable()
       vt$colorby
     })

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -1,260 +1,530 @@
 #!/usr/bin/env Rscript
 
-# This should be integrated with
+# Build an ExploratorySummarizedExperimentList from flat files, write a
+# ready-to-run Shiny app bundle, and optionally deploy it to shinyapps.io.
 
 library(optparse)
 
-option_list <- list(
-  make_option(
-    c("-t", "--title"),
-    type = "character",
-    default = "Default title",
-    help = "Experiment title to show."
+option_list <- c(
+  # Title and description --------------------------------------------------
+  list(
+    make_option(
+      c("-t", "--title"),
+      type = "character",
+      default = "Default title",
+      help = "Experiment title to show."
+    ),
+    make_option(
+      c("-a", "--author"),
+      type = "character",
+      default = "My authors",
+      help = "Author string to display."
+    ),
+    make_option(
+      c("-r", "--description"),
+      type = "character",
+      default = NULL,
+      help = "A description to display in the app."
+    ),
+    make_option(
+      c("-m", "--report_markdown_file"),
+      type = "character",
+      default = NULL,
+      help = "Path to file with description/ reporting in markdown. Alternative to 'description' for more extensive description content."
+    )
   ),
-  make_option(
-    c("-a", "--author"),
-    type = "character",
-    default = "My authors",
-    help = "Author string to display."
+  # Sample metadata ----------------------------------------------------------
+  list(
+    make_option(
+      c("-s", "--sample_metadata"),
+      type = "character",
+      default = NULL,
+      help = "CSV-format sample metadata file."
+    ),
+    make_option(
+      c("-i", "--sample_id_col"),
+      type = "character",
+      default = "sample",
+      help = "Column in sample metadata used as sample identifier. Should be used to name columns of expression matrices, and duplicate rows will be removed based on this column."
+    ),
+    make_option(
+      c("-g", "--group_vars"),
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of variables in the sample metadata to use as grouping variables. Shinyngs will guess these variables by default."
+    )
   ),
-  make_option(
-    c("-r", "--description"),
-    type = "character",
-    default = NULL,
-    help = "A description to display in the app."
+  # Feature metadata ---------------------------------------------------------
+  list(
+    make_option(
+      c("-f", "--feature_metadata"),
+      type = "character",
+      default = NULL,
+      help = "TSV-format feature (often gene) metadata file."
+    ),
+    make_option(
+      c("-j", "--feature_id_col"),
+      type = "character",
+      default = "gene_id",
+      help = "Column in feature metadata used as feature identifier. Should be used to name columns of expression matrices."
+    ),
+    make_option(
+      c("-N", "--feature_name_col"),
+      type = "character",
+      default = "gene_name",
+      help = "Column in feature metadata used as feature name/ label. Can be different to matrix column names."
+    ),
+    make_option(
+      c("--ensembl_species"),
+      type = "character",
+      default = NULL,
+      help = "Ensembl species definition, e.g. 'hsapiens' or 'mmusculus'. If set, and --feature_metadata provides chromosome_name/start_position/end_position columns, enables the gene model view in the gene module."
+    )
   ),
-  make_option(
-    c("-m", "--report_markdown_file"),
-    type = "character",
-    default = NULL,
-    help = "Path to file with description/ reporting in markdown. Alternative to 'description' for more extensive description content."
+  # Expression matrices -------------------------------------------------------
+  list(
+    make_option(
+      c("-e", "--assay_files"),
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of CSV or TSV-format file expression matrix files."
+    ),
+    make_option(
+      c("-w", "--assay_names"),
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of names of same length as --assay-files."
+    ),
+    make_option(
+      c("-x", "--assay_entity_name"),
+      type = "character",
+      default = "gene",
+      help = "Name of type of thing represented in assays. Default: gene."
+    ),
+    make_option(
+      c("--log2_assays"),
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of assay_names to which to apply log2. Alternatively, comma-separated list of positive integers indicating which assays to log (1-based!). If not specified, the script will guess the log status based on the maximum value of the input data. If empty string, will not apply log2."
+    ),
+    make_option(
+      c("--log2_guessing_threshold"),
+      type = "integer",
+      metavar = "integer",
+      help = "Magnitude used to guess log status.",
+      default = 30
+    )
   ),
-  make_option(
-    c("-s", "--sample_metadata"),
-    type = "character",
-    default = NULL,
-    help = "CSV-format sample metadata file."
+  # Contrasts and differential statistics --------------------------------------
+  list(
+    make_option(
+      c("-n", "--diff_feature_id_col"),
+      type = "character",
+      metavar = "string",
+      help = "Differential file column name containing feature identifiers.",
+      default = "gene_id"
+    ),
+    make_option(
+      c("-y", "--contrast_stats_assay"),
+      type = "numeric",
+      default = NULL,
+      help = "Integer indicating which element of --assay_files should be associated in displays with contrast statistics. Usually a normalised matrix useful for relating stats to assay values."
+    ),
+    make_option(
+      c("-c", "--contrast_file"),
+      type = "character",
+      default = NULL,
+      help = "CSV-format contrast file with variable,reference and target in the first 3 columns."
+    ),
+    make_option(
+      c("-d", "--differential_results"),
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of CSV or TSV-format files containing at least fold change and p value, one for each row of the contrast file."
+    ),
+    make_option(
+      c("-k", "--fold_change_column"),
+      type = "character",
+      default = "log2FoldChange",
+      help = "Column in differential results files holding fold changes."
+    ),
+    make_option(
+      c("--fold_change_scale"),
+      type = "character",
+      default = "auto",
+      help = "Scale of the values in --fold_change_column: 'log2', 'linear' or 'auto' (default). 'auto' infers the scale from the column name and the distribution of the values, and errors if the two signals (or an explicit 'log2'/'linear' declaration) disagree."
+    ),
+    make_option(
+      c("-u", "--unlog_foldchanges"),
+      action = "store_true",
+      default = NULL,
+      help = "Deprecated - use --fold_change_scale=log2 instead. Set this option if fold changes should be unlogged."
+    ),
+    make_option(
+      c("-p", "--pval_column"),
+      type = "character",
+      default = "padj",
+      help = "Column in differential results files holding p values."
+    ),
+    make_option(
+      c("-q", "--qval_column"),
+      type = "character",
+      default = "padj",
+      help = "Column in differential results files holding q values/ adjusted p values."
+    )
   ),
-  make_option(
-    c("-i", "--sample_id_col"),
-    type = "character",
-    default = "sample",
-    help = "Column in sample metadata used as sample identifier. Should be used to name columns of expression matrices, and duplicate rows will be removed based on this column."
+  # Gene set enrichment ---------------------------------------------------------
+  list(
+    make_option(
+      "--enrichment_gene_sets",
+      type = "character",
+      default = NULL,
+      help = "Comma-separated list of the GMT files used in the enrichment analyses."
+    ),
+    make_option(
+      "--enrichment_filename_template",
+      type = "character",
+      default = NULL,
+      help = "Template of filenames containing enrichment results. For instance '{contrast_name}_enrichment_for_{geneset_type}.tsv' or, if up and down regulated results are provided separately '{contrast_name}.{geneset_type}.gsea_report_for_{target|reference}.tsv'. '{contrast_name}', '{geneset_type}', and optionally '{target|reference}' are substituted dynamically for each contrast and geneset type. If not given, no enrichment results are included"
+    ),
+    make_option(
+      "--enrichment_skip_missing",
+      action = "store_true",
+      default = FALSE,
+      help = "Ignore if any gene set enrichment result for any contrast is missing"
+    ),
+    make_option(
+      "--enrichment_gene_type_id",
+      type = "character",
+      default = "gene_name",
+      help = "Gene identifier in the enrichment gene sets. Use this to specify that the gmt files represent genes with the gene name or an entrez id"
+    ),
+    make_option(
+      "--enrichment_pval_column",
+      type = "character",
+      default = NULL,
+      help = "Name of the p-value column in the enrichment results. Set this (together with --enrichment_fdr_column and --enrichment_direction_column) to support tools other than the auto-detected gsea/roast formats."
+    ),
+    make_option(
+      "--enrichment_fdr_column",
+      type = "character",
+      default = NULL,
+      help = "Name of the FDR/adjusted p-value column in the enrichment results. See --enrichment_pval_column."
+    ),
+    make_option(
+      "--enrichment_direction_column",
+      type = "character",
+      default = NULL,
+      help = "Name of the direction column in the enrichment results. See --enrichment_pval_column."
+    )
   ),
-  make_option(
-    c("-f", "--feature_metadata"),
-    type = "character",
-    default = NULL,
-    help = "TSV-format feature (often gene) metadata file."
+  # Output ---------------------------------------------------------------------
+  list(
+    make_option(
+      c("-o", "--output_directory"),
+      type = "character",
+      default = NULL,
+      help = "Serialized R object which can be used to generate a shiny app."
+    )
   ),
-  make_option(
-    c("-j", "--feature_id_col"),
-    type = "character",
-    default = "gene_id",
-    help = "Column in feature metadata used as feature identifier. Should be used to name columns of expression matrices."
-  ),
-  make_option(
-    c("-N", "--feature_name_col"),
-    type = "character",
-    default = "gene_name",
-    help = "Column in feature metadata used as feature name/ label. Can be different to matrix column names."
-  ),
-  make_option(
-    c("-n", "--diff_feature_id_col"),
-    type = "character",
-    metavar = "string",
-    help = "Differential file column name containing feature identifiers.",
-    default = "gene_id"
-  ),
-  make_option(
-    c("-e", "--assay_files"),
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of CSV or TSV-format file expression matrix files."
-  ),
-  make_option(
-    c("-w", "--assay_names"),
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of names of same length as --assay-files."
-  ),
-  make_option(
-    c("-x", "--assay_entity_name"),
-    type = "character",
-    default = "gene",
-    help = "Name of type of thing represented in assays. Default: gene."
-  ),
-  make_option(
-    c("-y", "--contrast_stats_assay"),
-    type = "numeric",
-    default = NULL,
-    help = "Integer indicating which element of --assay_files should be associated in displays with contrast statistics. Usually a normalised matrix useful for relating stats to assay values."
-  ),
-  make_option(
-    c("-g", "--group_vars"),
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of variables in the sample metadata to use as grouping variables. Shinyngs will guess these variables by default."
-  ),
-  make_option(
-    c("--ensembl_species"),
-    type = "character",
-    default = NULL,
-    help = "Ensembl species definition, e.g. 'hsapiens' or 'mmusculus'. If set, and --feature_metadata provides chromosome_name/start_position/end_position columns, enables the gene model view in the gene module."
-  ),
-  make_option(
-    c("-c", "--contrast_file"),
-    type = "character",
-    default = NULL,
-    help = "CSV-format contrast file with variable,reference and target in the first 3 columns."
-  ),
-  make_option(
-    c("-d", "--differential_results"),
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of CSV or TSV-format files containing at least fold change and p value, one for each row of the contrast file."
-  ),
-  make_option(
-    c("-k", "--fold_change_column"),
-    type = "character",
-    default = "log2FoldChange",
-    help = "Column in differential results files holding fold changes."
-  ),
-  make_option(
-    c("--fold_change_scale"),
-    type = "character",
-    default = "auto",
-    help = "Scale of the values in --fold_change_column: 'log2', 'linear' or 'auto' (default). 'auto' infers the scale from the column name and the distribution of the values, and errors if the two signals (or an explicit 'log2'/'linear' declaration) disagree."
-  ),
-  make_option(
-    c("-u", "--unlog_foldchanges"),
-    action = "store_true",
-    default = NULL,
-    help = "Deprecated - use --fold_change_scale=log2 instead. Set this option if fold changes should be unlogged."
-  ),
-  make_option(
-    c("-p", "--pval_column"),
-    type = "character",
-    default = "padj",
-    help = "Column in differential results files holding p values."
-  ),
-  make_option(
-    c("-q", "--qval_column"),
-    type = "character",
-    default = "padj",
-    help = "Column in differential results files holding q values/ adjusted p values."
-  ),
-  make_option(
-    "--enrichment_gene_sets",
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of the GMT files used in the enrichment analyses."
-  ),
-  make_option(
-    "--enrichment_filename_template",
-    type = "character",
-    default = NULL,
-    help = "Template of filenames containing enrichment results. For instance '{contrast_name}_enrichment_for_{geneset_type}.tsv' or, if up and down regulated results are provided separately '{contrast_name}.{geneset_type}.gsea_report_for_{target|reference}.tsv'. '{contrast_name}', '{geneset_type}', and optionally '{target|reference}' are substituted dynamically for each contrast and geneset type. If not given, no enrichment results are included"
-  ),
-  make_option(
-    "--enrichment_skip_missing",
-    action = "store_true",
-    default = FALSE,
-    help = "Ignore if any gene set enrichment result for any contrast is missing"
-  ),
-  make_option(
-    "--enrichment_gene_type_id",
-    type = "character",
-    default = "gene_name",
-    help = "Gene identifier in the enrichment gene sets. Use this to specify that the gmt files represent genes with the gene name or an entrez id"
-  ),
-  make_option(
-    "--enrichment_pval_column",
-    type = "character",
-    default = NULL,
-    help = "Name of the p-value column in the enrichment results. Set this (together with --enrichment_fdr_column and --enrichment_direction_column) to support tools other than the auto-detected gsea/roast formats."
-  ),
-  make_option(
-    "--enrichment_fdr_column",
-    type = "character",
-    default = NULL,
-    help = "Name of the FDR/adjusted p-value column in the enrichment results. See --enrichment_pval_column."
-  ),
-  make_option(
-    "--enrichment_direction_column",
-    type = "character",
-    default = NULL,
-    help = "Name of the direction column in the enrichment results. See --enrichment_pval_column."
-  ),
-  make_option(
-    c("-o", "--output_directory"),
-    type = "character",
-    default = NULL,
-    help = "Serialized R object which can be used to generate a shiny app."
-  ),
-  make_option(
-    c("-l", "--deploy_app"),
-    action = "store_true",
-    default = FALSE,
-    help = "Set this option if fold changes should be unlogged."
-  ),
-  make_option(
-    c("-b", "--shinyapps_account"),
-    type = "character",
-    default = NULL,
-    help = "Account name for shinyapp deploment."
-  ),
-  make_option(
-    c("-v", "--shinyapps_name"),
-    type = "character",
-    default = NULL,
-    help = "App name for shinyapp deploment."
-  ),
-  make_option(
-    c("--log2_assays"),
-    type = "character",
-    default = NULL,
-    help = "Comma-separated list of assay_names to which to apply log2. Alternatively, comma-separated list of positive integers indicating which assays to log (1-based!). If not specified, the script will guess the log status based on the maximum value of the input data. If empty string, will not apply log2."
-  ),
-  make_option(
-    c("--log2_guessing_threshold"),
-    type = "integer",
-    metavar = "integer",
-    help = "Magnitude used to guess log status.",
-    default = 30
+  # shinyapps.io deployment -----------------------------------------------------
+  list(
+    make_option(
+      c("-l", "--deploy_app"),
+      action = "store_true",
+      default = FALSE,
+      help = "Set this option if fold changes should be unlogged."
+    ),
+    make_option(
+      c("-b", "--shinyapps_account"),
+      type = "character",
+      default = NULL,
+      help = "Account name for shinyapp deploment."
+    ),
+    make_option(
+      c("-v", "--shinyapps_name"),
+      type = "character",
+      default = NULL,
+      help = "App name for shinyapp deploment."
+    )
   )
 )
 
-opt_parser <- OptionParser(option_list = option_list)
-opt <- parse_args(opt_parser)
+################################################
+## Build the app data bundle (.rds + app.R)  ##
+################################################
 
-opt$fold_change_scale <- shinyngs::resolve_deprecated_unlog_foldchanges(opt$fold_change_scale, opt$unlog_foldchanges)
+# Builds the ExploratorySummarizedExperimentList described by `opt` and writes
+# it, together with a runnable app.R, to opt$output_directory.
+build_app_bundle <- function(opt) {
+  # Name assay data
 
-# Check mandatory
+  assay_files <-
+    stringsToNamedVector(
+      elements_string = opt$assay_files,
+      opt$assay_names,
+      simplify_files = TRUE,
+      prettify_names = TRUE
+    )
 
-mandatory <-
-  c(
-    "title",
-    "author",
-    "sample_metadata",
-    "sample_id_col",
-    "feature_metadata",
-    "feature_id_col",
-    "diff_feature_id_col",
-    "assay_files",
-    "assay_entity_name",
-    "output_directory",
-    "contrast_stats_assay"
+  # Contrasts
+
+  contrast_stats_files <- strsplit(opt$differential_results, ",")
+  contrast_stats_assay <- opt$contrast_stats_assay
+
+  # Pick last assay by default to relate the stats to
+
+  if (is.null(contrast_stats_assay)) {
+    contrast_stats_assay <- length(assay_files)
+  }
+  names(contrast_stats_files) <- names(assay_files)[contrast_stats_assay]
+
+  contrast_stats <- list()
+  contrast_stats[[opt$assay_entity_name]] <- lapply(contrast_stats_files, function(x) {
+    list(
+      "files" = x,
+      "type" = "uncompiled",
+      "feature_id_column" = opt$diff_feature_id_col,
+      "fc_column" = opt$fold_change_column,
+      "pval_column" = opt$pval_column,
+      "qval_column" = opt$qval_column,
+      "fold_change_scale" = opt$fold_change_scale
+    )
+  })
+
+  # Enrichment results:
+  # To show enrichment results we need:
+  # - The contrasts file opt$contrast_file
+  # - The gmt enrichment files used
+  # - The actual enrichment results
+  #
+
+  if (!is.null(opt$enrichment_filename_template)) {
+    # Ensure we have gene sets and contrasts
+    if (is.null(opt$contrast_file)) {
+      stop("When --enrichment_filename_template is given, --contrast_file is required")
+    }
+    if (is.null(opt$enrichment_gene_sets)) {
+      stop("When --enrichment_filename_template is given, --enrichment_gene_sets is required")
+    }
+
+    contrasts_df <- read_metadata(opt$contrast_file)
+    genesets_files <- simpleSplit(opt$enrichment_gene_sets)
+    names(genesets_files) <- tools::file_path_sans_ext(basename(genesets_files))
+
+    gene_set_analyses <- list(
+      lapply(setNames(nm = names(genesets_files)), function(geneset_type) {
+        lapply(setNames(nm = contrasts_df$id), function(contrast_name) {
+          ctrst_info <- as.list(contrasts_df[contrasts_df$id == contrast_name, ])
+          # Two types of opt$enrichment_filename_template are supported:
+          # - The template points to a single file for each contrast and geneset_type
+          # - The template points to two files for each contrast and geneset_type. In
+          #   this case, one file is for the up-regulated results and another file is
+          #   for the down-regulated results.
+          #
+          # The template may look like:
+          # "gsea_for_{contrast_name}_using_{geneset_type}_for_{target|reference}.tsv"
+          # Which for a contrast "disease_vs_healthy" with target="disease" and reference="healthy"
+          # and geneset_type "geo_bp", would result in shinyngs expecting two files named:
+          # up: "gsea_for_disease_vs_healthy_using_geo_bp_for_disease.tsv"
+          # down: "gsea_for_disease_vs_healthy_using_geo_bp_for_healthy.tsv"
+          #
+          # If the template does not include {target|reference} we assume there is
+          # a single file per contrast and geneset type, for instance:
+          # "gsea_for_{contrast_name}_using_{geneset_type}_results.tsv"
+          # becomes:
+          # "gsea_for_disease_vs_healthy_using_geo_bp_results.tsv"
+          if (grepl("target\\|reference", opt$enrichment_filename_template)) {
+            up_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type, "up")
+            down_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type, "down")
+            if (file.exists(up_file) && file.exists(down_file)) {
+              list("up" = up_file, "down" = down_file)
+            } else {
+              if (opt$enrichment_skip_missing) {
+                NULL
+              } else {
+                stop(sprintf("both enrichment files should exist: %s and %s", up_file, down_file))
+              }
+            }
+          } else {
+            enrichment_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type)
+            if (file.exists(enrichment_file)) {
+              enrichment_file
+            } else {
+              if (opt$enrichment_skip_missing) {
+                NULL
+              } else {
+                stop(sprintf("enrichment file: %s does not exist", enrichment_file))
+              }
+            }
+          }
+        })
+      })
+    )
+    names(gene_set_analyses) <- names(assay_files)[contrast_stats_assay]
+
+    # Custom column mapping for enrichment tools other than the auto-detected
+    # gsea/roast formats. If any of the column options is given, all three are
+    # required, and the mapping is applied to every enrichment result.
+    custom_col_opts <- list(
+      pvalue = opt$enrichment_pval_column,
+      fdr = opt$enrichment_fdr_column,
+      direction = opt$enrichment_direction_column
+    )
+    n_custom_cols <- length(Filter(Negate(is.null), custom_col_opts))
+    if (n_custom_cols > 0 && n_custom_cols < 3) {
+      stop("--enrichment_pval_column, --enrichment_fdr_column and --enrichment_direction_column must all be given together")
+    }
+    if (n_custom_cols == 3) {
+      enrichment_custom_cols <- unlist(custom_col_opts)
+      gene_set_analyses_tool <- lapply(gene_set_analyses, function(assay) {
+        lapply(assay, function(geneset_type) {
+          lapply(geneset_type, function(contrast) enrichment_custom_cols)
+        })
+      })
+    } else {
+      gene_set_analyses_tool <- list()
+    }
+  } else {
+    gene_set_analyses <- list()
+    gene_set_analyses_tool <- list()
+    genesets_files <- list()
+  }
+
+  experiments <- list()
+  experiments[[opt$assay_entity_name]] <- list(
+    "coldata" = list(
+      "file" = opt$sample_metadata,
+      "id" = opt$sample_id_col
+    ),
+    "annotation" = list(
+      "file" = opt$feature_metadata,
+      "id" = opt$feature_id_col,
+      "label" = opt$feature_name_col
+    ),
+    "expression_matrices" = lapply(assay_files, function(x) {
+      list(
+        file = x,
+        measure = "counts"
+      )
+    }),
+    "gene_set_analyses" = gene_set_analyses,
+    "gene_set_analyses_tool" = gene_set_analyses_tool
   )
 
-missing_args <- mandatory[!mandatory %in% names(opt)]
-if (length(missing_args) > 0) {
-  stop(paste("Missing mandatory arguments:", paste(missing_args, collapse = ", ")))
+  shiny_config <- list(
+    "title" = opt$title,
+    "author" = opt$author,
+    "group_vars" = opt$group_vars,
+    "default_groupvar" = opt$group_vars[1],
+    "experiments" = experiments
+  )
+
+  if (!is.null(opt$contrast_file)) {
+    shiny_config$contrasts <- list(
+      "comparisons_file" = opt$contrast_file,
+      "stats" = contrast_stats
+    )
+  }
+
+  if (!is.null(opt$group_vars)) {
+    opt$group_vars <- simpleSplit(opt$group_vars, ",")
+    shiny_config[["group_vars"]] <- opt$group_vars
+    shiny_config[["default_groupvar"]] <- opt$group_vars[1]
+  }
+
+  if (!is.null(opt$description)) {
+    shiny_config[["description"]] <- opt$description
+  } else if (!is.null(opt$report_markdown_file)) {
+    shiny_config[["report"]] <- opt$report_markdown_file
+  }
+
+  if (length(genesets_files) > 0) {
+    shiny_config[["gene_set_id_type"]] <- opt$enrichment_gene_type_id
+    shiny_config[["gene_sets"]] <- genesets_files
+  }
+
+  if (!is.null(opt$ensembl_species)) {
+    shiny_config[["ensembl_species"]] <- opt$ensembl_species
+  }
+
+  myesel <- eselistfromConfig(
+    shiny_config,
+    log2_assays = opt$log2_assays,
+    log2_threshold = opt$log2_guessing_threshold
+  )
+
+  dir.create(opt$output_directory, showWarnings = FALSE, recursive = TRUE)
+  saveRDS(myesel, file = file.path(opt$output_directory, "data.rds"))
+  writeLines(
+    c(
+      "# See installation instructions at:",
+      "# https://github.com/pinin4fjords/shinyngs?tab=readme-ov-file#installation",
+      "library(shinyngs)",
+      "library(markdown)",
+      'esel <- readRDS("data.rds")',
+      'app <- prepareApp("rnaseq", esel)',
+      "shiny::shinyApp(app$ui, app$server)"
+    ),
+    file.path(opt$output_directory, "app.R")
+  )
 }
 
-if (opt$deploy_app) {
-  # Check we have what we need for an app deployment
+################################################
+## shinyapps.io deployment                   ##
+################################################
 
+# shinyapps.io deployment often fails against outdated BioC packages, and we
+# can't assume write access to the system library, so refresh those to a
+# local 'libs' dir before anything else (notably library(shinyngs) below)
+# pulls in a stale version.
+prepare_biocmanager_for_deploy <- function() {
+  print("Updating BioC packages as will be required for shinyapps.io deployment")
+
+  library(BiocManager)
+  options(repos = BiocManager::repositories())
+  ood <- data.frame(BiocManager::valid()$out_of_date)
+  ood_packages <- ood[grep("bioconductor", ood$Repository), "Package"]
+
+  dir.create("libs", showWarnings = FALSE)
+  .libPaths(c("libs", .libPaths()))
+
+  BiocManager::install(ood_packages, update = TRUE, ask = FALSE, lib = "libs")
+}
+
+# Deploys the app bundle already written to opt$output_directory. Needs
+# SHINYAPPS_SECRET and SHINYAPPS_TOKEN to be set in the environment.
+deploy_to_shinyapps <- function(opt) {
+  library(rsconnect)
+
+  options(BiocManager.check_repositories = FALSE)
+  rsconnect::setAccountInfo(name = opt$shinyapps_account, token = Sys.getenv("SHINYAPPS_TOKEN"), secret = Sys.getenv("SHINYAPPS_SECRET"))
+  deployApp(appDir = opt$output_directory, appName = opt$shinyapps_name, forceUpdate = TRUE, launch.browser = FALSE)
+}
+
+validate_mandatory_args <- function(opt) {
+  mandatory <-
+    c(
+      "title",
+      "author",
+      "sample_metadata",
+      "sample_id_col",
+      "feature_metadata",
+      "feature_id_col",
+      "diff_feature_id_col",
+      "assay_files",
+      "assay_entity_name",
+      "output_directory",
+      "contrast_stats_assay"
+    )
+
+  missing_args <- mandatory[!mandatory %in% names(opt)]
+  if (length(missing_args) > 0) {
+    stop(paste("Missing mandatory arguments:", paste(missing_args, collapse = ", ")))
+  }
+}
+
+validate_deploy_args <- function(opt) {
   mandatory <- c(
     "shinyapps_account",
     "shinyapps_name"
@@ -272,256 +542,28 @@ if (opt$deploy_app) {
   if (length(missing_secrets) > 0) {
     stop(paste("Environment variables not defined for shinyapps deployment:", paste(missing_secrets, collapse = ", ")))
   }
+}
 
-  # The app deployment will often fail if BioC packages are out of date, but we
-  # can't assume we have access to the system R directories. So re-install
-  # outdated ones to a local dir before any important library calls.
+################################################
+## Main                                       ##
+################################################
 
-  print("Updating BioC packages as will be required for shinyapps.io deployment")
+opt_parser <- OptionParser(option_list = option_list)
+opt <- parse_args(opt_parser)
 
-  library(BiocManager)
-  options(repos = BiocManager::repositories())
-  ood <- data.frame(BiocManager::valid()$out_of_date)
-  ood_packages <- ood[grep("bioconductor", ood$Repository), "Package"]
+opt$fold_change_scale <- shinyngs::resolve_deprecated_unlog_foldchanges(opt$fold_change_scale, opt$unlog_foldchanges)
 
-  dir.create("libs", showWarnings = FALSE)
-  .libPaths(c("libs", .libPaths()))
+validate_mandatory_args(opt)
 
-  BiocManager::install(ood_packages, update = TRUE, ask = FALSE, lib = "libs")
+if (opt$deploy_app) {
+  validate_deploy_args(opt)
+  prepare_biocmanager_for_deploy()
 }
 
 library(shinyngs)
 
-# Name assay data
-
-assay_files <-
-  stringsToNamedVector(
-    elements_string = opt$assay_files,
-    opt$assay_names,
-    simplify_files = TRUE,
-    prettify_names = TRUE
-  )
-
-# Contrasts
-
-contrast_stats_files <- strsplit(opt$differential_results, ",")
-contrast_stats_assay <- opt$contrast_stats_assay
-
-# Pick last assay by default to relate the stats to
-
-if (is.null(contrast_stats_assay)) {
-  contrast_stats_assay <- length(assay_files)
-}
-names(contrast_stats_files) <- names(assay_files)[contrast_stats_assay]
-
-contrast_stats <- list()
-contrast_stats[[opt$assay_entity_name]] <- lapply(contrast_stats_files, function(x) {
-  list(
-    "files" = x,
-    "type" = "uncompiled",
-    "feature_id_column" = opt$diff_feature_id_col,
-    "fc_column" = opt$fold_change_column,
-    "pval_column" = opt$pval_column,
-    "qval_column" = opt$qval_column,
-    "fold_change_scale" = opt$fold_change_scale
-  )
-})
-
-# Enrichment results:
-# To show enrichment results we need:
-# - The contrasts file opt$contrast_file
-# - The gmt enrichment files used
-# - The actual enrichment results
-#
-
-if (!is.null(opt$enrichment_filename_template)) {
-  # Ensure we have gene sets and contrasts
-  if (is.null(opt$contrast_file)) {
-    stop("When --enrichment_filename_template is given, --contrast_file is required")
-  }
-  if (is.null(opt$enrichment_gene_sets)) {
-    stop("When --enrichment_filename_template is given, --enrichment_gene_sets is required")
-  }
-
-  contrasts_df <- read_metadata(opt$contrast_file)
-  genesets_files <- simpleSplit(opt$enrichment_gene_sets)
-  names(genesets_files) <- tools::file_path_sans_ext(basename(genesets_files))
-
-  gene_set_analyses <- list(
-    lapply(setNames(nm = names(genesets_files)), function(geneset_type) {
-      lapply(setNames(nm = contrasts_df$id), function(contrast_name) {
-        ctrst_info <- as.list(contrasts_df[contrasts_df$id == contrast_name, ])
-        # Two types of opt$enrichment_filename_template are supported:
-        # - The template points to a single file for each contrast and geneset_type
-        # - The template points to two files for each contrast and geneset_type. In
-        #   this case, one file is for the up-regulated results and another file is
-        #   for the down-regulated results.
-        #
-        # The template may look like:
-        # "gsea_for_{contrast_name}_using_{geneset_type}_for_{target|reference}.tsv"
-        # Which for a contrast "disease_vs_healthy" with target="disease" and reference="healthy"
-        # and geneset_type "geo_bp", would result in shinyngs expecting two files named:
-        # up: "gsea_for_disease_vs_healthy_using_geo_bp_for_disease.tsv"
-        # down: "gsea_for_disease_vs_healthy_using_geo_bp_for_healthy.tsv"
-        #
-        # If the template does not include {target|reference} we assume there is
-        # a single file per contrast and geneset type, for instance:
-        # "gsea_for_{contrast_name}_using_{geneset_type}_results.tsv"
-        # becomes:
-        # "gsea_for_disease_vs_healthy_using_geo_bp_results.tsv"
-        if (grepl("target\\|reference", opt$enrichment_filename_template)) {
-          up_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type, "up")
-          down_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type, "down")
-          if (file.exists(up_file) && file.exists(down_file)) {
-            list("up" = up_file, "down" = down_file)
-          } else {
-            if (opt$enrichment_skip_missing) {
-              NULL
-            } else {
-              stop(sprintf("both enrichment files should exist: %s and %s", up_file, down_file))
-            }
-          }
-        } else {
-          enrichment_file <- build_enrichment_path(opt$enrichment_filename_template, ctrst_info, geneset_type)
-          if (file.exists(enrichment_file)) {
-            enrichment_file
-          } else {
-            if (opt$enrichment_skip_missing) {
-              NULL
-            } else {
-              stop(sprintf("enrichment file: %s does not exist", enrichment_file))
-            }
-          }
-        }
-      })
-    })
-  )
-  names(gene_set_analyses) <- names(assay_files)[contrast_stats_assay]
-
-  # Custom column mapping for enrichment tools other than the auto-detected
-  # gsea/roast formats. If any of the column options is given, all three are
-  # required, and the mapping is applied to every enrichment result.
-  custom_col_opts <- list(
-    pvalue = opt$enrichment_pval_column,
-    fdr = opt$enrichment_fdr_column,
-    direction = opt$enrichment_direction_column
-  )
-  n_custom_cols <- length(Filter(Negate(is.null), custom_col_opts))
-  if (n_custom_cols > 0 && n_custom_cols < 3) {
-    stop("--enrichment_pval_column, --enrichment_fdr_column and --enrichment_direction_column must all be given together")
-  }
-  if (n_custom_cols == 3) {
-    enrichment_custom_cols <- unlist(custom_col_opts)
-    gene_set_analyses_tool <- lapply(gene_set_analyses, function(assay) {
-      lapply(assay, function(geneset_type) {
-        lapply(geneset_type, function(contrast) enrichment_custom_cols)
-      })
-    })
-  } else {
-    gene_set_analyses_tool <- list()
-  }
-} else {
-  gene_set_analyses <- list()
-  gene_set_analyses_tool <- list()
-  genesets_files <- list()
-}
-
-
-
-################################################
-################################################
-## Build the app                              ##
-################################################
-################################################
-
-experiments <- list()
-experiments[[opt$assay_entity_name]] <- list(
-  "coldata" = list(
-    "file" = opt$sample_metadata,
-    "id" = opt$sample_id_col
-  ),
-  "annotation" = list(
-    "file" = opt$feature_metadata,
-    "id" = opt$feature_id_col,
-    "label" = opt$feature_name_col
-  ),
-  "expression_matrices" = lapply(assay_files, function(x) {
-    list(
-      file = x,
-      measure = "counts"
-    )
-  }),
-  "gene_set_analyses" = gene_set_analyses,
-  "gene_set_analyses_tool" = gene_set_analyses_tool
-)
-
-shiny_config <- list(
-  "title" = opt$title,
-  "author" = opt$author,
-  "group_vars" = opt$group_vars,
-  "default_groupvar" = opt$group_vars[1],
-  "experiments" = experiments
-)
-
-if (!is.null(opt$contrast_file)) {
-  shiny_config$contrasts <- list(
-    "comparisons_file" = opt$contrast_file,
-    "stats" = contrast_stats
-  )
-}
-
-if (!is.null(opt$group_vars)) {
-  opt$group_vars <- simpleSplit(opt$group_vars, ",")
-  shiny_config[["group_vars"]] <- opt$group_vars
-  shiny_config[["default_groupvar"]] <- opt$group_vars[1]
-}
-
-if (!is.null(opt$description)) {
-  shiny_config[["description"]] <- opt$description
-} else if (!is.null(opt$report_markdown_file)) {
-  shiny_config[["report"]] <- opt$report_markdown_file
-}
-
-if (length(genesets_files) > 0) {
-  shiny_config[["gene_set_id_type"]] <- opt$enrichment_gene_type_id
-  shiny_config[["gene_sets"]] <- genesets_files
-}
-
-if (!is.null(opt$ensembl_species)) {
-  shiny_config[["ensembl_species"]] <- opt$ensembl_species
-}
-
-
-myesel <- eselistfromConfig(
-  shiny_config,
-  log2_assays = opt$log2_assays,
-  log2_threshold = opt$log2_guessing_threshold
-)
-
-# Write output
-
-dir.create(opt$output_directory, showWarnings = FALSE, recursive = TRUE)
-saveRDS(myesel, file = file.path(opt$output_directory, "data.rds"))
-writeLines(
-  c(
-    '# See installation instructions at:',
-    '# https://github.com/pinin4fjords/shinyngs?tab=readme-ov-file#installation',
-    "library(shinyngs)",
-    "library(markdown)",
-    'esel <- readRDS("data.rds")',
-    'app <- prepareApp("rnaseq", esel)',
-    "shiny::shinyApp(app$ui, app$server)"
-  ),
-  file.path(opt$output_directory, "app.R")
-)
-
-# If deployment has been indicated, try to do that. Needs SHINYAPPS_SECRET AND
-# SHINYAPPS_TOKEN to be set in the environment
+build_app_bundle(opt)
 
 if (opt$deploy_app) {
-  library(rsconnect)
-
-  options(BiocManager.check_repositories = FALSE)
-  rsconnect::setAccountInfo(name = opt$shinyapps_account, token = Sys.getenv("SHINYAPPS_TOKEN"), secret = Sys.getenv("SHINYAPPS_SECRET"))
-  deployApp(appDir = opt$output_directory, appName = opt$shinyapps_name, forceUpdate = TRUE, launch.browser = FALSE)
+  deploy_to_shinyapps(opt)
 }

--- a/man/prepareApp.Rd
+++ b/man/prepareApp.Rd
@@ -65,23 +65,22 @@ if (interactive()) {
 
 # 2: AUGMENT WITH ANNOTATION INFO FOR MORE INFORMATIVE APP
 
-# Use Biomart to retrieve some annotation, add it to the object, then choose a
-# different default grouping variable and re-make the app.
+# Add row metadata (gene symbol, genomic coordinates) so plots and tables
+# are labelled meaningfully, then choose a different default grouping
+# variable and re-make the app. Any source of per-gene annotation works
+# here (a GTF, an annotation package, a pre-built CSV); the requirement is
+# a data.frame keyed by the same IDs as rownames(ese). Adding
+# chromosome_name/start_position/end_position columns plus ensembl_species
+# also enables the igv.js gene model view on the gene page.
 
 if (interactive()) {
-  library(biomaRt)
-  attributes <- c(
-    "ensembl_gene_id", # The sort of ID your results are keyed by
-    "entrezgene", # Could be used for gene sets keyed by Entrez ID
-    "external_gene_name" # Used to annotate gene names on the plot
+  annotation <- data.frame(
+    ensembl_gene_id = rownames(ese),
+    external_gene_name = rownames(ese), # substitute real gene symbols
+    chromosome_name = "1", # substitute real coordinates
+    start_position = seq_along(rownames(ese)),
+    end_position = seq_along(rownames(ese)) + 1000
   )
-
-  mart <- useMart(
-    biomart = "ENSEMBL_MART_ENSEMBL",
-    dataset = "hsapiens_gene_ensembl", host = "www.ensembl.org"
-  )
-  annotation <- getBM(attributes = attributes, mart = mart)
-  annotation <- annotation[order(annotation$entrezgene), ]
 
   mcols(ese) <- annotation[match(rownames(ese), annotation$ensembl_gene_id), ]
   ese@labelfield <- "external_gene_name"
@@ -91,7 +90,8 @@ if (interactive()) {
     title = expinfo$Title,
     author = expinfo$Author,
     description = expinfo$Description,
-    default_groupvar = "dex"
+    default_groupvar = "dex",
+    ensembl_species = "hsapiens" # enables the igv.js gene model view
   )
   app <- prepareApp("rnaseq", eselist)
   shiny::shinyApp(ui = app$ui, server = app$server)

--- a/man/scatterplot.Rd
+++ b/man/scatterplot.Rd
@@ -14,7 +14,7 @@ scatterplot(
   getShowLabels = NULL,
   getPointSize = NULL,
   getPalette = NULL,
-  colorBy = NULL,
+  getColorby = NULL,
   getTitle = reactive({
      ""
  }),
@@ -60,10 +60,10 @@ points.}
 reactive supplying an integer point size to pass to plotly.}
 
 \item{getPalette}{An optional palette of colors, one for each level of
-colorBy.}
+getColorby.}
 
-\item{colorBy}{A reactive returning a factor definining the groups in which
-points should be colored.}
+\item{getColorby}{A reactive returning a factor definining the groups in
+which points should be colored.}
 
 \item{getTitle}{A reactive expression supplying a title.}
 

--- a/vignettes/shinyngs.Rmd
+++ b/vignettes/shinyngs.Rmd
@@ -101,17 +101,20 @@ shiny::shinyApp(ui = app$ui, server = app$server)
 All this app knows about is gene IDs, however, which aren't all that informative for gene expression plots etc. We can add row metadata to fix that:
 
 ```{r eval = FALSE}
-# Use Biomart to retrieve some annotation, and add it to the object
+# Add annotation to the object. Any source of per-gene annotation works here
+# (a GTF, an annotation package, a pre-built CSV); the requirement is a
+# data.frame keyed by the same IDs as rownames(ese). Adding
+# chromosome_name/start_position/end_position columns plus ensembl_species
+# (below) also enables the igv.js gene model view on the gene page.
 
-library(biomaRt)
-attributes <- c(
-  'ensembl_gene_id', # The sort of ID your results are keyed by
-  'entrezgene', # Will be used mostly for gene set based stuff
-  'external_gene_name' # Used to annotate gene names on the plot
+annotation <- data.frame(
+  ensembl_gene_id = rownames(ese),
+  entrezgene = rownames(ese), # substitute real Entrez IDs
+  external_gene_name = rownames(ese), # substitute real gene symbols
+  chromosome_name = '1', # substitute real coordinates
+  start_position = seq_along(rownames(ese)),
+  end_position = seq_along(rownames(ese)) + 1000
 )
-
-mart <- useMart(biomart = 'ENSEMBL_MART_ENSEMBL', dataset = 'hsapiens_gene_ensembl', host='www.ensembl.org')
-annotation <- getBM(attributes = attributes, mart = mart)
 annotation <- annotation[order(annotation$entrezgene),]
 
 mcols(ese) <- annotation[match(rownames(ese), annotation$ensembl_gene_id),]
@@ -127,7 +130,8 @@ eselist <- ExploratorySummarizedExperimentList(
   ese,
   title = expinfo@title,
   author = expinfo@name,
-  description = abstract(expinfo)
+  description = abstract(expinfo),
+  ensembl_species = 'hsapiens' # enables the igv.js gene model view
 )
 app <- prepareApp('rnaseq', eselist)
 shiny::shinyApp(ui = app$ui, server = app$server)


### PR DESCRIPTION
## Summary

- Removes the stale `biomaRt`/`useMart()`/`getBM()` example from `prepareApp()`'s roxygen and the vignette, replacing it with a plain `data.frame` annotation example plus `ensembl_species` (the current igvShiny-based gene model view path). `biomaRt` dropped from `DESCRIPTION` Suggests.
- Adds `CONTRIBUTING.md` documenting the snake_case convention for new/internal code and the `get`-prefix convention for Shiny module parameters that carry a reactive, without renaming any exported user-facing functions (breaking change). Applies it by renaming `scatterplot()`'s `colorBy` parameter (and the local reactives that feed it) to `getColorby`, reconciling it with the unrelated plain-string `colorby` parameter used throughout the plotting/builder layer.
- Regroups `exec/make_app_from_files.R`'s flat 36-option `optparse` block into logical sections, and separates object-construction (`build_app_bundle()`) from shinyapps.io deployment (`prepare_biocmanager_for_deploy()`/`deploy_to_shinyapps()`). No option names, defaults, or help text changed.

Closes #191.

## Test plan

- [x] Full `testthat` suite passes (`devtools::load_all()` + `testthat::test_dir()`)
- [x] `exec-smoke` tests (including `make_app_from_files.R`) pass run with `NOT_CRAN=true`, exercising the CLI end-to-end as a subprocess against fixtures
- [x] `lintr::lint_package()` clean
- [x] `devtools::document()` regenerated matching `man/prepareApp.Rd` and `man/scatterplot.Rd`
- [x] Package installs cleanly and vignette builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)