### PR TITLE
Add structural tests for dendro, summarytiles and upset plot builders

### DIFF
--- a/R/ExploratorySummarizedExperimentList-class.R
+++ b/R/ExploratorySummarizedExperimentList-class.R
@@ -128,7 +128,7 @@ ExploratorySummarizedExperimentList <- function(eses, title = "", author = "", d
 
   if (length(group_vars) == 0) {
     group_vars <- chooseGroupingVariables(data.frame(colData(eses[[1]]), check.names = FALSE))
-    default_groupvar <- group_vars[1]
+    default_groupvar <- if (length(group_vars) > 0) group_vars[1] else character(0)
   }
 
   # If gene sets are provided, key the gene sets by gene name for easier access

--- a/R/dendro.R
+++ b/R/dendro.R
@@ -296,7 +296,9 @@ plotly_clusteringDendrogram <- function(plotmatrix, experiment, colorby = NULL, 
       line = list(color = "black", width = 1), hoverinfo = "none", showlegend = FALSE
     )
   } else {
-    p <- plotly::add_lines(p, x = numeric(0), y = numeric(0), hoverinfo = "none", showlegend = FALSE)
+    # plotly::add_lines() rejects zero-length x/y outright, so a single NA
+    # point stands in for "nothing to draw" while keeping trace 0 present.
+    p <- plotly::add_lines(p, x = NA_real_, y = NA_real_, hoverinfo = "none", showlegend = FALSE)
   }
 
   if (is.null(colorby)) {

--- a/tests/testthat/test-ExploratorySummarizedExperimentList-class.R
+++ b/tests/testthat/test-ExploratorySummarizedExperimentList-class.R
@@ -1,0 +1,23 @@
+# ExploratorySummarizedExperimentList()
+
+test_that("ExploratorySummarizedExperimentList leaves default_groupvar empty when no grouping column is found", {
+  n_samples <- 4
+  counts <- matrix(seq_len(6 * n_samples), nrow = 6)
+  rownames(counts) <- paste0("gene", 1:6)
+  colnames(counts) <- paste0("s", seq_len(n_samples))
+
+  # A column with no repeated values gives chooseGroupingVariables() nothing
+  # to pick, so group_vars is auto-detected as empty.
+  coldata <- S4Vectors::DataFrame(row.names = colnames(counts), uid = paste0("u", seq_len(n_samples)))
+  annotation <- data.frame(gene_id = rownames(counts), row.names = rownames(counts))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id"
+  )
+  eselist <- ExploratorySummarizedExperimentList(eses = list(counts = ese))
+
+  expect_length(eselist@group_vars, 0)
+  expect_length(eselist@default_groupvar, 0)
+  expect_false(has_slot_data(eselist, "default_groupvar"))
+})

