### PR TITLE
Decompose contrasts() into named reactive-stage factories

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -88,6 +88,15 @@ contrastsOutput <- function(id) {
 #' This function is called directly, using the same id as its UI counterpart,
 #' and wraps its logic in \code{moduleServer()} (see example).
 #'
+#' The reactive graph is built by a sequence of internal factory functions,
+#' each owning one cohesive stage (contrast enumeration, naming, the dynamic
+#' filter-set engine, table building, selection, filtering, labelling, and
+#' the query summary) - see \code{contrastEnumeration}, \code{contrastNaming},
+#' \code{contrastFilterSetEngine}, \code{contrastTableBuilder},
+#' \code{contrastSelection}, \code{contrastFiltering}, \code{contrastLabelling}
+#' and \code{contrastQuerySummary}. This function itself just wires those
+#' stages together in dependency order and returns their public reactives.
+#'
 #' @param id Module namespace
 #' @param eselist ExploratorySummarizedExperimentList object containing
 #'   ExploratorySummarizedExperiment objects
@@ -112,775 +121,1021 @@ contrasts <- function(id, eselist, selectmatrix_reactives = list(), multiple = F
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    getSummaryType <- summarisematrix("contrasts")
+    enumeration <- contrastEnumeration(eselist, selectmatrix_reactives)
+    naming <- contrastNaming(enumeration$getAllContrasts)
 
-    ########################################################################### Rendering the contrast control filter sets
+    filter_set <- contrastFilterSetEngine(
+      ns, input, output, session, selectmatrix_reactives,
+      multiple = multiple, show_controls = show_controls,
+      default_foldchange = default_foldchange, default_pval = default_pval, default_qval = default_qval,
+      select_all_contrasts = select_all_contrasts,
+      getAllContrasts = enumeration$getAllContrasts,
+      getAllContrastsNumbers = enumeration$getAllContrastsNumbers,
+      fcsAvailable = enumeration$fcsAvailable,
+      pvalsAvailable = enumeration$pvalsAvailable,
+      qvalsAvailable = enumeration$qvalsAvailable
+    )
 
-    inserted <- c() # Stores the list of inserted filter sets
-    filterset_values <- list() # Stores the list of values in the filter set
-    makeReactiveBinding("filterset_values") # Make the stored values reactive
+    tables <- contrastTableBuilder(
+      selectmatrix_reactives,
+      getSummaries = enumeration$getSummaries,
+      getAllContrasts = enumeration$getAllContrasts,
+      getAllContrastsNumbers = enumeration$getAllContrastsNumbers,
+      fcsAvailable = enumeration$fcsAvailable,
+      pvalsAvailable = enumeration$pvalsAvailable,
+      qvalsAvailable = enumeration$qvalsAvailable
+    )
 
-    filter_observers <- list()
+    selection <- contrastSelection(
+      getSelectedContrastNumbers = filter_set$getSelectedContrastNumbers,
+      getAllContrasts = enumeration$getAllContrasts,
+      getContrastSamples = enumeration$getContrastSamples,
+      makeContrastNames = naming$makeContrastNames,
+      makeSafeContrastNames = naming$makeSafeContrastNames
+    )
 
-    # insert_more is a bare counter the insert observer depends on, so restored
-    # filter sets beyond the first can be re-inserted one at a time.
+    filtering <- contrastFiltering(
+      selectmatrix_reactives,
+      getSelectedContrastNumbers = filter_set$getSelectedContrastNumbers,
+      contrastsTablesToMatchMatrix = tables$contrastsTablesToMatchMatrix,
+      singleContrast = selection$singleContrast,
+      getFoldChange = filter_set$getFoldChange,
+      getFoldChangeCard = filter_set$getFoldChangeCard,
+      getPval = filter_set$getPval,
+      getPvalCard = filter_set$getPvalCard,
+      getQval = filter_set$getQval,
+      getQvalCard = filter_set$getQvalCard,
+      pvalsAvailable = enumeration$pvalsAvailable,
+      qvalsAvailable = enumeration$qvalsAvailable,
+      getFilterRows = filter_set$getFilterRows,
+      getFilterSetCombinationOperator = filter_set$getFilterSetCombinationOperator
+    )
 
-    restored_filtersets <- NULL
-    insert_more <- reactiveVal(0)
+    labelling <- contrastLabelling(
+      eselist, selectmatrix_reactives,
+      selectFinalFeatures = filtering$selectFinalFeatures,
+      filteredContrastsTables = filtering$filteredContrastsTables
+    )
 
-    # Seed a freshly-inserted filter set's fields from bookmarked values. The
-    # per-field observers created alongside the set then propagate these into
-    # filterset_values, re-establishing the normal dependency chain.
+    query_summary <- contrastQuerySummary(
+      output, selectmatrix_reactives,
+      filteredContrastsTables = filtering$filteredContrastsTables,
+      getSelectedContrasts = selection$getSelectedContrasts,
+      makeContrastNames = naming$makeContrastNames,
+      getFilterSetValues = filter_set$getFilterSetValues,
+      selectFilterFinalFeatures = filtering$selectFilterFinalFeatures,
+      selectFinalFeatures = filtering$selectFinalFeatures,
+      getFilterSetCombinationOperator = filter_set$getFilterSetCombinationOperator
+    )
 
-    applyRestoredFilterSet <- function(index, vals) {
-      if (!is.null(vals$contrasts)) {
-        updateSelectInput(session, paste0("contrasts", index), selected = vals$contrasts)
-      }
-      for (field in c("p_value", "q_value", "fold_change")) {
-        if (!is.null(vals[[field]])) {
-          updateNumericInput(session, paste0(field, index), value = as.numeric(vals[[field]]))
+    list(
+      getFoldChange = filter_set$getFoldChange, getFoldChangeCard = filter_set$getFoldChangeCard, getFoldChangeScale = enumeration$getFoldChangeScale,
+      getQval = filter_set$getQval, getQvalCard = filter_set$getQvalCard, getPval = filter_set$getPval, getPvalCard = filter_set$getPvalCard,
+      getAllContrasts = enumeration$getAllContrasts, getSelectedContrasts = selection$getSelectedContrasts, getSelectedContrastNumbers = filter_set$getSelectedContrastNumbers,
+      getSelectedContrastNames = selection$getSelectedContrastNames, getSafeSelectedContrastNames = selection$getSafeSelectedContrastNames,
+      getContrastSamples = enumeration$getContrastSamples, getSelectedContrastSamples = selection$getSelectedContrastSamples,
+      contrastsTables = tables$contrastsTables, filteredContrastsTables = filtering$filteredContrastsTables, labelledContrastsTable = labelling$labelledContrastsTable,
+      linkedLabelledContrastsTable = labelling$linkedLabelledContrastsTable,
+      makeDifferentialSetSummary = query_summary$makeDifferentialSetSummary, getQueryStrings = query_summary$getQueryStrings, selectedContrastsTables = filtering$selectedContrastsTables
+    )
+  })
+}
+
+#' Enumerate contrasts and their per-group summary statistics
+#'
+#' Owns the reactives that read the raw \code{contrasts} slot and, where
+#' requested, calculate per-contrast-variable group summaries (means etc) -
+#' the data every later stage subsets and filters. Independent of the
+#' dynamic filter-set UI: it only reads \code{eselist}/\code{selectmatrix_reactives}.
+#'
+#' @param eselist ExploratorySummarizedExperimentList object
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#'
+#' @return A list of reactives: \code{getSummaries}, \code{getAllContrasts},
+#'   \code{getAllContrastsNumbers}, \code{getContrastSamples},
+#'   \code{fcsAvailable}, \code{getFoldChangeScale}, \code{pvalsAvailable},
+#'   \code{qvalsAvailable}
+#' @noRd
+contrastEnumeration <- function(eselist, selectmatrix_reactives) {
+  getSummaryType <- summarisematrix("contrasts")
+
+  # Generate the summary statistic (probably mean) for column groups as defined by the possible contrasts. Other functions can then pick from this output and
+  # calculate fold changes etc.
+
+  getSummaries <- reactive({
+    if (!is.null(getSummaryType())) {
+      ese <- selectmatrix_reactives$getExperiment()
+      contrasts <- getAllContrasts()
+      matrix <- selectmatrix_reactives$getAssayMatrix()
+      coldata <- data.frame(colData(ese), check.names = FALSE)
+
+      validate(need(nrow(matrix) > 0, "Waiting for input matrix"))
+
+      contrast_variables <- unique(unlist(lapply(contrasts, function(x) x["Variable"])))
+      names(contrast_variables) <- contrast_variables
+
+      withProgress(message = paste("Calculating summaries by", getSummaryType()), value = 0, {
+        summaries <- lapply(contrast_variables, function(cv) summarizeMatrix(matrix, coldata[[cv]], getSummaryType()))
+      })
+
+      summaries
+    }
+  })
+
+  # Get all the contrasts the user specified in their StructuredExperiment- if any
+
+  getAllContrasts <- reactive({
+    if (has_slot_data(eselist, "contrasts")) {
+      contrasts <- eselist@contrasts
+
+      contrasts <- lapply(contrasts, function(cont) {
+        if (is.null(names(cont))) {
+          names(cont) <- c("Variable", "Group.1", "Group.2")
         }
-        card <- paste0(field, "_card")
-        if (!is.null(vals[[card]])) {
-          updateSelectInput(session, paste0(card, index), selected = vals[[card]])
-        }
-      }
+        cont
+      })
+
+      names(contrasts) <- as.character(seq_along(contrasts))
+      contrasts
+    } else {
+      NULL
+    }
+  })
+
+  # Get a named vector of integers for contrasts, to be used in field etc
+
+  getAllContrastsNumbers <- reactive({
+    contrasts <- getAllContrasts()
+    contrast_names <- makeContrastNamesFor(contrasts)
+
+    if (!is.null(contrasts)) {
+      structure(names(contrasts), names = contrast_names)
+    } else {
+      NULL
+    }
+  })
+
+  # Get list describing, for each contrast, the samples on each side
+
+  getContrastSamples <- reactive({
+    ese <- selectmatrix_reactives$getExperiment()
+    coldata <- selectmatrix_reactives$selectColData()
+    contrasts <- getAllContrasts()
+
+    lapply(contrasts, function(c) {
+      list(colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.1"]]], colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.2"]]])
+    })
+  })
+
+  # Test for the presence of pre-computed fold changes (e.g. from modelling)
+
+  fcsAvailable <- reactive({
+    assay <- selectmatrix_reactives$getAssay()
+    ese <- selectmatrix_reactives$getExperiment()
+
+    has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "fold_changes" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$fold_changes)
+  })
+
+  # Report the scale that pre-computed fold changes were interpreted as when
+  # they were read in (see resolve_foldchange_scale()). Fold changes
+  # calculated on the fly via foldChange() are always linear.
+
+  getFoldChangeScale <- reactive({
+    if (!fcsAvailable()) {
+      return("linear")
     }
 
-    # This observer adds a set of filters on the first page load and when the assocaited button is clicked.
+    assay <- selectmatrix_reactives$getAssay()
+    ese <- selectmatrix_reactives$getExperiment()
 
-    observeEvent(
-      {
-        selectmatrix_reactives$selectMatrix()
-        input$insertBtn
-        insert_more()
-      },
-      {
-        ese <- selectmatrix_reactives$getExperiment()
-        contrasts <- getAllContrasts()
-        contrast_numbers <- getAllContrastsNumbers()
-        assay <- selectmatrix_reactives$getAssay()
-        coldata <- selectmatrix_reactives$selectColData()
+    scale <- attr(ese@contrast_stats[[assay]]$fold_changes, "fold_change_scale")
+    if (is.null(scale)) "unspecified" else scale
+  })
 
-        # Restrict contrasts to those valid for the input matrix
+  # Test for the presence of p values in the input object
 
-        valid_contrasts <- unlist(lapply(contrasts, function(cont) {
-          all(c(cont[["Group.1"]], cont[["Group.2"]]) %in% coldata[[cont[["Variable"]]]])
-        }))
-        contrasts <- contrasts[valid_contrasts]
-        contrast_numbers <- contrast_numbers[valid_contrasts]
+  pvalsAvailable <- reactive({
+    assay <- selectmatrix_reactives$getAssay()
+    ese <- selectmatrix_reactives$getExperiment()
 
-        # btn keeps track of how many filter sets have been added
+    has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "pvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$pvals)
+  })
 
-        btn <- length(inserted)
+  # Test for the presence of q values in the input object
 
-        # Call makeContrastFilterSet() to generate a set of filters, and add to the UI with insertUI()
+  qvalsAvailable <- reactive({
+    assay <- selectmatrix_reactives$getAssay()
+    ese <- selectmatrix_reactives$getExperiment()
 
-        insertUI(selector = paste0("#", ns("contrasts-placeholder")), where = "beforeEnd", ui = makeContrastFilterSet(ns, ese, assay, contrasts, contrast_numbers,
-          multiple = multiple, show_controls = show_controls, default_foldchange = default_foldchange, default_pval = default_pval, default_qval = default_qval,
-          filter_rows = getFilterRows(), index = btn, select_all_contrasts = select_all_contrasts
-        ))
+    has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "qvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$qvals)
+  })
 
-        # Record the ID of the added filter set
+  list(
+    getSummaries = getSummaries, getAllContrasts = getAllContrasts, getAllContrastsNumbers = getAllContrastsNumbers,
+    getContrastSamples = getContrastSamples, fcsAvailable = fcsAvailable, getFoldChangeScale = getFoldChangeScale,
+    pvalsAvailable = pvalsAvailable, qvalsAvailable = qvalsAvailable
+  )
+}
 
-        inserted <<- c(inserted, paste0("contrast", btn))
+# Shared by contrastEnumeration()'s getAllContrastsNumbers and contrastNaming()'s
+# makeContrastNames - both build the same "Variable: Group.2 vs Group.1 (extras)"
+# label from a contrasts list, but the former needs it before contrastNaming()
+# exists yet (it only depends on getAllContrasts). Kept as a plain function
+# (not a reactive) since it's pure given its input.
+makeContrastNamesFor <- function(contrasts) {
+  lapply(contrasts, function(x) {
+    x <- x[!names(x) %in% "id"]
+    contrast_name <- paste(prettifyVariablename(x["Variable"]), paste(x["Group.2"], x["Group.1"], sep = " vs "), sep = ": ")
+    extras <- setdiff(names(x), c("Variable", "Group.1", "Group.2"))
+    if (length(extras) > 0) {
+      suffix <- paste0("(", paste(paste(extras, x[extras], sep = ":"), collapse = ","), ")")
+      contrast_name <- paste(contrast_name, suffix)
+    }
+    contrast_name
+  })
+}
 
-        # Now add observers for each new element generated by makeControlFilterSet(). When they fire, these observers will add the filter values to the reactive
-        # filterset_values. When this is referenced (by e.g. getFoldChange()), the dependency chain is established such that outputs are refreshed when the
-        # dynamically added fields are altered.
+#' Build display names for contrasts
+#'
+#' @param getAllContrasts Reactive returning the raw contrasts list, from
+#'   \code{contrastEnumeration}
+#'
+#' @return A list of reactives: \code{makeContrastNames} (human-readable),
+#'   \code{makeSafeContrastNames} (safe for use as e.g. plot trace names)
+#' @noRd
+contrastNaming <- function(getAllContrasts) {
+  makeContrastNames <- reactive({
+    makeContrastNamesFor(getAllContrasts())
+  })
 
-        filterId <- paste0("filter", btn)
+  # Make safe set of names to be used where spaces etc not allowed
 
-        filter_observers[[filterId]] <<- lapply(c("contrasts", "fold_change", "q_value", "p_value", "fold_change_card", "q_value_card", "p_value_card"), function(field) {
-          filter_field_id <- paste0(field, btn)
-          observeEvent(input[[filter_field_id]],
-            {
-              req(input[[filter_field_id]])
-              if (is.null(filterset_values[[filterId]])) {
-                filterset_values[[filterId]] <<- list()
-              }
+  makeSafeContrastNames <- reactive({
+    contrasts <- getAllContrasts()
+    names <- lapply(contrasts, function(x) paste(ucfirst(prettifyVariablename(x["Variable"])), paste(ucfirst(x["Group.2"]), ucfirst(x["Group.1"]), sep = "_vs_"), sep = "."))
+    names <- lapply(names, function(name) {
+      name <- sub("\\+", "_POS_", name)
+      name <- sub("\\-", "_NEG_", name)
+    })
+    names
+  })
 
-              if (length(input[[filter_field_id]]) == 1 && input[[filter_field_id]] == "NULL") {
-                filterset_values[[filterId]][[field]] <<- NULL
-              } else {
-                filterset_values[[filterId]][[field]] <<- input[[filter_field_id]]
-              }
+  list(makeContrastNames = makeContrastNames, makeSafeContrastNames = makeSafeContrastNames)
+}
 
-              # filterset_values[[filterId]][[paste0(field, 'card')]] <<- input[[paste0(filter_field_id, 'card')]]
-            },
-            ignoreNULL = FALSE
-          )
-        })
+#' The dynamic contrast filter-set engine
+#'
+#' Owns everything about the progressively-addable filter sets: inserting and
+#' removing filter set UI, tracking their current values in
+#' \code{filterset_values} (a reactive-bound list mutated by per-field
+#' observers), rebuilding on assay change, and bookmarking/restoring that
+#' state. Also owns the accessors that just read \code{filterset_values} (the
+#' "form value" reactives), since they're only meaningful together with this
+#' state and folding them in here removes what would otherwise be a forward
+#' reference (the insert observer and \code{output$combine_operator} use
+#' \code{getFilterRows()}/\code{getSelectedContrastNumbers()} before those
+#' would be defined, if they lived in a separate stage called later).
+#'
+#' @param ns,input,output,session Module namespace function and Shiny objects
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#' @param multiple,show_controls,default_foldchange,default_pval,default_qval,select_all_contrasts
+#'   Passed through from \code{contrasts()}'s own arguments
+#' @param getAllContrasts,getAllContrastsNumbers Reactives from
+#'   \code{contrastEnumeration}
+#' @param fcsAvailable,pvalsAvailable,qvalsAvailable Reactives from
+#'   \code{contrastEnumeration}, used to decide whether a filter set's
+#'   cardinality fields are required
+#'
+#' @return A list of reactives: \code{getFilterRows},
+#'   \code{getSelectedContrastNumbers}, \code{getFoldChange},
+#'   \code{getFoldChangeCard}, \code{getQval}, \code{getQvalCard},
+#'   \code{getPval}, \code{getPvalCard}, \code{getFilterSetCombinationOperator},
+#'   \code{isDynamic}, and \code{getFilterSetValues} (a raw accessor to the
+#'   whole \code{filterset_values} list, for \code{contrastQuerySummary})
+#' @noRd
+contrastFilterSetEngine <- function(ns, input, output, session, selectmatrix_reactives,
+                                     multiple, show_controls, default_foldchange, default_pval, default_qval, select_all_contrasts,
+                                     getAllContrasts, getAllContrastsNumbers, fcsAvailable, pvalsAvailable, qvalsAvailable) {
+  ########################################################################### Rendering the contrast control filter sets
 
-        # Re-seed this set from bookmarked values on every (re)creation while a
-        # restore is pending. The assay-change reset (priority 2) rebuilds the
-        # sets whenever selectMatrix() changes as inputs restore, so applying
-        # once would be wiped; re-applying here survives that churn until
-        # onRestored clears the pending state.
+  inserted <- c() # Stores the list of inserted filter sets
+  filterset_values <- list() # Stores the list of values in the filter set
+  makeReactiveBinding("filterset_values") # Make the stored values reactive
 
-        if (!is.null(restored_filtersets)) {
-          if (btn < length(restored_filtersets)) {
-            applyRestoredFilterSet(btn, restored_filtersets[[btn + 1]])
-          }
-          if (length(inserted) < length(restored_filtersets)) {
-            insert_more(insert_more() + 1)
-          }
-        }
-      },
-      ignoreNULL = FALSE,
-      priority = 1
-    )
+  filter_observers <- list()
 
