### PR TITLE
Fail CI when test coverage drops below a floor

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -77,13 +77,27 @@ jobs:
           args: 'c("--no-manual", "--as-cran", "--no-examples", "--no-vignettes")'
           build_args: 'c("--no-manual", "--no-build-vignettes")'
 
-      - name: Report test coverage
-        # Reporting only: a flaky covr instrumentation run shouldn't fail a PR
-        # that R-CMD-check has already passed on its own.
-        continue-on-error: true
+      - name: Report and enforce test coverage
+        # covr instrumentation itself can be flaky (unrelated to actual test
+        # coverage), so that failure mode is caught and only warned about
+        # below. A genuine drop below the floor is not tolerated: it fails
+        # the job via stop(), with no continue-on-error on this step.
         run: |
           Rscript -e '
-            cov <- covr::package_coverage(quiet = FALSE)
+            coverage_floor <- 55
+
+            cov <- tryCatch(
+              covr::package_coverage(quiet = FALSE),
+              error = function(e) {
+                cat("::warning::covr instrumentation failed, skipping coverage report and floor check:", conditionMessage(e), "\n")
+                NULL
+              }
+            )
+
+            if (is.null(cov)) {
+              quit(status = 0)
+            }
+
             print(cov)
 
             overall <- covr::percent_coverage(cov)
@@ -101,6 +115,13 @@ jobs:
             summary_md <- paste(summary_lines, collapse = "\n")
             cat(summary_md, "\n", file = Sys.getenv("GITHUB_STEP_SUMMARY"), append = TRUE)
             cat(summary_md, "\n")
+
+            if (overall < coverage_floor) {
+              stop(sprintf(
+                "Test coverage %.1f%% is below the required floor of %d%%. Restore the missing tests, or if the drop is justified, lower the floor in .github/workflows/check-release.yaml alongside an explanation in the PR.",
+                overall, coverage_floor
+              ))
+            }
           '
 
       - name: Download test data from nf-core tests data repo

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -78,10 +78,14 @@ jobs:
           build_args: 'c("--no-manual", "--no-build-vignettes")'
 
       - name: Report and enforce test coverage
-        # covr instrumentation itself can be flaky (unrelated to actual test
-        # coverage), so that failure mode is caught and only warned about
-        # below. A genuine drop below the floor is not tolerated: it fails
-        # the job via stop(), with no continue-on-error on this step.
+        # covr instrumentation itself can be flaky, independent of actual
+        # coverage, so that failure mode is only warned about below. This
+        # step doesn't fail the job directly (continue-on-error below) so
+        # that the integration steps that follow still run and report their
+        # own failures in the same CI run; the final step fails the job if
+        # this one's outcome was a genuine coverage-floor failure.
+        id: coverage
+        continue-on-error: true
         run: |
           Rscript -e '
             coverage_floor <- 55
@@ -174,4 +178,10 @@ jobs:
             wait "$pid" || status=1
           done
           exit $status
+
+      - name: Fail the job if coverage was below the floor
+        if: always() && steps.coverage.outcome == 'failure'
+        run: |
+          echo "Test coverage was below the required floor; see the 'Report and enforce test coverage' step above for the measured percentage."
+          exit 1
 


### PR DESCRIPTION
## Summary

Part of #190, item 3 ("coverage gating"). `check-release.yaml`'s coverage step ran with `continue-on-error: true` and only ever printed a markdown table to the job summary — a PR could delete tests and CI would stay green.

- The step now fails the job when overall coverage drops below a 55% floor, derived from three recent `check-release.yaml` runs on `develop` (60.6%, 60.6%, 61.2%), with a few points of margin for normal fluctuation.
- `covr::package_coverage()` instrumentation failing (a known flaky mode, unrelated to actual coverage) is still only warned about, not treated as a coverage drop.
- The coverage step no longer blocks the "Download test data"/"Run integration scripts" steps that follow it in the same job (`continue-on-error` on the coverage step plus a final `if: always()` check) — a PR that dips below the floor still gets the FOM/plots/app-build integration results in the same CI run instead of needing a second push to see them.

No Codecov integration was added: there's no `CODECOV_TOKEN` currently configured for this repo, so the self-contained floor check was used instead of introducing a dependency on a secret that would need adding separately.

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Manually traced the step ordering/`if: always()` logic against GitHub Actions' documented `continue-on-error`/`outcome` semantics
- [ ] First real CI run on this PR will exercise the floor check and step ordering end-to-end (not fully dry-runnable locally)