--- a/tests/testthat/test-dendro.R
+++ b/tests/testthat/test-dendro.R
@@ -1,0 +1,76 @@
+# calculateDist() / calculateDendrogram()
+
+test_that("calculateDist returns a dist object with one entry per sample pair", {
+  set.seed(1)
+  mat <- matrix(rpois(50 * 5, lambda = 40) + 1, nrow = 50)
+  colnames(mat) <- paste0("s", 1:5)
+  rownames(mat) <- paste0("g", 1:50)
+
+  d <- calculateDist(mat, cor_method = "pearson")
+
+  expect_s3_class(d, "dist")
+  expect_length(d, choose(5, 2))
+})
+
+test_that("calculateDendrogram produces an hclust tree with one merge per sample gap", {
+  set.seed(1)
+  mat <- matrix(rpois(50 * 5, lambda = 40) + 1, nrow = 50)
+  colnames(mat) <- paste0("s", 1:5)
+  rownames(mat) <- paste0("g", 1:50)
+
+  hcd <- calculateDendrogram(mat, cor_method = "pearson", cluster_method = "average")
+
+  expect_s3_class(hcd, "dendrogram")
+  expect_setequal(labels(hcd), colnames(mat))
+
+  hc <- as.hclust(hcd)
+  expect_equal(nrow(hc$merge), ncol(mat) - 1)
+})
+
+# plotly_clusteringDendrogram()
+
+test_that("plotly_clusteringDendrogram puts the branch tree in trace 0 and hides toggled-off groups", {
+  set.seed(4)
+  grps <- c("A", "B", "C")
+  samp <- unlist(lapply(grps, function(g) paste0(g, 1:2)))
+  mat <- matrix(rpois(300 * length(samp), lambda = 50) + 1, nrow = 300)
+  colnames(mat) <- samp
+  rownames(mat) <- paste0("gene", 1:300)
+  experiment <- data.frame(row.names = samp, group = rep(grps, each = 2))
+
+  built <- plotly::plotly_build(plotly_clusteringDendrogram(mat, experiment, colorby = "group", hidden_groups = "B", source = "test"))
+  traces <- built$x$data
+
+  # Trace 0 is always the branch tree, with one trace per group after it
+  expect_equal(traces[[1]]$type, "scatter")
+  expect_null(traces[[1]]$name)
+  expect_length(traces, 4)
+
+  visibility <- setNames(
+    lapply(traces[-1], function(t) if (is.null(t$visible)) "TRUE" else as.character(t$visible)),
+    vapply(traces[-1], function(t) t$name, character(1))
+  )
+  expect_equal(visibility[["B"]], "legendonly")
+  expect_equal(visibility[["A"]], "TRUE")
+  expect_equal(visibility[["C"]], "TRUE")
+
+  # The hidden group's samples are dropped from the leaf axis, others remain
+  expect_false(any(c("B1", "B2") %in% built$x$layout$xaxis$ticktext))
+  expect_true(all(c("A1", "A2", "C1", "C2") %in% built$x$layout$xaxis$ticktext))
+})
+
+test_that("plotly_clusteringDendrogram falls back to a placeholder when fewer than two groups remain visible", {
+  set.seed(5)
+  samp <- c("A1", "A2", "B1", "B2", "C1")
+  experiment <- data.frame(row.names = samp, group = c("A", "A", "B", "B", "C"))
+  mat <- matrix(rpois(300 * length(samp), lambda = 50) + 1, nrow = 300)
+  colnames(mat) <- samp
+  rownames(mat) <- paste0("gene", 1:300)
+
+  built <- suppressWarnings(plotly::plotly_build(plotly_clusteringDendrogram(mat, experiment, colorby = "group", hidden_groups = c("A", "B"), source = "test2")))
+
+  expect_match(built$x$layout$annotations[[1]]$text, "Select at least two groups to cluster")
+
+  # The branch trace draws nothing when there's nothing to cluster
+  expect_null(built$x$data[[1]][["x", exact = TRUE]])
+})

--- a/tests/testthat/test-summarytiles.R
+++ b/tests/testthat/test-summarytiles.R
@@ -17,14 +17,7 @@ make_minimal_eselist <- function() {
     assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
     idfield = "gene_id", labelfield = "gene_name"
   )