-    # This observer removes a filter set when the 'remove' button is clicked.  This removes both the UI element and its stored values in filterset_values
+  # insert_more is a bare counter the insert observer depends on, so restored
+  # filter sets beyond the first can be re-inserted one at a time.
 
-    observeEvent(input$removeBtn, {
-      if (length(inserted) > 1) {
-        removeUI(selector = paste0("#", inserted[length(inserted)]))
-        inserted <<- inserted[-length(inserted)]
-        filterset_values[[length(filterset_values)]] <<- NULL
+  restored_filtersets <- NULL
+  insert_more <- reactiveVal(0)
+
+  # Get current value of field which determines if the table should be filtered at all.
+
+  getFilterRows <- reactive({
+    req(!is.null(input$filterRows))
+    as.logical(input$filterRows)
+  })
+
+  # Seed a freshly-inserted filter set's fields from bookmarked values. The
+  # per-field observers created alongside the set then propagate these into
+  # filterset_values, re-establishing the normal dependency chain.
+
+  applyRestoredFilterSet <- function(index, vals) {
+    if (!is.null(vals$contrasts)) {
+      updateSelectInput(session, paste0("contrasts", index), selected = vals$contrasts)
+    }
+    for (field in c("p_value", "q_value", "fold_change")) {
+      if (!is.null(vals[[field]])) {
+        updateNumericInput(session, paste0(field, index), value = as.numeric(vals[[field]]))
       }
-    })
-
-    # When a new assay is selected, or when the input matrix is otherwise changed, we need to rebuild the inputs
-
-    observeEvent(selectmatrix_reactives$selectMatrix(),
-      {
-        if (length(inserted) > 0) {
-          lapply(names(filterset_values), function(filterId) {
-            lapply(names(filterset_values[[filterId]]), function(field) {
-              filterset_values[[filterId]][[field]] <<- NULL
-            })
-            filterset_values[[filterId]] <<- NULL
-          })
-          removeUI(selector = ".shinyngs-contrast", multiple = TRUE, immediate = TRUE)
-          inserted <<- c()
-        }
-      },
-      priority = 2
-    )
-
-    # The combine_operator field is only necessary with more than one filter set
-
-    output$combine_operator <- renderUI({
-      scn <- getSelectedContrastNumbers()
-      if (length(scn) > 1) {
-        inlineField(selectInput(ns("combine_operator"), NULL, c(and = "intersect", or = "union")),
-          label = "Combine using", 6,
-          tooltip = "'Intersect' requires rows to satisfy every selected contrast filter; 'union' includes rows matching any one of them."
-        )
-      } else {
-        hiddenInput(ns("combine_operator"), "intersect")
+      card <- paste0(field, "_card")
+      if (!is.null(vals[[card]])) {
+        updateSelectInput(session, paste0(card, index), selected = vals[[card]])
       }
-    })
+    }
+  }
 
-    ########################################################################### Accessors for form values
+  # This observer adds a set of filters on the first page load and when the assocaited button is clicked.
 
-    # Get current value of field which determines if the table should be filtered at all.
-
-    getFilterRows <- reactive({
-      req(!is.null(input$filterRows))
-      as.logical(input$filterRows)
-    })
-
-    # Get the indices of the currently selected contrasts for each filter set by querying filterset_values.
-
-    getSelectedContrastNumbers <- reactive({
-      req(length(filterset_values) > 0)
-      lapply(filterset_values, function(x) x$contrasts)
-    })
-
-    # Fetch the values from all the fold change filters
-
-    getFoldChange <- reactive({
-      req(length(filterset_values) > 0)
-      unlist(lapply(filterset_values, function(x) x$fold_change))
-    })
-
-    # Fetch the values from all the fold change cardinality filters
-
-    getFoldChangeCard <- reactive({
-      req(length(filterset_values) > 0)
-      card <- unlist(lapply(filterset_values, function(x) x$fold_change_card))
-      if (fcsAvailable()) {
-        req(length(card) > 0)
-      }
-      card
-    })
-
-    # Get current value of the q value filter
-
-    getQval <- reactive({
-      req(length(filterset_values) > 0)
-      unlist(lapply(filterset_values, function(x) x$q_value))
-    })
-
-    # Get current value of the q value cardinality filter
-
-    getQvalCard <- reactive({
-      req(length(filterset_values) > 0)
-      card <- unlist(lapply(filterset_values, function(x) x$q_value_card))
-      if (qvalsAvailable()) {
-        req(length(card) > 0)
-      }
-      card
-    })
-
-    # Get current value of the p value filter
-
-    getPval <- reactive({
-      req(length(filterset_values) > 0)
-      unlist(lapply(filterset_values, function(x) x$p_value))
-    })
-
-    # Get current value of the p value cardinality filter
-
-    getPvalCard <- reactive({
-      req(length(filterset_values) > 0)
-      card <- unlist(lapply(filterset_values, function(x) x$p_value_card))
-      if (pvalsAvailable()) {
-        req(length(card) > 0)
-      }
-      card
-    })
-
-    # Get method for combining filters
-
-    getFilterSetCombinationOperator <- reactive({
-      req(input$combine_operator)
-      input$combine_operator
-    })
-
-    # Use presence of combine operator as a flag for use of dynamic contrasts, i.e. the possibility of multiple filter sets
-
-    isDynamic <- reactive({
-      !is.null(input$dynamic)
-    })
-
-    ########################################################################### Generate summaries and contrast stats for all contrasts and all rows.  Then the data is handy for subsetting by other functions.  NOTE: this uses ALL
-    ########################################################################### rows in the input ExploratorySummarizedExperiment.  The rows in the matrix returned by selectmatrix_reactives$selectMatrix() will but a subset, but any modifications to the
-    ########################################################################### rows used will not necessitate a re-calculation of these basic stats.
-
-    # Generate the summary statistic (probably mean) for column groups as defined by the possible contrasts. Other functions can then pick from this output and
-    # calculate fold changes etc.
-
-    getSummaries <- reactive({
-      if (!is.null(getSummaryType())) {
-        ese <- selectmatrix_reactives$getExperiment()
-        contrasts <- getAllContrasts()
-        matrix <- selectmatrix_reactives$getAssayMatrix()
-        coldata <- data.frame(colData(ese), check.names = FALSE)
-
-        validate(need(nrow(matrix) > 0, "Waiting for input matrix"))
-
-        contrast_variables <- unique(unlist(lapply(contrasts, function(x) x["Variable"])))
-        names(contrast_variables) <- contrast_variables
-
-        withProgress(message = paste("Calculating summaries by", getSummaryType()), value = 0, {
-          summaries <- lapply(contrast_variables, function(cv) summarizeMatrix(matrix, coldata[[cv]], getSummaryType()))
-        })
-
-        summaries
-      }
-    })
-
-    # Get all the contrasts the user specified in their StructuredExperiment- if any
-
-    getAllContrasts <- reactive({
-      if (has_slot_data(eselist, "contrasts")) {
-        contrasts <- eselist@contrasts
-
-        contrasts <- lapply(contrasts, function(cont) {
-          if (is.null(names(cont))) {
-            names(cont) <- c("Variable", "Group.1", "Group.2")
-          }
-          cont
-        })
-
-        names(contrasts) <- as.character(seq_along(contrasts))
-        contrasts
-      } else {
-        NULL
-      }
-    })
-
-    # Get a named vector of integers for contrasts, to be used in field etc
-
-    getAllContrastsNumbers <- reactive({
-      contrasts <- getAllContrasts()
-      contrast_names <- makeContrastNames()
-
-      if (!is.null(contrasts)) {
-        structure(names(contrasts), names = contrast_names)
-      } else {
-        NULL
-      }
-    })
-
-    # Get list describing, for each contrast, the samples on each side
-
-    getContrastSamples <- reactive({
+  observeEvent(
+    {
+      selectmatrix_reactives$selectMatrix()
+      input$insertBtn
+      insert_more()
+    },
+    {
       ese <- selectmatrix_reactives$getExperiment()
+      contrasts <- getAllContrasts()
+      contrast_numbers <- getAllContrastsNumbers()
+      assay <- selectmatrix_reactives$getAssay()
       coldata <- selectmatrix_reactives$selectColData()
-      contrasts <- getAllContrasts()
 
-      lapply(contrasts, function(c) {
-        list(colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.1"]]], colnames(ese)[coldata[[c[["Variable"]]]] == c[["Group.2"]]])
-      })
-    })
+      # Restrict contrasts to those valid for the input matrix
 
-    # Main function for returning the table of contrast information. Means, fold changes calculated on the fly, p/q values must be supplied in a 'contrast_stats' slot
-    # of the ExploratorySummarizedExperiment. Make a summary table for every contrast. This data can then be re-used when processing filter sets.
+      valid_contrasts <- unlist(lapply(contrasts, function(cont) {
+        all(c(cont[["Group.1"]], cont[["Group.2"]]) %in% coldata[[cont[["Variable"]]]])
+      }))
+      contrasts <- contrasts[valid_contrasts]
+      contrast_numbers <- contrast_numbers[valid_contrasts]
 
-    contrastsTables <- reactive({
-      matrix <- selectmatrix_reactives$selectMatrix()
+      # btn keeps track of how many filter sets have been added
 
-      ese <- selectmatrix_reactives$getExperiment()
-      summaries <- getSummaries()
-      contrasts <- getAllContrasts()
-      assay <- selectmatrix_reactives$getAssay()
+      btn <- length(inserted)
 
-      # There can be a mismatch between the conrasts and summaries as we adjust the input matrix. Wait for updates to finish before making the table.
+      # Call makeContrastFilterSet() to generate a set of filters, and add to the UI with insertUI()
 
-      # validate(need(all(unlist(lapply(selected_contrasts, function(x) all(x[-1] %in% colnames(summaries[[x[1]]]))))), 'Matching summaries and contrasts'))
+      insertUI(selector = paste0("#", ns("contrasts-placeholder")), where = "beforeEnd", ui = makeContrastFilterSet(ns, ese, assay, contrasts, contrast_numbers,
+        multiple = multiple, show_controls = show_controls, default_foldchange = default_foldchange, default_pval = default_pval, default_qval = default_qval,
+        filter_rows = getFilterRows(), index = btn, select_all_contrasts = select_all_contrasts
+      ))
 
-      withProgress(message = "Calculating contrast tables", value = 0, {
-        contrast_tables <- lapply(names(contrasts), function(c) {
-          cont <- contrasts[[c]]
+      # Record the ID of the added filter set
 
-          smry1 <- summaries[[cont[["Variable"]]]][, cont[["Group.1"]]]
-          smry2 <- summaries[[cont[["Variable"]]]][, cont[["Group.2"]]]
+      inserted <<- c(inserted, paste0("contrast", btn))
 
-          ct <- data.frame(cont[["Variable"]], cont[["Group.1"]], cont[["Group.2"]], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
-          names(ct) <- c("Variable", "Condition 1", "Condition 2", "Average 1", "Average 2")
+      # Now add observers for each new element generated by makeControlFilterSet(). When they fire, these observers will add the filter values to the reactive
+      # filterset_values. When this is referenced (by e.g. getFoldChange()), the dependency chain is established such that outputs are refreshed when the
+      # dynamically added fields are altered.
 
-          # Use pre-computed fold changes where provided.
+      filterId <- paste0("filter", btn)
 
-          if (fcsAvailable()) {
-            fcs <- ese@contrast_stats[[assay]]$fold_changes
-            ct[["Fold change"]] <- round(fcs[match(rownames(ct), rownames(fcs)), as.numeric(c)], 2)
-          } else {
-            ct[["Fold change"]] <- round(foldChange(smry1, smry2), 2)
-          }
-
-          if (pvalsAvailable()) {
-            pvals <- ese@contrast_stats[[assay]]$pvals
-            ct[["p value"]] <- signif(pvals[match(rownames(ct), rownames(pvals)), as.numeric(c)], 5)
-          }
-
-          if (qvalsAvailable()) {
-            qvals <- ese@contrast_stats[[assay]]$qvals
-            ct[["q value"]] <- signif(qvals[match(rownames(ct), rownames(qvals)), as.numeric(c)], 5)
-          }
-
-          ct
-        })
-      })
-
-      names(contrast_tables) <- getAllContrastsNumbers()
-      contrast_tables
-    })
-
-    # Test for the presence of pre-computed fold changes (e.g. from modelling)
-
-    fcsAvailable <- reactive({
-      assay <- selectmatrix_reactives$getAssay()
-      ese <- selectmatrix_reactives$getExperiment()
-
-      has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "fold_changes" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$fold_changes)
-    })
-
-    # Report the scale that pre-computed fold changes were interpreted as when
-    # they were read in (see resolve_foldchange_scale()). Fold changes
-    # calculated on the fly via foldChange() are always linear.
-
-    getFoldChangeScale <- reactive({
-      if (!fcsAvailable()) {
-        return("linear")
-      }
-
-      assay <- selectmatrix_reactives$getAssay()
-      ese <- selectmatrix_reactives$getExperiment()
-
-      scale <- attr(ese@contrast_stats[[assay]]$fold_changes, "fold_change_scale")
-      if (is.null(scale)) "unspecified" else scale
-    })
-
-    # Test for the presence of p values in the input object
-
-    pvalsAvailable <- reactive({
-      assay <- selectmatrix_reactives$getAssay()
-      ese <- selectmatrix_reactives$getExperiment()
-
-      has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "pvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$pvals)
-    })
-
-    # Test for the presence of q values in the input object
-
-    qvalsAvailable <- reactive({
-      assay <- selectmatrix_reactives$getAssay()
-      ese <- selectmatrix_reactives$getExperiment()
-
-      has_slot_data(ese, "contrast_stats") && assay %in% names(ese@contrast_stats) && "qvals" %in% names(ese@contrast_stats[[assay]]) && !is.null(ese@contrast_stats[[assay]]$qvals)
-    })
-
-    ########################################################################### Subsetting using the rows in the input matrix. This does NOT involve the filters from this module, but simply subsets the base data to the rows pertinent
-    ########################################################################### to the input matrix.
-
-    # Get contrasts tables with rows reflecting the input matrix
-
-    contrastsTablesToMatchMatrix <- reactive({
-      contrast_tables <- contrastsTables()
-      matrix <- selectmatrix_reactives$selectMatrix()
-
-      lapply(contrast_tables, function(ct) {
-        ct[rownames(matrix), ]
-      })
-    })
-
-    ########################################################################### Contrast naming
-
-    # Make names for the contrasts
-
-    makeContrastNames <- reactive({
-      contrasts <- getAllContrasts()
-
-      lapply(contrasts, function(x) {
-        x <- x[!names(x) %in% "id"]
-        contrast_name <- paste(prettifyVariablename(x["Variable"]), paste(x["Group.2"], x["Group.1"], sep = " vs "), sep = ": ")
-        extras <- setdiff(names(x), c("Variable", "Group.1", "Group.2"))
-        if (length(extras) > 0) {
-          suffix <- paste0("(", paste(paste(extras, x[extras], sep = ":"), collapse = ","), ")")
-          contrast_name <- paste(contrast_name, suffix)
-        }
-        contrast_name
-      })
-    })
-
-    # Make safe set of names to be used where spaces etc not allowed
-
-    makeSafeContrastNames <- reactive({
-      contrasts <- getAllContrasts()
-      names <- lapply(contrasts, function(x) paste(ucfirst(prettifyVariablename(x["Variable"])), paste(ucfirst(x["Group.2"]), ucfirst(x["Group.1"]), sep = "_vs_"), sep = "."))
-      names <- lapply(names, function(name) {
-        name <- sub("\\+", "_POS_", name)
-        name <- sub("\\-", "_NEG_", name)
-      })
-      names
-    })
-
-    ########################################################################### Subset contrast-related variables according to filters
-
-    # Get the actual contrasts to which the numbers from the interface pertain
-
-    getSelectedContrasts <- reactive({
-      scn <- getSelectedContrastNumbers()
-      all_contrasts <- getAllContrasts()
-
-      lapply(scn, function(s) {
-        all_contrasts[s]
-      })
-    })
-
-    # Get the name of the currently selected contrast
-
-    getSelectedContrastNames <- reactive({
-      contrast_names <- makeContrastNames()
-      lapply(getSelectedContrastNumbers(), function(x) contrast_names[x])
-    })
-
-    # The same, but with safe names that won't get mangled by plotting etc
-
-    getSafeSelectedContrastNames <- reactive({
-      contrast_names <- makeSafeContrastNames()
-
-      lapply(getSelectedContrastNumbers(), function(scns) {
-        contrast_names[scns]
-      })
-    })
-
-    # Get samples for currently selected contrast
-
-    getSelectedContrastSamples <- reactive({
-      contrast_samples <- getContrastSamples()
-      selected_contrasts <- getSelectedContrastNumbers()
-      contrast_samples[[selected_contrasts]]
-    })
-
-    ########################################################################### Process data in response to contrasts filters
-
-    # If we're only looking at a single contrast filter with a single contrast (e.g. for a fold change plot etc), then we can simplify.
-
-    singleContrast <- reactive({
-      selected_contrasts <- getSelectedContrastNumbers()
-      length(selected_contrasts) == 1 && length(selected_contrasts[[1]]) == 1
-    })
-
-    # Filter contrasts tables down to the contrasts of interest
-
-    selectedContrastsTables <- reactive({
-      selected_contrasts <- getSelectedContrastNumbers()
-      contrast_tables <- contrastsTablesToMatchMatrix()
-
-      req(selected_contrasts, contrast_tables)
-
-      # Selected contrasts is a list, one for each filter set. Each one can have multiple contrasts
-
-      withProgress(message = "Filtering to specified features", value = 0, {
-        lapply(selected_contrasts, function(scs_set) {
-          lapply(scs_set, function(s) {
-            ct <- contrast_tables[[s]]
-            if (singleContrast()) {
-              simplifyContrastTable(ct)
-            } else {
-              ct
+      filter_observers[[filterId]] <<- lapply(c("contrasts", "fold_change", "q_value", "p_value", "fold_change_card", "q_value_card", "p_value_card"), function(field) {
+        filter_field_id <- paste0(field, btn)
+        observeEvent(input[[filter_field_id]],
+          {
+            req(input[[filter_field_id]])
+            if (is.null(filterset_values[[filterId]])) {
+              filterset_values[[filterId]] <<- list()
             }
-          })
-        })
+
+            if (length(input[[filter_field_id]]) == 1 && input[[filter_field_id]] == "NULL") {
+              filterset_values[[filterId]][[field]] <<- NULL
+            } else {
+              filterset_values[[filterId]][[field]] <<- input[[filter_field_id]]
+            }
+
+            # filterset_values[[filterId]][[paste0(field, 'card')]] <<- input[[paste0(filter_field_id, 'card')]]
+          },
+          ignoreNULL = FALSE
+        )
       })
-    })
 
-    # Apply user filters to results of contrastsTables(). Called on first page load and on subsequent clicks of 'Apply'.
+      # Re-seed this set from bookmarked values on every (re)creation while a
+      # restore is pending. The assay-change reset (priority 2) rebuilds the
+      # sets whenever selectMatrix() changes as inputs restore, so applying
+      # once would be wiped; re-applying here survives that churn until
+      # onRestored clears the pending state.
 
-    filteredContrastsTables <- reactive({
-      selected_contrasts_tables <- selectedContrastsTables()
-      req(length(selected_contrasts_tables) > 0)
-
-      if (getFilterRows()) {
-        ese <- selectmatrix_reactives$getExperiment()
-        assay <- selectmatrix_reactives$getAssay()
-
-        fold_change <- getFoldChange()
-        fold_change_card <- getFoldChangeCard()
-        p_value <- getPval()
-        p_value_card <- getPvalCard()
-        q_value <- getQval()
-        q_value_card <- getQvalCard()
-
-        withProgress(message = "Applying filters", value = 0, {
-          fcts <- lapply(seq_along(selected_contrasts_tables), function(i) {
-            sct <- selected_contrasts_tables[[i]]
-
-            lapply(sct, function(s) {
-              filter <- evaluateCardinalFilter(s[["Fold change"]], fold_change_card[i], fold_change[i])
-
-              if (pvalsAvailable()) {
-                filter <- filter & evaluateCardinalFilter(s[["p value"]], p_value_card[i], p_value[i])
-              }
-
-              if (qvalsAvailable()) {
-                filter <- filter & evaluateCardinalFilter(s[["q value"]], q_value_card[i], q_value[i])
-              }
-
-              s[filter, , drop = FALSE]
-            })
-          })
-        })
-      } else {
-        fcts <- selected_contrasts_tables
+      if (!is.null(restored_filtersets)) {
+        if (btn < length(restored_filtersets)) {
+          applyRestoredFilterSet(btn, restored_filtersets[[btn + 1]])
+        }
+        if (length(inserted) < length(restored_filtersets)) {
+          insert_more(insert_more() + 1)
+        }
       }
-      fcts
-    })
+    },
+    ignoreNULL = FALSE,
+    priority = 1
+  )
 
-    # Find the list of features that result from combining all the filters
+  # This observer removes a filter set when the 'remove' button is clicked.  This removes both the UI element and its stored values in filterset_values
 
-    selectFilterFinalFeatures <- reactive({
-      filtered_contrasts_tables <- filteredContrastsTables()
-      validate(need(length(filtered_contrasts_tables) > 0, "Waiting for filtered contrasts tables"))
+  observeEvent(input$removeBtn, {
+    if (length(inserted) > 1) {
+      removeUI(selector = paste0("#", inserted[length(inserted)]))
+      inserted <<- inserted[-length(inserted)]
+      filterset_values[[length(filterset_values)]] <<- NULL
+    }
+  })
 
-      lapply(filtered_contrasts_tables, function(fcts) {
-        Reduce(intersect, lapply(fcts, function(fct) {
-          rownames(fct)
-        }))
+  # When a new assay is selected, or when the input matrix is otherwise changed, we need to rebuild the inputs
+
+  observeEvent(selectmatrix_reactives$selectMatrix(),
+    {
+      if (length(inserted) > 0) {
+        lapply(names(filterset_values), function(filterId) {
+          lapply(names(filterset_values[[filterId]]), function(field) {
+            filterset_values[[filterId]][[field]] <<- NULL
+          })
+          filterset_values[[filterId]] <<- NULL
+        })
+        removeUI(selector = ".shinyngs-contrast", multiple = TRUE, immediate = TRUE)
+        inserted <<- c()
+      }
+    },
+    priority = 2
+  )
+
+  # The combine_operator field is only necessary with more than one filter set
+
+  output$combine_operator <- renderUI({
+    scn <- getSelectedContrastNumbers()
+    if (length(scn) > 1) {
+      inlineField(selectInput(ns("combine_operator"), NULL, c(and = "intersect", or = "union")),
+        label = "Combine using", 6,
+        tooltip = "'Intersect' requires rows to satisfy every selected contrast filter; 'union' includes rows matching any one of them."
+      )
+    } else {
+      hiddenInput(ns("combine_operator"), "intersect")
+    }
+  })
+
+  ########################################################################### Accessors for form values
+
+  # Get the indices of the currently selected contrasts for each filter set by querying filterset_values.
+
+  getSelectedContrastNumbers <- reactive({
+    req(length(filterset_values) > 0)
+    lapply(filterset_values, function(x) x$contrasts)
+  })
+
+  # Fetch the values from all the fold change filters
+
+  getFoldChange <- reactive({
+    req(length(filterset_values) > 0)
+    unlist(lapply(filterset_values, function(x) x$fold_change))
+  })
+
+  # Fetch the values from all the fold change cardinality filters
+
+  getFoldChangeCard <- reactive({
+    req(length(filterset_values) > 0)
+    card <- unlist(lapply(filterset_values, function(x) x$fold_change_card))
+    if (fcsAvailable()) {
+      req(length(card) > 0)
+    }
+    card
+  })
+
+  # Get current value of the q value filter
+
+  getQval <- reactive({
+    req(length(filterset_values) > 0)
+    unlist(lapply(filterset_values, function(x) x$q_value))
+  })
+
+  # Get current value of the q value cardinality filter
+
+  getQvalCard <- reactive({
+    req(length(filterset_values) > 0)
+    card <- unlist(lapply(filterset_values, function(x) x$q_value_card))
+    if (qvalsAvailable()) {
+      req(length(card) > 0)
+    }
+    card
+  })
+
+  # Get current value of the p value filter
+
+  getPval <- reactive({
+    req(length(filterset_values) > 0)
+    unlist(lapply(filterset_values, function(x) x$p_value))
+  })
+
+  # Get current value of the p value cardinality filter
+
+  getPvalCard <- reactive({
+    req(length(filterset_values) > 0)
+    card <- unlist(lapply(filterset_values, function(x) x$p_value_card))
+    if (pvalsAvailable()) {
+      req(length(card) > 0)
+    }
+    card
+  })
+
+  # Get method for combining filters
+
+  getFilterSetCombinationOperator <- reactive({
+    req(input$combine_operator)
+    input$combine_operator
+  })
+
+  # Use presence of combine operator as a flag for use of dynamic contrasts, i.e. the possibility of multiple filter sets
+
+  isDynamic <- reactive({
+    !is.null(input$dynamic)
+  })
+
+  ########################################################################### Bookmarking of the dynamically-built filter sets
+
+  # The filter-set inputs are inserted at runtime, so a bookmark URL cannot
+  # capture or restore them by itself. Snapshot filterset_values on bookmark
+  # and stash it on restore for the insert observer to replay. Keys are
+  # namespaced so multiple contrasts instances in one app don't collide.
+
+  onBookmark(function(state) {
+    state$values[[session$ns("contrast_filtersets")]] <- filterset_values
+  })
+
+  onRestore(function(state) {
+    saved <- state$values[[session$ns("contrast_filtersets")]]
+    if (!is.null(saved) && length(saved) > 0) {
+      restored_filtersets <<- unname(saved)
+    }
+  })
+
+  # Close the restore window once the restore flush has settled, so later
+  # user-driven filter sets start from defaults rather than the bookmarked
+  # values.
+
+  onRestored(function(state) {
+    restored_filtersets <<- NULL
+  })
+
+  list(
+    getFilterRows = getFilterRows, getSelectedContrastNumbers = getSelectedContrastNumbers,
+    getFoldChange = getFoldChange, getFoldChangeCard = getFoldChangeCard,
+    getQval = getQval, getQvalCard = getQvalCard, getPval = getPval, getPvalCard = getPvalCard,
+    getFilterSetCombinationOperator = getFilterSetCombinationOperator, isDynamic = isDynamic,
+    getFilterSetValues = function() filterset_values
+  )
+}
+
+#' Build per-contrast summary tables (means, fold changes, p/q values)
+#'
+#' Main table generation: for every contrast, a table of the group summary
+#' stats and fold change, with pre-computed or on-the-fly fold changes/p/q
+#' values, followed by subsetting those tables down to the rows of the
+#' currently selected input matrix.
+#'
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#' @param getSummaries,getAllContrasts,getAllContrastsNumbers,fcsAvailable,pvalsAvailable,qvalsAvailable
+#'   Reactives from \code{contrastEnumeration}
+#'
+#' @return A list of reactives: \code{contrastsTables},
+#'   \code{contrastsTablesToMatchMatrix}
+#' @noRd
+contrastTableBuilder <- function(selectmatrix_reactives, getSummaries, getAllContrasts, getAllContrastsNumbers, fcsAvailable, pvalsAvailable, qvalsAvailable) {
+  # Main function for returning the table of contrast information. Means, fold changes calculated on the fly, p/q values must be supplied in a 'contrast_stats' slot
+  # of the ExploratorySummarizedExperiment. Make a summary table for every contrast. This data can then be re-used when processing filter sets.
+
+  contrastsTables <- reactive({
+    matrix <- selectmatrix_reactives$selectMatrix()
+
+    ese <- selectmatrix_reactives$getExperiment()
+    summaries <- getSummaries()
+    contrasts <- getAllContrasts()
+    assay <- selectmatrix_reactives$getAssay()
+
+    # There can be a mismatch between the conrasts and summaries as we adjust the input matrix. Wait for updates to finish before making the table.
+
+    # validate(need(all(unlist(lapply(selected_contrasts, function(x) all(x[-1] %in% colnames(summaries[[x[1]]]))))), 'Matching summaries and contrasts'))
+
+    withProgress(message = "Calculating contrast tables", value = 0, {
+      contrast_tables <- lapply(names(contrasts), function(c) {
+        cont <- contrasts[[c]]
+
+        smry1 <- summaries[[cont[["Variable"]]]][, cont[["Group.1"]]]
+        smry2 <- summaries[[cont[["Variable"]]]][, cont[["Group.2"]]]
+
+        ct <- data.frame(cont[["Variable"]], cont[["Group.1"]], cont[["Group.2"]], round(smry1, 2), round(smry2, 2), row.names = names(smry1))
+        names(ct) <- c("Variable", "Condition 1", "Condition 2", "Average 1", "Average 2")
+
+        # Use pre-computed fold changes where provided.
+
+        if (fcsAvailable()) {
+          fcs <- ese@contrast_stats[[assay]]$fold_changes
+          ct[["Fold change"]] <- round(fcs[match(rownames(ct), rownames(fcs)), as.numeric(c)], 2)
+        } else {
+          ct[["Fold change"]] <- round(foldChange(smry1, smry2), 2)
+        }
+
+        if (pvalsAvailable()) {
+          pvals <- ese@contrast_stats[[assay]]$pvals
+          ct[["p value"]] <- signif(pvals[match(rownames(ct), rownames(pvals)), as.numeric(c)], 5)
+        }
+
+        if (qvalsAvailable()) {
+          qvals <- ese@contrast_stats[[assay]]$qvals
+          ct[["q value"]] <- signif(qvals[match(rownames(ct), rownames(qvals)), as.numeric(c)], 5)
+        }
+
+        ct
       })
     })
 
-    selectFinalFeatures <- reactive({
-      filter_final_features <- selectFilterFinalFeatures()
+    names(contrast_tables) <- getAllContrastsNumbers()
+    contrast_tables
+  })
 
-      withProgress(message = "Selecting final feature set", value = 0, {
-        comb_op <- getFilterSetCombinationOperator()
-        Reduce(get(comb_op), filter_final_features)
+  ########################################################################### Subsetting using the rows in the input matrix. This does NOT involve the filters from this module, but simply subsets the base data to the rows pertinent
+  ########################################################################### to the input matrix.
+
+  # Get contrasts tables with rows reflecting the input matrix
+
+  contrastsTablesToMatchMatrix <- reactive({
+    contrast_tables <- contrastsTables()
+    matrix <- selectmatrix_reactives$selectMatrix()
+
+    lapply(contrast_tables, function(ct) {
+      ct[rownames(matrix), ]
+    })
+  })
+
+  list(contrastsTables = contrastsTables, contrastsTablesToMatchMatrix = contrastsTablesToMatchMatrix)
+}
+
+#' Resolve the currently-selected contrasts and their names/samples
+#'
+#' @param getSelectedContrastNumbers Reactive from \code{contrastFilterSetEngine}
+#' @param getAllContrasts,getContrastSamples Reactives from
+#'   \code{contrastEnumeration}
+#' @param makeContrastNames,makeSafeContrastNames Reactives from
+#'   \code{contrastNaming}
+#'
+#' @return A list of reactives: \code{getSelectedContrasts},
+#'   \code{getSelectedContrastNames}, \code{getSafeSelectedContrastNames},
+#'   \code{getSelectedContrastSamples}, \code{singleContrast}
+#' @noRd
+contrastSelection <- function(getSelectedContrastNumbers, getAllContrasts, getContrastSamples, makeContrastNames, makeSafeContrastNames) {
+  # Get the actual contrasts to which the numbers from the interface pertain
+
+  getSelectedContrasts <- reactive({
+    scn <- getSelectedContrastNumbers()
+    all_contrasts <- getAllContrasts()
+
+    lapply(scn, function(s) {
+      all_contrasts[s]
+    })
+  })
+
+  # Get the name of the currently selected contrast
+
+  getSelectedContrastNames <- reactive({
+    contrast_names <- makeContrastNames()
+    lapply(getSelectedContrastNumbers(), function(x) contrast_names[x])
+  })
+
+  # The same, but with safe names that won't get mangled by plotting etc
+
+  getSafeSelectedContrastNames <- reactive({
+    contrast_names <- makeSafeContrastNames()
+
+    lapply(getSelectedContrastNumbers(), function(scns) {
+      contrast_names[scns]
+    })
+  })
+
+  # Get samples for currently selected contrast
+
+  getSelectedContrastSamples <- reactive({
+    contrast_samples <- getContrastSamples()
+    selected_contrasts <- getSelectedContrastNumbers()
+    contrast_samples[[selected_contrasts]]
+  })
+
+  # If we're only looking at a single contrast filter with a single contrast (e.g. for a fold change plot etc), then we can simplify.
+
+  singleContrast <- reactive({
+    selected_contrasts <- getSelectedContrastNumbers()
+    length(selected_contrasts) == 1 && length(selected_contrasts[[1]]) == 1
+  })
+
+  list(
+    getSelectedContrasts = getSelectedContrasts, getSelectedContrastNames = getSelectedContrastNames,
+    getSafeSelectedContrastNames = getSafeSelectedContrastNames, getSelectedContrastSamples = getSelectedContrastSamples,
+    singleContrast = singleContrast
+  )
+}
+
+#' Apply the user's filter-set selections and cardinality filters
+#'
+#' Filters the per-contrast tables down to the selected contrasts, then (if
+#' row filtering is enabled) to the rows meeting the fold change/p/q value
+#' cardinality filters, and finally intersects/unions the resulting feature
+#' sets across filter sets.
+#'
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#' @param getSelectedContrastNumbers,getFilterRows,getFilterSetCombinationOperator
+#'   Reactives from \code{contrastFilterSetEngine}
+#' @param contrastsTablesToMatchMatrix Reactive from \code{contrastTableBuilder}
+#' @param singleContrast Reactive from \code{contrastSelection}
+#' @param getFoldChange,getFoldChangeCard,getPval,getPvalCard,getQval,getQvalCard
+#'   Reactives from \code{contrastFilterSetEngine}
+#' @param pvalsAvailable,qvalsAvailable Reactives from \code{contrastEnumeration}
+#'
+#' @return A list of reactives: \code{selectedContrastsTables},
+#'   \code{filteredContrastsTables}, \code{selectFilterFinalFeatures},
+#'   \code{selectFinalFeatures}
+#' @noRd
+contrastFiltering <- function(selectmatrix_reactives, getSelectedContrastNumbers, contrastsTablesToMatchMatrix, singleContrast,
+                               getFoldChange, getFoldChangeCard, getPval, getPvalCard, getQval, getQvalCard,
+                               pvalsAvailable, qvalsAvailable, getFilterRows, getFilterSetCombinationOperator) {
+  # Filter contrasts tables down to the contrasts of interest
+
+  selectedContrastsTables <- reactive({
+    selected_contrasts <- getSelectedContrastNumbers()
+    contrast_tables <- contrastsTablesToMatchMatrix()
+
+    req(selected_contrasts, contrast_tables)
+
+    # Selected contrasts is a list, one for each filter set. Each one can have multiple contrasts
+
+    withProgress(message = "Filtering to specified features", value = 0, {
+      lapply(selected_contrasts, function(scs_set) {
+        lapply(scs_set, function(s) {
+          ct <- contrast_tables[[s]]
+          if (singleContrast()) {
+            simplifyContrastTable(ct)
+          } else {
+            ct
+          }
+        })
       })
     })
+  })
 
-    # The output of filteredContrastsTables() are significant results for each filter set, and each contrast within those.
+  # Apply user filters to results of contrastsTables(). Called on first page load and on subsequent clicks of 'Apply'.
 
-    labelledContrastsTable <- reactive({
+  filteredContrastsTables <- reactive({
+    selected_contrasts_tables <- selectedContrastsTables()
+    req(length(selected_contrasts_tables) > 0)
+
+    if (getFilterRows()) {
       ese <- selectmatrix_reactives$getExperiment()
-      sff <- selectFinalFeatures()
+      assay <- selectmatrix_reactives$getAssay()
 
-      filtered_contrast_tables <- filteredContrastsTables()
+      fold_change <- getFoldChange()
+      fold_change_card <- getFoldChangeCard()
+      p_value <- getPval()
+      p_value_card <- getPvalCard()
+      q_value <- getQval()
+      q_value_card <- getQvalCard()
 
-      metafields <- c()
-      if (!is.null(selectmatrix_reactives$getMetafields)) {
-        metafields <- selectmatrix_reactives$getMetafields()
-      }
+      withProgress(message = "Applying filters", value = 0, {
+        fcts <- lapply(seq_along(selected_contrasts_tables), function(i) {
+          sct <- selected_contrasts_tables[[i]]
 
-      withProgress(message = "Making labelled table", value = 0, {
-        final_contrasts_table <- unique(rbindlist(lapply(filtered_contrast_tables, function(fcts) {
-          rbindlist(lapply(fcts, function(fct) {
-            labelMatrix(fct[sff, , drop = FALSE], ese = ese, metafields = metafields)
-          }))
-        })))
+          lapply(sct, function(s) {
+            filter <- evaluateCardinalFilter(s[["Fold change"]], fold_change_card[i], fold_change[i])
+
+            if (pvalsAvailable()) {
+              filter <- filter & evaluateCardinalFilter(s[["p value"]], p_value_card[i], p_value[i])
+            }
+
+            if (qvalsAvailable()) {
+              filter <- filter & evaluateCardinalFilter(s[["q value"]], q_value_card[i], q_value[i])
+            }
+
+            s[filter, , drop = FALSE]
+          })
+        })
       })
-    })
+    } else {
+      fcts <- selected_contrasts_tables
+    }
+    fcts
+  })
 
-    # Use labelledContrastsTable to get the labelled matrix and add some links.
+  # Find the list of features that result from combining all the filters
 
-    linkedLabelledContrastsTable <- reactive({
-      lct <- labelledContrastsTable()
-      if (has_slot_data(eselist, "url_roots")) {
-        lct <- linkMatrix(lct, eselist@url_roots)
-      }
-      lct
-    })
+  selectFilterFinalFeatures <- reactive({
+    filtered_contrasts_tables <- filteredContrastsTables()
+    validate(need(length(filtered_contrasts_tables) > 0, "Waiting for filtered contrasts tables"))
 
-    # A summary table of differential expression
-
-    makeDifferentialSetSummary <- reactive({
-      fcts <- filteredContrastsTables()
-      selected_contrasts <- getSelectedContrasts()
-      queries <- getQueryStrings()
-      eid <- selectmatrix_reactives$getExperimentId()
-
-      summaries <- lapply(seq_along(fcts), function(i) {
-        summary <- data.frame(cbind(query = queries[i], do.call(rbind, selected_contrasts[[i]])))
-        colnames(summary) <- c("Query", "Variable", "group 1", "group 2")
-        summary[[paste0("Differential ", eid, "s (up)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] > 0)))
-        summary[[paste0("Differential ", eid, "s (down)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] < 0)))
-        summary[[paste0("Differential ", eid, "s (total)")]] <- unlist(lapply(fcts[[i]], nrow))
-
-        summary
-      })
-
-      if (length(summaries) == 1) {
-        summaries[[1]][, -1]
-      } else {
-        rbindlist(summaries)
-      }
-    })
-
-    getQueryStrings <- reactive({
-      contrast_names <- makeContrastNames()
-
-      # Get the current filters, getting the name for the contrast(s)
-
-      fvs <- lapply(filterset_values, function(fv) {
-        fv$contrasts <- paste(contrast_names[fv$contrasts], collapse = ", ")
-        fv
-      })
-
-      unlist(lapply(fvs, function(x) {
-        paste("<p>", paste(unlist(lapply(grep("card", names(x[-1]), invert = TRUE, value = TRUE), function(y) {
-          paste(y, x[[paste0(y, "_card")]], x[[y]])
-        })), collapse = " AND "), "in <i>", x[[1]], "</i></p>")
+    lapply(filtered_contrasts_tables, function(fcts) {
+      Reduce(intersect, lapply(fcts, function(fct) {
+        rownames(fct)
       }))
     })
+  })
 
-    makeQuerySummary <- reactive({
-      filters <- getQueryStrings()
+  selectFinalFeatures <- reactive({
+    filter_final_features <- selectFilterFinalFeatures()
 
-      # Get the list of features resulting from each filter
+    withProgress(message = "Selecting final feature set", value = 0, {
+      comb_op <- getFilterSetCombinationOperator()
+      Reduce(get(comb_op), filter_final_features)
+    })
+  })
 
-      filter_final_features <- selectFilterFinalFeatures()
+  list(
+    selectedContrastsTables = selectedContrastsTables, filteredContrastsTables = filteredContrastsTables,
+    selectFilterFinalFeatures = selectFilterFinalFeatures, selectFinalFeatures = selectFinalFeatures
+  )
+}
 
-      # Make a table of the number of features resulting from each filter
+#' Label and link the final filtered contrasts table
+#'
+#' @param eselist ExploratorySummarizedExperimentList object
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#' @param selectFinalFeatures,filteredContrastsTables Reactives from
+#'   \code{contrastFiltering}
+#'
+#' @return A list of reactives: \code{labelledContrastsTable},
+#'   \code{linkedLabelledContrastsTable}
+#' @noRd
+contrastLabelling <- function(eselist, selectmatrix_reactives, selectFinalFeatures, filteredContrastsTables) {
+  # The output of filteredContrastsTables() are significant results for each filter set, and each contrast within those.
 
-      query_summary <- data.frame(filter = filters, features = unlist(lapply(filter_final_features, length)))
+  labelledContrastsTable <- reactive({
+    ese <- selectmatrix_reactives$getExperiment()
+    sff <- selectFinalFeatures()
 
-      exp_id <- selectmatrix_reactives$getExperimentId()
-      colnames(query_summary)[2] <- paste0(exp_id, "s")
+    filtered_contrast_tables <- filteredContrastsTables()
 
-      # Convert to labels
+    metafields <- c()
+    if (!is.null(selectmatrix_reactives$getMetafields)) {
+      metafields <- selectmatrix_reactives$getMetafields()
+    }
+
+    withProgress(message = "Making labelled table", value = 0, {
+      final_contrasts_table <- unique(rbindlist(lapply(filtered_contrast_tables, function(fcts) {
+        rbindlist(lapply(fcts, function(fct) {
+          labelMatrix(fct[sff, , drop = FALSE], ese = ese, metafields = metafields)
+        }))
+      })))
+    })
+  })
+
+  # Use labelledContrastsTable to get the labelled matrix and add some links.
+
+  linkedLabelledContrastsTable <- reactive({
+    lct <- labelledContrastsTable()
+    if (has_slot_data(eselist, "url_roots")) {
+      lct <- linkMatrix(lct, eselist@url_roots)
+    }
+    lct
+  })
+
+  list(labelledContrastsTable = labelledContrastsTable, linkedLabelledContrastsTable = linkedLabelledContrastsTable)
+}
+
+#' Summarise the query and its results for the user
+#'
+#' Builds the differential-count summary table, the human-readable query
+#' strings describing each filter set, the query summary table, and renders
+#' \code{output$summary}.
+#'
+#' @param output The module's \code{output} object
+#' @param selectmatrix_reactives Reactives from the \code{selectmatrix} module
+#' @param filteredContrastsTables,selectFilterFinalFeatures,selectFinalFeatures
+#'   Reactives from \code{contrastFiltering}
+#' @param getSelectedContrasts Reactive from \code{contrastSelection}
+#' @param makeContrastNames Reactive from \code{contrastNaming}
+#' @param getFilterSetValues Raw \code{filterset_values} accessor from
+#'   \code{contrastFilterSetEngine}
+#' @param getFilterSetCombinationOperator Reactive from
+#'   \code{contrastFilterSetEngine}
+#'
+#' @return A list of reactives: \code{makeDifferentialSetSummary},
+#'   \code{getQueryStrings}
+#' @noRd
+contrastQuerySummary <- function(output, selectmatrix_reactives, filteredContrastsTables, getSelectedContrasts, makeContrastNames,
+                                  getFilterSetValues, selectFilterFinalFeatures, selectFinalFeatures, getFilterSetCombinationOperator) {
+  # A summary table of differential expression
+
+  makeDifferentialSetSummary <- reactive({
+    fcts <- filteredContrastsTables()
+    selected_contrasts <- getSelectedContrasts()
+    queries <- getQueryStrings()
+    eid <- selectmatrix_reactives$getExperimentId()
+
+    summaries <- lapply(seq_along(fcts), function(i) {
+      summary <- data.frame(cbind(query = queries[i], do.call(rbind, selected_contrasts[[i]])))
+      colnames(summary) <- c("Query", "Variable", "group 1", "group 2")
+      summary[[paste0("Differential ", eid, "s (up)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] > 0)))
+      summary[[paste0("Differential ", eid, "s (down)")]] <- unlist(lapply(fcts[[i]], function(x) sum(x[, "Fold change"] < 0)))
+      summary[[paste0("Differential ", eid, "s (total)")]] <- unlist(lapply(fcts[[i]], nrow))
+
+      summary
+    })
+
+    if (length(summaries) == 1) {
+      summaries[[1]][, -1]
+    } else {
+      rbindlist(summaries)
+    }
+  })
+
+  getQueryStrings <- reactive({
+    contrast_names <- makeContrastNames()
+
+    # Get the current filters, getting the name for the contrast(s)
+
+    fvs <- lapply(getFilterSetValues(), function(fv) {
+      fv$contrasts <- paste(contrast_names[fv$contrasts], collapse = ", ")
+      fv
+    })
+
+    unlist(lapply(fvs, function(x) {
+      paste("<p>", paste(unlist(lapply(grep("card", names(x[-1]), invert = TRUE, value = TRUE), function(y) {
+        paste(y, x[[paste0(y, "_card")]], x[[y]])
+      })), collapse = " AND "), "in <i>", x[[1]], "</i></p>")
+    }))
+  })
+
+  makeQuerySummary <- reactive({
+    filters <- getQueryStrings()
+
+    # Get the list of features resulting from each filter
+
+    filter_final_features <- selectFilterFinalFeatures()
+
+    # Make a table of the number of features resulting from each filter
+
+    query_summary <- data.frame(filter = filters, features = unlist(lapply(filter_final_features, length)))
+
+    exp_id <- selectmatrix_reactives$getExperimentId()
+    colnames(query_summary)[2] <- paste0(exp_id, "s")
+
+    # Convert to labels
+
+    labelfield <- selectmatrix_reactives$getLabelField()
+    if (!is.null(labelfield)) {
+      ese <- selectmatrix_reactives$getExperiment()
+      filter_final_labels <- lapply(filter_final_features, function(x) convertIds(x, ese, labelfield))
+
+      query_summary[[paste0(labelfield, "s")]] <- unlist(lapply(filter_final_labels, function(x) length(unique(x))))
+    }
+
+    query_summary
+  })
+
+  ########################################################################### Tell the user something about the query and its results
+
+  output$summary <- renderUI({
+    query_summary <- makeQuerySummary()
+    comb_op <- getFilterSetCombinationOperator()
+    operator <- ifelse(comb_op == "intersect", "AND", "OR")
+    query_summary[-1, 1] <- paste0("<p><b>", operator, "</b></p>", query_summary[-1, 1])
+
+    if (ncol(query_summary) == 2) {
+      column_widths <- c(8, 4)
+    } else {
+      column_widths <- c(6, 3, 3)
+    }
+
+    makeFluidRow <- function(row) {
+      do.call(fluidRow, lapply(seq_along(row), function(r) {
+        column(column_widths[r], HTML(row[r]))
+      }))
+    }
+
+    summary_bits <- list(h4("Query Summary"), makeFluidRow(prettifyVariablename(colnames(query_summary))), br(), apply(query_summary, 1, makeFluidRow))
+
+    if (nrow(query_summary) > 1) {
+      sff_in <- selectFinalFeatures()
+      sff <- unique(sff_in)
+      ese <- selectmatrix_reactives$getExperiment()
+
+      summary_row <- c(comb_op, length(sff))
 
       labelfield <- selectmatrix_reactives$getLabelField()
       if (!is.null(labelfield)) {
-        ese <- selectmatrix_reactives$getExperiment()
-        filter_final_labels <- lapply(filter_final_features, function(x) convertIds(x, ese, labelfield))
-
-        query_summary[[paste0(labelfield, "s")]] <- unlist(lapply(filter_final_labels, function(x) length(unique(x))))
+        labels <- convertIds(ids = sff, ese, labelfield)
+        summary_row <- c(summary_row, length(unique(labels[!is.na(labels)])))
       }
 
-      query_summary
-    })
+      summary_bits <- c(summary_bits, list(hr(), makeFluidRow(summary_row)))
+    }
 
-    ########################################################################### Tell the user something about the query and its results
-
-    output$summary <- renderUI({
-      query_summary <- makeQuerySummary()
-      comb_op <- getFilterSetCombinationOperator()
-      operator <- ifelse(comb_op == "intersect", "AND", "OR")
-      query_summary[-1, 1] <- paste0("<p><b>", operator, "</b></p>", query_summary[-1, 1])
-
-      if (ncol(query_summary) == 2) {
-        column_widths <- c(8, 4)
-      } else {
-        column_widths <- c(6, 3, 3)
-      }
-
-      makeFluidRow <- function(row) {
-        do.call(fluidRow, lapply(seq_along(row), function(r) {
-          column(column_widths[r], HTML(row[r]))
-        }))
-      }
-
-      summary_bits <- list(h4("Query Summary"), makeFluidRow(prettifyVariablename(colnames(query_summary))), br(), apply(query_summary, 1, makeFluidRow))
-
-      if (nrow(query_summary) > 1) {
-        sff_in <- selectFinalFeatures()
-        sff <- unique(sff_in)
-        ese <- selectmatrix_reactives$getExperiment()
-
-        summary_row <- c(comb_op, length(sff))
-
-        labelfield <- selectmatrix_reactives$getLabelField()
-        if (!is.null(labelfield)) {
-          labels <- convertIds(ids = sff, ese, labelfield)
-          summary_row <- c(summary_row, length(unique(labels[!is.na(labels)])))
-        }
-
-        summary_bits <- c(summary_bits, list(hr(), makeFluidRow(summary_row)))
-      }
-
-      list(tags$br(), do.call(wellPanel, summary_bits))
-    })
-
-    ########################################################################### Bookmarking of the dynamically-built filter sets
-
-    # The filter-set inputs are inserted at runtime, so a bookmark URL cannot
-    # capture or restore them by itself. Snapshot filterset_values on bookmark
-    # and stash it on restore for the insert observer to replay. Keys are
-    # namespaced so multiple contrasts instances in one app don't collide.
-
-    onBookmark(function(state) {
-      state$values[[session$ns("contrast_filtersets")]] <- filterset_values
-    })
-
-    onRestore(function(state) {
-      saved <- state$values[[session$ns("contrast_filtersets")]]
-      if (!is.null(saved) && length(saved) > 0) {
-        restored_filtersets <<- unname(saved)
-      }
-    })
-
-    # Close the restore window once the restore flush has settled, so later
-    # user-driven filter sets start from defaults rather than the bookmarked
-    # values.
-
-    onRestored(function(state) {
-      restored_filtersets <<- NULL
-    })
-
-    ########################################################################### Return the reactive that allow other modules to interact with this one
-
-    list(
-      getFoldChange = getFoldChange, getFoldChangeCard = getFoldChangeCard, getFoldChangeScale = getFoldChangeScale, getQval = getQval, getQvalCard = getQvalCard, getPval = getPval, getPvalCard = getPvalCard,
-      getAllContrasts = getAllContrasts, getSelectedContrasts = getSelectedContrasts, getSelectedContrastNumbers = getSelectedContrastNumbers, getSelectedContrastNames = getSelectedContrastNames,
-      getSafeSelectedContrastNames = getSafeSelectedContrastNames, getContrastSamples = getContrastSamples, getSelectedContrastSamples = getSelectedContrastSamples,
-      contrastsTables = contrastsTables, filteredContrastsTables = filteredContrastsTables, labelledContrastsTable = labelledContrastsTable, linkedLabelledContrastsTable = linkedLabelledContrastsTable,
-      makeDifferentialSetSummary = makeDifferentialSetSummary, getQueryStrings = getQueryStrings, selectedContrastsTables = selectedContrastsTables
-    )
+    list(tags$br(), do.call(wellPanel, summary_bits))
   })
+
+  list(makeDifferentialSetSummary = makeDifferentialSetSummary, getQueryStrings = getQueryStrings)
 }
 
 #' Calculate fold change between two vectors

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -410,8 +410,8 @@ contrastNaming <- function(getAllContrasts) {
 #'   \code{getSelectedContrastNumbers}, \code{getFoldChange},
 #'   \code{getFoldChangeCard}, \code{getQval}, \code{getQvalCard},
 #'   \code{getPval}, \code{getPvalCard}, \code{getFilterSetCombinationOperator},
-#'   \code{isDynamic}, and \code{getFilterSetValues} (a raw accessor to the
-#'   whole \code{filterset_values} list, for \code{contrastQuerySummary})
+#'   and \code{getFilterSetValues} (a raw accessor to the whole
+#'   \code{filterset_values} list, for \code{contrastQuerySummary})
 #' @noRd
 contrastFilterSetEngine <- function(ns, input, output, session, selectmatrix_reactives,
                                      multiple, show_controls, default_foldchange, default_pval, default_qval, select_all_contrasts,
@@ -652,12 +652,6 @@ contrastFilterSetEngine <- function(ns, input, output, session, selectmatrix_rea
     input$combine_operator
   })
 
-  # Use presence of combine operator as a flag for use of dynamic contrasts, i.e. the possibility of multiple filter sets
-
-  isDynamic <- reactive({
-    !is.null(input$dynamic)
-  })
-
   ########################################################################### Bookmarking of the dynamically-built filter sets
 
   # The filter-set inputs are inserted at runtime, so a bookmark URL cannot
@@ -688,7 +682,7 @@ contrastFilterSetEngine <- function(ns, input, output, session, selectmatrix_rea
     getFilterRows = getFilterRows, getSelectedContrastNumbers = getSelectedContrastNumbers,
     getFoldChange = getFoldChange, getFoldChangeCard = getFoldChangeCard,
     getQval = getQval, getQvalCard = getQvalCard, getPval = getPval, getPvalCard = getPvalCard,
-    getFilterSetCombinationOperator = getFilterSetCombinationOperator, isDynamic = isDynamic,
+    getFilterSetCombinationOperator = getFilterSetCombinationOperator,
     getFilterSetValues = function() filterset_values
   )
 }

--- a/man/contrasts.Rd
+++ b/man/contrasts.Rd
@@ -46,6 +46,15 @@ users to add filters to progressively refine a query.
 \details{
 This function is called directly, using the same id as its UI counterpart,
 and wraps its logic in \code{moduleServer()} (see example).
+
+The reactive graph is built by a sequence of internal factory functions,
+each owning one cohesive stage (contrast enumeration, naming, the dynamic
+filter-set engine, table building, selection, filtering, labelling, and
+the query summary) - see \code{contrastEnumeration}, \code{contrastNaming},
+\code{contrastFilterSetEngine}, \code{contrastTableBuilder},
+\code{contrastSelection}, \code{contrastFiltering}, \code{contrastLabelling}
+and \code{contrastQuerySummary}. This function itself just wires those
+stages together in dependency order and returns their public reactives.
 }
 \examples{
 contrasts("differential", eselist = eselist, selectmatrix_reactives = selectmatrix_reactives, multiple = TRUE)


### PR DESCRIPTION
## Summary
- The `contrasts()` `moduleServer` body (~773 lines, ~28 inline reactives/observers) is split into 8 named internal factory functions - `contrastEnumeration`, `contrastNaming`, `contrastFilterSetEngine`, `contrastTableBuilder`, `contrastSelection`, `contrastFiltering`, `contrastLabelling`, `contrastQuerySummary` - each owning one cohesive stage of the reactive graph (following the section banners already in the file) and taking its dependencies as explicit arguments.
- `contrasts()` itself is now a thin wiring layer: call each factory in dependency order, pass its outputs to the next, return the same public reactives it always has (same names/shape - every calling module, e.g. `differentialtable`, is unaffected).
- One structural note: `getAllContrastsNumbers()` and `makeContrastNames()` both build contrast display names from the same logic; in the original file this worked via a same-function forward reference. Decomposing them into two separate stages would create a circular dependency between them, so the shared naming logic is pulled out into a small pure helper (`makeContrastNamesFor()`) both reactives call - same inputs, same recomputation triggers, no behaviour change.
- Second half of #188 (the `accessory.R` split half shipped separately in #193).

## Test plan
- [x] `devtools::document()` - `NAMESPACE` unchanged, only `contrasts.Rd`'s roxygen text changed
- [x] `devtools::test()` - 283 passed, 0 failed, including the bookmark-restore and `differentialtable` integration tests in `test-shinytest2.R`
- [x] `lintr::lint_package()` - no lints found
- [x] Manual click-through against the full RNA-seq app (zhangneurons data): contrast selection, fold-change/p-value/q-value cardinality filtering (475 → 3 rows on a `fold_change >= 50` filter, Query Summary matching), dynamic filter-set Add/Remove, and Share-view bookmark round-trip (reloaded URL restored the exact filter values and table) - no console or R errors