### PR TITLE
Simplify make_app_from_files.R validation; fix pca.R reactive name

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -138,7 +138,7 @@ pca <- function(id, eselist) {
     scatterplot("pca",
       getDatamatrix = pcaMatrix, getThreedee = scatterplotcontrols_reactives$getThreedee, getXAxis = scatterplotcontrols_reactives$getXAxis,
       getYAxis = scatterplotcontrols_reactives$getYAxis, getZAxis = scatterplotcontrols_reactives$getZAxis, getShowLabels = scatterplotcontrols_reactives$getShowLabels,
-      getPointSize = scatterplotcontrols_reactives$getPointSize, getTitle = getComponentsTitle, getColorby = pcaGetColorby, getPalette = groupby_reactives$getPalette
+      getPointSize = scatterplotcontrols_reactives$getPointSize, getTitle = getComponentsTitle, getColorby = getPcaColorby, getPalette = groupby_reactives$getPalette
     )
     scatterplot("loading",
       getDatamatrix = loadingMatrix, getThreedee = scatterplotcontrols_reactives$getThreedee, getXAxis = scatterplotcontrols_reactives$getXAxis,
@@ -173,7 +173,7 @@ pca <- function(id, eselist) {
       pcam
     })
 
-    pcaGetColorby <- reactive({
+    getPcaColorby <- reactive({
       if (is.null(groupby_reactives$getGroupby())) {
 
       } else {

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -503,45 +503,37 @@ deploy_to_shinyapps <- function(opt) {
 }
 
 validate_mandatory_args <- function(opt) {
-  mandatory <-
-    c(
-      "title",
-      "author",
-      "sample_metadata",
-      "sample_id_col",
-      "feature_metadata",
-      "feature_id_col",
-      "diff_feature_id_col",
-      "assay_files",
-      "assay_entity_name",
-      "output_directory",
-      "contrast_stats_assay"
-    )
+  mandatory <- c(
+    "title",
+    "author",
+    "sample_metadata",
+    "sample_id_col",
+    "feature_metadata",
+    "feature_id_col",
+    "diff_feature_id_col",
+    "assay_files",
+    "assay_entity_name",
+    "output_directory",
+    "contrast_stats_assay"
+  )
 
-  missing_args <- mandatory[!mandatory %in% names(opt)]
-  if (length(missing_args) > 0) {
-    stop(paste("Missing mandatory arguments:", paste(missing_args, collapse = ", ")))
-  }
+  invisible(shinyngs::checkListIsSubset(mandatory, names(opt), "mandatory arguments", "provided options"))
 }
 
 validate_deploy_args <- function(opt) {
-  mandatory <- c(
-    "shinyapps_account",
-    "shinyapps_name"
+  shinyngs::checkListIsSubset(
+    c("shinyapps_account", "shinyapps_name"),
+    names(opt),
+    "mandatory arguments for shinyapps deployment",
+    "provided options"
   )
-  missing_args <- mandatory[!mandatory %in% names(opt)]
-  if (length(missing_args) > 0) {
-    stop(paste("Missing mandatory arguments for shinyapps deployment:", paste(missing_args, collapse = ", ")))
-  }
 
-  mandatory <- c(
-    "SHINYAPPS_SECRET",
-    "SHINYAPPS_TOKEN"
-  )
-  missing_secrets <- mandatory[!mandatory %in% names(Sys.getenv())]
-  if (length(missing_secrets) > 0) {
-    stop(paste("Environment variables not defined for shinyapps deployment:", paste(missing_secrets, collapse = ", ")))
-  }
+  invisible(shinyngs::checkListIsSubset(
+    c("SHINYAPPS_SECRET", "SHINYAPPS_TOKEN"),
+    names(Sys.getenv()),
+    "environment variables for shinyapps deployment",
+    "environment"
+  ))
 }
 
 ################################################


### PR DESCRIPTION
## Summary

Follow-up to #194 (merged), from a `/simplify` pass over that PR's diff:

- `validate_mandatory_args()`/`validate_deploy_args()` in `exec/make_app_from_files.R` hand-rolled the same "is X a subset of Y, else stop listing what's missing" check three times. Replaced with the existing `checkListIsSubset()` helper (`R/accessory.R`), already used for equivalent checks elsewhere in the package.
- `R/pca.R`'s local reactive was named `pcaGetColorby`, embedding "Get" mid-name instead of leading with it like every sibling reactive in that file (`getComponentsTitle`, `getLoadingTitle`, ...). Renamed to `getPcaColorby` for consistency with the naming convention #194 documented in `CONTRIBUTING.md`.

## Test plan

- [x] Full `testthat` suite passes, including `exec-smoke` run with `NOT_CRAN=true` (exercises `make_app_from_files.R` end-to-end as a subprocess)
- [x] Manually verified `validate_mandatory_args()`/`validate_deploy_args()` still error correctly on missing args/secrets, with no stray stdout output from `checkListIsSubset()`'s return value
- [x] `lintr::lint_package()` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)