-  eselist <- ExploratorySummarizedExperimentList(eses = list(counts = ese))
-
-  # The constructor's group_vars[1] fallback turns "no candidate columns" into
-  # a stray NA rather than a genuinely empty default_groupvar; clear both
-  # slots directly so has_slot_data() reports what this fixture intends.
-  eselist@group_vars <- character(0)
-  eselist@default_groupvar <- character(0)
-  eselist
+  ExploratorySummarizedExperimentList(eses = list(counts = ese))
 }
 
 make_full_eselist <- function(n_contrasts = 15) {

--- a/tests/testthat/test-summarytiles.R
+++ b/tests/testthat/test-summarytiles.R
@@ -1,0 +1,135 @@
+# Fixtures: one eselist with no grouping/contrasts/gene sets, one with all
+# three populated (and enough contrasts to exercise detailContrasts' cap).
+
+make_minimal_eselist <- function() {
+  n_genes <- 6
+  n_samples <- 4
+  counts <- matrix(seq_len(n_genes * n_samples), nrow = n_genes)
+  rownames(counts) <- paste0("gene", seq_len(n_genes))
+  colnames(counts) <- paste0("s", seq_len(n_samples))
+
+  # A column with no repeated values gives chooseGroupingVariables() nothing
+  # to pick, so the constructor's auto-detected group_vars stays empty.
+  coldata <- S4Vectors::DataFrame(row.names = colnames(counts), uid = paste0("u", seq_len(n_samples)))
+  annotation <- data.frame(gene_id = rownames(counts), gene_name = paste0("Gene", seq_len(n_genes)), row.names = rownames(counts))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id", labelfield = "gene_name"
+  )
+  eselist <- ExploratorySummarizedExperimentList(eses = list(counts = ese))
+
+  # The constructor's group_vars[1] fallback turns "no candidate columns" into
+  # a stray NA rather than a genuinely empty default_groupvar; clear both
+  # slots directly so has_slot_data() reports what this fixture intends.
+  eselist@group_vars <- character(0)
+  eselist@default_groupvar <- character(0)
+  eselist
+}
+
+make_full_eselist <- function(n_contrasts = 15) {
+  n_genes <- 6
+  n_samples <- 4
+  counts <- matrix(seq_len(n_genes * n_samples), nrow = n_genes)
+  rownames(counts) <- paste0("gene", seq_len(n_genes))
+  colnames(counts) <- paste0("s", seq_len(n_samples))
+
+  coldata <- S4Vectors::DataFrame(row.names = colnames(counts), condition = rep(c("ctrl", "treat"), each = n_samples / 2))
+  annotation <- data.frame(gene_id = rownames(counts), gene_name = paste0("Gene", seq_len(n_genes)), row.names = rownames(counts))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id", labelfield = "gene_name",
+    gene_set_analyses = list(hallmark = list(cond_vs_ctrl = data.frame(`p value` = 0.01, FDR = 0.05, Direction = "Up", check.names = FALSE))),
+    gene_set_analyses_tool = list(hallmark = list(cond_vs_ctrl = "roast"))
+  )
+  eselist <- ExploratorySummarizedExperimentList(eses = list(counts = ese), group_vars = "condition", default_groupvar = "condition")
+  eselist@contrasts <- lapply(seq_len(n_contrasts), function(i) list(Variable = "condition", Group.1 = "ctrl", Group.2 = "treat"))
+  eselist
+}
+
+# summaryTileSpecs()
+
+test_that("summaryTileSpecs omits the groups/contrasts/genesets tiles when that data is absent", {
+  specs <- summaryTileSpecs(make_minimal_eselist())
+  keys <- vapply(specs, function(s) s$key, character(1))
+
+  expect_setequal(keys, c("samples", "features_counts", "assays"))
+})
+
+test_that("summaryTileSpecs includes the groups/contrasts/genesets tiles when that data is present", {
+  specs <- summaryTileSpecs(make_full_eselist())
+  keys <- vapply(specs, function(s) s$key, character(1))
+
+  expect_setequal(keys, c("samples", "features_counts", "assays", "groups", "contrasts", "genesets"))
+
+  contrasts_spec <- specs[[which(keys == "contrasts")]]
+  expect_equal(contrasts_spec$value, 15)
+})
+
+# detailSamples()
+
+test_that("detailSamples reports a plain sample count when there's no default groupvar", {
+  d <- detailSamples(make_minimal_eselist())
+
+  expect_equal(d$title, "Samples")
+  expect_match(as.character(d$body), "4 samples, with no grouping variable defined")
+})
+
+test_that("detailSamples breaks samples down by group when a default groupvar exists", {
+  d <- detailSamples(make_full_eselist())
+
+  expect_match(d$title, "4 libraries across 2 Condition levels")
+  expect_match(as.character(d$body), "shinyngs-bar-row")
+})
+
+# detailFeatures() / detailAssays() / detailGroups() / detailGenesets()
+
+test_that("detailFeatures reports the feature count and available assays", {
+  eselist <- make_full_eselist()
+  d <- detailFeatures(eselist, "counts")
+
+  expect_match(d$title, "6 quantified")
+  expect_match(as.character(d$body), "1 assays: Counts")
+})
+
+test_that("detailAssays lists each assay as a pill", {
+  d <- detailAssays(make_full_eselist())
+
+  expect_match(d$title, "1 matrices")
+  expect_match(as.character(d$body), "shinyngs-pill")
+})
+
+test_that("detailGroups marks the default groupvar and reports level counts", {
+  d <- detailGroups(make_full_eselist())
+
+  expect_match(d$title, "1 variables")
+  body_html <- as.character(d$body)
+  expect_match(body_html, "default")
+  expect_match(body_html, "2 levels")
+})
+
+test_that("detailGenesets lists one entry per assay/gene-set-type combination", {
+  d <- detailGenesets(make_full_eselist())
+
+  expect_match(as.character(d$body), "gene set analysis available")
+})
+
+# detailContrasts()
+
+test_that("detailContrasts caps displayed rows at 12 and notes how many more there are", {
+  d <- detailContrasts(make_full_eselist(n_contrasts = 15))
+  body_html <- as.character(d$body)
+
+  expect_match(d$title, "15 differential comparisons")
+  expect_equal(lengths(regmatches(body_html, gregexpr("<tr>", body_html))), 13) # header + 12 rows
+  expect_match(body_html, "\\+ 3 more")
+})
+
+test_that("detailContrasts shows every row and no 'more' note when there are 12 or fewer", {
+  d <- detailContrasts(make_full_eselist(n_contrasts = 5))
+  body_html <- as.character(d$body)
+
+  expect_equal(lengths(regmatches(body_html, gregexpr("<tr>", body_html))), 6) # header + 5 rows
+  expect_false(grepl("more", body_html))
+})

