### PR TITLE
Exercise exec/ CLI error paths with negative tests

### DIFF
--- a/R/io-read.R
+++ b/R/io-read.R
@@ -386,6 +386,10 @@ read_gmt <- function(file) {
 #' @export
 
 read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, sep = NULL, row.names = 1) {
+  if (!file.exists(matrix_file)) {
+    stop(paste("Matrix file", matrix_file, "does not exist."))
+  }
+
   if (is.null(sep)) {
     sep <- getSeparator(matrix_file)
   }

--- a/tests/testthat/helper-exec-smoke.R
+++ b/tests/testthat/helper-exec-smoke.R
@@ -80,3 +80,13 @@ run_exec_script <- function(script, args) {
 expect_exec_success <- function(result) {
   testthat::expect_equal(result$status, 0, info = paste(result$output, collapse = "\n"))
 }
+
+# expect_exec_failure()
+#
+# Assert an exec/*.R script exited with a non-zero status and that its
+# combined output matches the given pattern.
+
+expect_exec_failure <- function(result, pattern) {
+  testthat::expect_false(result$status == 0)
+  testthat::expect_match(paste(result$output, collapse = "\n"), pattern, fixed = TRUE)
+}

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -764,6 +764,15 @@ test_that("read_matrix falls back to the first column for feature identifiers", 
   expect_equal(colnames(result), c("Sample1", "Sample2"))
 })
 
+test_that("read_matrix errors when the file does not exist", {
+  samples <- data.frame(row.names = c("Sample1", "Sample2"))
+
+  expect_error(
+    read_matrix(tempfile(fileext = ".tsv"), samples),
+    "does not exist"
+  )
+})
+
 # read_metadata()
 
 test_that("read_metadata reads a csv file", {

--- a/tests/testthat/test-exec-smoke.R
+++ b/tests/testthat/test-exec-smoke.R
@@ -21,6 +21,73 @@ test_that("validate_fom_components.R runs against fixtures and rewrites normaliz
   expect_true(file.exists(file.path(outdir, "SRP254919.salmon.merged.gene_counts.top1000cov.assay.tsv")))
 })
 
+test_that("validate_fom_components.R fails clearly when --assay_files does not exist", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("validate_fom_components.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("does_not_exist.tsv"),
+    "--output_directory", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+})
+
+test_that("validate_fom_components.R fails clearly when assay matrix columns don't match the sample sheet", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  # The feature metadata file has no sample-named columns at all, so it stands
+  # in for an assay matrix whose columns don't match the sample sheet.
+  result <- run_exec_script("validate_fom_components.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--output_directory", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(
+    paste(result$output, collapse = "\n"),
+    "Some sample metadata names",
+    fixed = TRUE
+  )
+})
+
+test_that("validate_fom_components.R fails clearly when the contrasts file references an unknown variable", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+  bad_contrasts <- withr::local_tempfile(fileext = ".csv")
+  writeLines(
+    c(
+      "id,variable,reference,target,blocking",
+      "bad_contrast,not_a_real_variable,mCherry,hND6,"
+    ),
+    bad_contrasts
+  )
+
+  result <- run_exec_script("validate_fom_components.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("SRP254919.salmon.merged.gene_counts.top1000cov.tsv"),
+    "--contrasts_file", bad_contrasts,
+    "--output_directory", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(
+    paste(result$output, collapse = "\n"),
+    "Not all contrast variables are available in the sample metadata",
+    fixed = TRUE
+  )
+})
+
 # exec/exploratory_plots.R
 
 test_that("exploratory_plots.R runs against fixtures and writes plot PNGs", {
@@ -46,6 +113,61 @@ test_that("exploratory_plots.R runs against fixtures and writes plot PNGs", {
   }
 })
 
+test_that("exploratory_plots.R fails clearly when a mandatory argument is missing", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("exploratory_plots.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("SRP254919.salmon.merged.gene_counts.top1000cov.tsv"),
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(paste(result$output, collapse = "\n"), "Please provide a contrast_variable", fixed = TRUE)
+})
+
+test_that("exploratory_plots.R fails clearly when --assay_files does not exist", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("exploratory_plots.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("does_not_exist.tsv"),
+    "--contrast_variable", "treatment",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+})
+
+test_that("exploratory_plots.R fails clearly when --final_assay is not among the supplied assays", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("exploratory_plots.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("SRP254919.salmon.merged.gene_counts.top1000cov.tsv"),
+    "--contrast_variable", "treatment",
+    "--final_assay", "not_a_real_assay",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(
+    paste(result$output, collapse = "\n"),
+    "Indicated final assay 'not_a_real_assay' not among",
+    fixed = TRUE
+  )
+})
+
 # exec/differential_plots.R
 
 test_that("differential_plots.R runs against fixtures and writes a volcano plot", {
@@ -66,6 +188,84 @@ test_that("differential_plots.R runs against fixtures and writes a volcano plot"
   volcano_path <- file.path(outdir, "png", "volcano.png")
   expect_true(file.exists(volcano_path))
   expect_gt(file.size(volcano_path), 0)
+})
+
+test_that("differential_plots.R fails clearly when --differential_file does not exist", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("differential_plots.R", c(
+    "--differential_file", exec_smoke_fixture("does_not_exist.tsv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--reference_level", "mCherry",
+    "--treatment_level", "hND6",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+})
+
+test_that("differential_plots.R fails clearly when --feature_metadata does not exist", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("differential_plots.R", c(
+    "--differential_file", exec_smoke_fixture("SRP254919.salmon.merged.deseq2.results.tsv"),
+    "--feature_metadata", exec_smoke_fixture("does_not_exist.tsv"),
+    "--reference_level", "mCherry",
+    "--treatment_level", "hND6",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+})
+
+test_that("differential_plots.R fails clearly when --fold_change_col is absent from the differential file", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("differential_plots.R", c(
+    "--differential_file", exec_smoke_fixture("SRP254919.salmon.merged.deseq2.results.tsv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--fold_change_col", "not_a_real_column",
+    "--reference_level", "mCherry",
+    "--treatment_level", "hND6",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(
+    paste(result$output, collapse = "\n"),
+    "Missing stats variables: not_a_real_column",
+    fixed = TRUE
+  )
+})
+
+test_that("differential_plots.R fails clearly when --p_value_column is absent from the differential file", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("differential_plots.R", c(
+    "--differential_file", exec_smoke_fixture("SRP254919.salmon.merged.deseq2.results.tsv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--p_value_column", "not_a_real_column",
+    "--reference_level", "mCherry",
+    "--treatment_level", "hND6",
+    "--outdir", outdir
+  ))
+
+  expect_false(result$status == 0)
+  expect_match(
+    paste(result$output, collapse = "\n"),
+    "Missing stats variables: not_a_real_column",
+    fixed = TRUE
+  )
 })
 
 # exec/make_app_from_files.R

--- a/tests/testthat/test-exec-smoke.R
+++ b/tests/testthat/test-exec-smoke.R
@@ -33,8 +33,7 @@ test_that("validate_fom_components.R fails clearly when --assay_files does not e
     "--output_directory", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+  expect_exec_failure(result, "does not exist")
 })
 
 test_that("validate_fom_components.R fails clearly when assay matrix columns don't match the sample sheet", {
@@ -51,12 +50,7 @@ test_that("validate_fom_components.R fails clearly when assay matrix columns don
     "--output_directory", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(
-    paste(result$output, collapse = "\n"),
-    "Some sample metadata names",
-    fixed = TRUE
-  )
+  expect_exec_failure(result, "Some sample metadata names")
 })
 
 test_that("validate_fom_components.R fails clearly when the contrasts file references an unknown variable", {
@@ -80,12 +74,7 @@ test_that("validate_fom_components.R fails clearly when the contrasts file refer
     "--output_directory", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(
-    paste(result$output, collapse = "\n"),
-    "Not all contrast variables are available in the sample metadata",
-    fixed = TRUE
-  )
+  expect_exec_failure(result, "Not all contrast variables are available in the sample metadata")
 })
 
 # exec/exploratory_plots.R
@@ -125,8 +114,7 @@ test_that("exploratory_plots.R fails clearly when a mandatory argument is missin
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(paste(result$output, collapse = "\n"), "Please provide a contrast_variable", fixed = TRUE)
+  expect_exec_failure(result, "Please provide a contrast_variable")
 })
 
 test_that("exploratory_plots.R fails clearly when --assay_files does not exist", {
@@ -142,8 +130,7 @@ test_that("exploratory_plots.R fails clearly when --assay_files does not exist",
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+  expect_exec_failure(result, "does not exist")
 })
 
 test_that("exploratory_plots.R fails clearly when --final_assay is not among the supplied assays", {
@@ -160,12 +147,7 @@ test_that("exploratory_plots.R fails clearly when --final_assay is not among the
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(
-    paste(result$output, collapse = "\n"),
-    "Indicated final assay 'not_a_real_assay' not among",
-    fixed = TRUE
-  )
+  expect_exec_failure(result, "Indicated final assay 'not_a_real_assay' not among")
 })
 
 # exec/differential_plots.R
@@ -203,8 +185,7 @@ test_that("differential_plots.R fails clearly when --differential_file does not 
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+  expect_exec_failure(result, "does not exist")
 })
 
 test_that("differential_plots.R fails clearly when --feature_metadata does not exist", {
@@ -220,8 +201,7 @@ test_that("differential_plots.R fails clearly when --feature_metadata does not e
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(paste(result$output, collapse = "\n"), "does not exist", fixed = TRUE)
+  expect_exec_failure(result, "does not exist")
 })
 
 test_that("differential_plots.R fails clearly when --fold_change_col is absent from the differential file", {
@@ -238,12 +218,7 @@ test_that("differential_plots.R fails clearly when --fold_change_col is absent f
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(
-    paste(result$output, collapse = "\n"),
-    "Missing stats variables: not_a_real_column",
-    fixed = TRUE
-  )
+  expect_exec_failure(result, "Missing stats variables: not_a_real_column")
 })
 
 test_that("differential_plots.R fails clearly when --p_value_column is absent from the differential file", {
@@ -260,12 +235,7 @@ test_that("differential_plots.R fails clearly when --p_value_column is absent fr
     "--outdir", outdir
   ))
 
-  expect_false(result$status == 0)
-  expect_match(
-    paste(result$output, collapse = "\n"),
-    "Missing stats variables: not_a_real_column",
-    fixed = TRUE
-  )
+  expect_exec_failure(result, "Missing stats variables: not_a_real_column")
 })
 
 # exec/make_app_from_files.R
@@ -467,7 +437,5 @@ test_that("make_app_from_files.R fails with an actionable error for a malformed 
     "--output_directory", outdir
   ))
 
-  expect_false(result$status == 0)
-  combined_output <- paste(result$output, collapse = "\n")
-  expect_match(combined_output, "FDR column not found", fixed = TRUE)
+  expect_exec_failure(result, "FDR column not found")
 })


### PR DESCRIPTION
## Summary

Part of #190, item 2 ("exec/ error paths"). `differential_plots.R`, `exploratory_plots.R` and `validate_fom_components.R` had only happy-path smoke tests; adds negative `run_exec_script` cases for missing/mismatched inputs across all three:

- `validate_fom_components.R`: missing `--assay_files` path, assay matrix columns not matching the sample sheet, contrasts file referencing an unknown variable.
- `exploratory_plots.R`: missing mandatory `--contrast_variable`, missing `--assay_files` path, `--final_assay` not among the supplied assays.
- `differential_plots.R`: missing `--differential_file`/`--feature_metadata`, `--fold_change_col`/`--p_value_column` absent from the differential file.

(`make_app_from_files.R` already had a negative test for a malformed enrichment file, so no changes were needed there.)

`R/io-read.R`'s `read_matrix()` had no file-existence check (unlike its `read_metadata()` sibling), which surfaced as a confusing indirect failure for a missing assay file rather than a clear message — added the same guard, in the same style, plus a direct unit test in `test-accessory.R` alongside `read_matrix()`'s other tests.

All other cases already produced clear, actionable `stop()` messages via existing validation (`read_metadata`, `read_stats_table`, `read_contrasts`), so no redundant guards were added there.

Every negative test follows the same `expect_false(status)` + `expect_match(output, pattern)` shape, now collapsed into a shared `expect_exec_failure()` helper in `helper-exec-smoke.R` (mirroring the existing `expect_exec_success()`), used consistently including the pre-existing malformed-enrichment test.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-exec-smoke.R")` passes with `NOT_CRAN=true` (62 assertions, subprocess-driven)
- [x] `testthat::test_file("tests/testthat/test-accessory.R")` passes (new `read_matrix` regression test included)
- [x] `lintr::lint_package()` clean