--- a/tests/testthat/test-upset.R
+++ b/tests/testthat/test-upset.R
@@ -1,0 +1,163 @@
+# Fixture: 12 genes, two contrasts (grpA: ctrl vs treatA, grpB: ctrl vs
+# treatB) with hand-picked fold-change signs so that, once split into
+# up/down sets, the four resulting sets and their pairwise overlaps are
+# exactly known:
+#
+#              grpA down (7)   grpA up (5)
+# grpB down (5)      3              2
+# grpB up   (7)      4              3
+#
+# i.e. set sizes {7, 5, 5, 7} and non-empty pairwise intersections
+# {3, 4, 2, 3}; every other combination (same-contrast up/down, and any
+# 3- or 4-way combination) is empty by construction.
+
+make_upset_eselist <- function() {
+  n_genes <- 12
+  gene_ids <- paste0("gene", seq_len(n_genes))
+
+  set.seed(1)
+  counts <- matrix(rpois(n_genes * 4, lambda = 50) + 1, nrow = n_genes)
+  rownames(counts) <- gene_ids
+  colnames(counts) <- paste0("s", 1:4)
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    grpA = c("ctrl", "ctrl", "treatA", "treatA"),
+    grpB = c("ctrl", "ctrl", "treatB", "treatB")
+  )
+  annotation <- data.frame(gene_id = gene_ids, row.names = gene_ids)
+
+  # (+,+) x3, (+,-) x2, (-,+) x4, (-,-) x3
+  fc1 <- c(3, 3, 3, 2, 2, -2, -2, -2, -2, -3, -3, -3)
+  fc2 <- c(4, 4, 4, -4, -4, 5, 5, 5, 5, -5, -5, -5)
+  fold_changes <- matrix(c(fc1, fc2), nrow = n_genes, dimnames = list(gene_ids, c("1", "2")))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id", contrast_stats = list(counts = list(fold_changes = fold_changes))
+  )
+
+  eselist <- ExploratorySummarizedExperimentList(eses = list(counts = ese), group_vars = c("grpA", "grpB"), default_groupvar = "grpA")
+  eselist@contrasts <- list(
+    list(id = "c1", Variable = "grpA", Group.1 = "ctrl", Group.2 = "treatA"),
+    list(id = "c2", Variable = "grpB", Group.1 = "ctrl", Group.2 = "treatB")
+  )
+  eselist
+}
+
+# Drives the upset module up to the point where its reactives are ready to
+# read, mirroring the differentialtable testServer test in
+# test-shinytest2.R: selectmatrix/contrasts inputs are only rendered
+# client-side (via uiOutput()/insertUI()), so testServer needs every one of
+# them set explicitly rather than relying on the widget defaults.
+
+run_upset_server <- function(eselist, extra_inputs = list(), expr) {
+  args <- c(
+    list(
+      "upset-experiment" = "counts",
+      "upset-assay" = "counts",
+      "upset-selectmatrix-geneSelect" = "all",
+      "upset-selectmatrix-sampleSelect" = "all",
+      "upset-filterRows" = FALSE,
+      "upset-contrasts-summaryType" = "colMeans",
+      "upset-contrasts0" = c("1", "2"),
+      nsets = 4,
+      minorder = 1,
+      nintersects = 20,
+      separate_by_direction = TRUE,
+      set_sort = FALSE,
+      bar_numbers = FALSE,
+      show_empty_intersections = FALSE,
+      intersection_assignment_type = "all"
+    ),
+    extra_inputs
+  )
+  args <- args[!duplicated(names(args), fromLast = TRUE)]
+
+  shiny::testServer(upset, args = list(id = "upset", eselist = eselist), {
+    session$userData$plotFormat <- function() "png"
+    do.call(session$setInputs, args)
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("getValidSets splits each contrast by direction into disjoint, non-empty sets", {
+  run_upset_server(make_upset_eselist(), expr = quote({
+    vs <- getValidSets()
+
+    expect_setequal(names(vs), c("GrpA.TreatA_vs_Ctrl.down", "GrpA.TreatA_vs_Ctrl.up", "GrpB.TreatB_vs_Ctrl.down", "GrpB.TreatB_vs_Ctrl.up"))
+    expect_setequal(vs$GrpA.TreatA_vs_Ctrl.down, paste0("gene", 6:12))
+    expect_setequal(vs$GrpA.TreatA_vs_Ctrl.up, paste0("gene", 1:5))
+    expect_setequal(vs$GrpB.TreatB_vs_Ctrl.down, c(paste0("gene", 4:5), paste0("gene", 10:12)))
+    expect_setequal(vs$GrpB.TreatB_vs_Ctrl.up, c(paste0("gene", 1:3), paste0("gene", 6:9)))
+  }))
+})
+
+test_that("getMaxSets caps at the number of valid sets found", {
+  run_upset_server(make_upset_eselist(), expr = quote({
+    expect_equal(getMaxSets(), 4)
+  }))
+})
+
+test_that("calculateIntersections computes exact overlap sizes with 'all' assignment", {
+  run_upset_server(make_upset_eselist(), expr = quote({
+    ints <- calculateIntersections()
+
+    # order-1 (the four sets themselves) then order-2 non-empty overlaps;
+    # every same-contrast pair and every 3-/4-way combination is empty and
+    # so dropped by show_empty_intersections = FALSE
+    expect_equal(ints$intersections, c(7, 7, 5, 5, 4, 3, 3, 2))
+    expect_true(all(lengths(ints$combinations) <= 2))
+  }))
+})
+
+test_that("calculateIntersections assigns overlapping members only to their highest-order intersection under 'upset' assignment", {
+  run_upset_server(make_upset_eselist(), extra_inputs = list(intersection_assignment_type = "upset"), expr = quote({
+    ints <- calculateIntersections()
+
+    # every gene in each of the four sets also falls in exactly one pairwise
+    # overlap, so nothing is left over for the sets on their own
+    expect_true(all(lengths(ints$combinations) == 2))
+    expect_equal(sort(ints$intersections), c(2, 3, 3, 4))
+  }))
+})
+
+test_that("upsetSetSizeBarChart and upsetIntersectSizeBarChart draw bars matching the computed sizes", {
+  run_upset_server(make_upset_eselist(), expr = quote({
+    set_chart <- plotly::plotly_build(upsetSetSizeBarChart())$x$data[[1]]
+    expect_equal(set_chart$type, "bar")
+    expect_equal(as.numeric(set_chart$x), c(7, 5, 5, 7))
+
+    intersect_chart <- plotly::plotly_build(upsetIntersectSizeBarChart())$x$data[[1]]
+    expect_equal(intersect_chart$type, "bar")
+    expect_equal(as.numeric(intersect_chart$y), c(7, 7, 5, 5, 4, 3, 3, 2))
+  }))
+})
+
+test_that("upsetIntersectSizeBarChart truncates to the requested number of intersections", {
+  run_upset_server(make_upset_eselist(), extra_inputs = list(nintersects = 3), expr = quote({
+    intersect_chart <- plotly::plotly_build(upsetIntersectSizeBarChart())$x$data[[1]]
+    expect_equal(as.numeric(intersect_chart$y), c(7, 7, 5))
+  }))
+})
+
+test_that("upsetIntersectSizeBarChart adds a text trace when bar_numbers is enabled", {
+  run_upset_server(make_upset_eselist(), extra_inputs = list(bar_numbers = TRUE), expr = quote({
+    built <- plotly::plotly_build(upsetIntersectSizeBarChart())
+
+    expect_length(built$x$data, 2)
+    expect_equal(built$x$data[[2]]$mode, "text")
+    expect_equal(as.numeric(built$x$data[[2]]$text), c(7, 7, 5, 5, 4, 3, 3, 2))
+  }))
+})
+
+test_that("upsetGrid draws the background grid, set-membership lines and intersection markers as three scatter traces", {
+  run_upset_server(make_upset_eselist(), expr = quote({
+    built <- plotly::plotly_build(upsetGrid())
+
+    expect_length(built$x$data, 3)
+    expect_true(all(vapply(built$x$data, function(t) t$type, character(1)) == "scatter"))
+    expect_equal(built$x$layout$yaxis$range, c(0, 4))
+  }))
+})

--- a/tests/testthat/test-upset.R
+++ b/tests/testthat/test-upset.R
@@ -52,7 +52,7 @@ make_upset_eselist <- function() {
 # them set explicitly rather than relying on the widget defaults.
 
 run_upset_server <- function(eselist, extra_inputs = list(), expr) {
-  args <- c(
+  args <- modifyList(
     list(
       "upset-experiment" = "counts",
       "upset-assay" = "counts",
@@ -72,7 +72,6 @@ run_upset_server <- function(eselist, extra_inputs = list(), expr) {
     ),
     extra_inputs
   )
-  args <- args[!duplicated(names(args), fromLast = TRUE)]
 
   shiny::testServer(upset, args = list(id = "upset", eselist = eselist), {
     session$userData$plotFormat <- function() "png"


### PR DESCRIPTION
## Summary

Part of #190, item 1 ("plot builder tests"), scoped to the builders not already covered by the open #197 (which consolidates and tests volcano/MA/foldchange). Adds structural tests for the remaining untested plot builders:

- `tests/testthat/test-dendro.R`: `calculateDist`/`calculateDendrogram` structural checks, and `plotly_clusteringDendrogram`'s hidden-groups behaviour (branch tree always trace 0, hidden group visible as `legendonly` but dropped from the axis, fallback placeholder when fewer than two groups remain).
- `tests/testthat/test-summarytiles.R`: `summaryTileSpecs`' has-slot-data gating for groups/contrasts/genesets tiles, and each `detail*()` drawer builder including `detailContrasts()`'s 12-row cap.
- `tests/testthat/test-upset.R`: drives the `upset` module via `shiny::testServer()` against a small fixture with hand-picked fold-change signs, so set sizes and pairwise intersection counts are known by construction. Covers `getValidSets`, `calculateIntersections` under both assignment types, and the three plotly-building reactives.

Two real bugs turned up while writing these and are fixed here rather than deferred:

- `R/dendro.R`: `plotly::add_lines()` with `x = numeric(0), y = numeric(0)` throws in the installed plotly version; the "fewer than two groups selected" fallback path was broken. Fixed with the `NA_real_` sentinel already used elsewhere in the same function.
- `R/ExploratorySummarizedExperimentList-class.R`: the auto-detected `default_groupvar <- group_vars[1]` fallback produced `NA_character_` instead of a genuinely empty slot when no grouping column exists, and `has_slot_data()` (length-only) reported that NA as "populated" throughout the app. Guarded the fallback and added a dedicated regression test.

## Test plan

- [x] Full `testthat` suite passes (350 passed, 0 failed) including shinytest2 (real Chrome) and exec-smoke (subprocess) tests
- [x] `lintr::lint_package()` clean