### PR TITLE
Deepen shinytest2 PCA/heatmap assertions and de-flake polling

### DIFF
--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -27,6 +27,28 @@ test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
   expect_true("rnaseq-pca-pca-scatter" %in% outputs)
   expect_true("rnaseq-pca-components-datatable" %in% outputs)
   expect_true("rnaseq-pca-pca-selectmatrix-geneSelect" %in% outputs)
+
+  # 12 samples in shinytest2_eselist(); assert the scatter actually plots one
+  # point per sample rather than just checking the output registered.
+  scatter <- jsonlite::fromJSON(
+    app$get_value(output = "rnaseq-pca-pca-scatter"),
+    simplifyVector = FALSE
+  )
+  traces <- scatter$x$data
+  expect_gt(length(traces), 0)
+
+  point_traces <- Filter(function(tr) length(tr$x) > 0, traces)
+  expect_gt(length(point_traces), 0)
+  n_points <- sum(vapply(point_traces, function(tr) length(tr$x), integer(1)))
+  expect_equal(n_points, 12)
+  expect_equal(sum(vapply(point_traces, function(tr) length(tr$y), integer(1))), 12)
+
+  # The components datatable lists one row per sample.
+  components <- jsonlite::fromJSON(
+    app$get_value(output = "rnaseq-pca-components-datatable"),
+    simplifyVector = FALSE
+  )
+  expect_equal(length(components$x$data[[1]]), 12)
 })
 
 # heatmap module
@@ -44,6 +66,22 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
   outputs <- names(app$get_values()$output)
   expect_true("rnaseq-heatmap-clustering-interactiveHeatmap" %in% outputs)
   expect_true("rnaseq-heatmap-clustering-heatmap-selectmatrix-geneSelect" %in% outputs)
+
+  # 12 samples in shinytest2_eselist(); the clustering heatmap's main trace is
+  # a 12x12 sample-by-sample matrix, so assert that shape rather than just
+  # checking the output registered.
+  widget <- jsonlite::fromJSON(
+    app$get_value(output = "rnaseq-heatmap-clustering-interactiveHeatmap"),
+    simplifyVector = FALSE
+  )
+  heatmap_traces <- Filter(function(tr) identical(tr$type, "heatmap"), widget$x$data)
+  expect_gt(length(heatmap_traces), 0)
+
+  row_counts <- vapply(heatmap_traces, function(tr) length(tr$z), integer(1))
+  expect_true(12 %in% row_counts)
+  main_trace <- heatmap_traces[[which(row_counts == 12)[1]]]
+  expect_equal(length(main_trace$x), 12)
+  expect_equal(length(main_trace$y), 12)
 })
 
 # selectmatrix + contrasts modules, as composed by differentialtable()
@@ -74,10 +112,10 @@ test_that("a bookmark URL restores the active tab and a contrast filter value", 
   app$set_inputs(`rnaseq-rnaseq` = "diff_tables")
   app$wait_for_idle(timeout = 40000)
   app$set_inputs(`rnaseq-differential-differential-fold_change0` = 7)
-  Sys.sleep(2)
+  app$wait_for_idle(timeout = 40000)
 
   app$click("shinyngs_share_view")
-  Sys.sleep(3)
+  app$wait_for_idle(timeout = 40000)
   url <- app$get_js("window.location.href")
 
   expect_match(url, "\\?", info = "bookmark should put state in the address bar")
@@ -85,17 +123,23 @@ test_that("a bookmark URL restores the active tab and a contrast filter value", 
   expect_false(grepl("plotly_", url), info = "transient plotly inputs are excluded")
   expect_false(grepl("_rows_", url), info = "transient DataTable inputs are excluded")
 
+  # A full page navigation tears down the old page's Shiny JS object and boots
+  # a fresh session; wait_for_idle() errors ("An error occurred while waiting
+  # for Shiny to be stable") if called immediately afterwards, since there is
+  # no stable Shiny busy-state to observe yet. Poll the DOM directly instead.
   app$run_js(sprintf("window.location.href = %s;", jsonlite::toJSON(url, auto_unbox = TRUE)))
 
-  restored <- NA_character_
-  for (i in seq_len(20)) {
-    Sys.sleep(2)
-    val <- app$get_js("(function(){var e=document.getElementById('rnaseq-differential-differential-fold_change0'); return e ? String(e.value) : 'NOEL';})()")
-    if (!is.null(val) && val == "7") {
-      restored <- val
-      break
-    }
-  }
+  restored_condition <- paste(
+    "(function(){",
+    "var e = document.getElementById('rnaseq-differential-differential-fold_change0');",
+    "return !!e && e.value === '7';",
+    "})()"
+  )
+  app$wait_for_js(restored_condition, timeout = 40000, interval = 200)
+
+  restored <- app$get_js(
+    "(function(){var e=document.getElementById('rnaseq-differential-differential-fold_change0'); return e ? String(e.value) : 'NOEL';})()"
+  )
   expect_equal(restored, "7")
   expect_equal(
     app$get_js("(window.Shiny && Shiny.shinyapp) ? String(Shiny.shinyapp.$inputValues['rnaseq-rnaseq']) : 'NA'"),
@@ -116,7 +160,6 @@ test_that("differentialtable computes a table without error given a real contras
       "expression-selectmatrix-sampleSelect" = "all",
       "expression-selectmatrix-geneSelect" = "all"
     )
-    Sys.sleep(0.5)
 
     rendered <- output$differentialtable
     expect_type(rendered, "list")

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -77,9 +77,12 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
   heatmap_traces <- Filter(function(tr) identical(tr$type, "heatmap"), widget$x$data)
   expect_gt(length(heatmap_traces), 0)
 
+  # The main sample-by-sample trace is picked by row count, same as
+  # splitAnnotationLegend() (R/heatmap.R) does to tell it apart from any
+  # annotation-strip trace of the same type.
   row_counts <- vapply(heatmap_traces, function(tr) length(tr$z), integer(1))
-  expect_true(12 %in% row_counts)
-  main_trace <- heatmap_traces[[which(row_counts == 12)[1]]]
+  expect_equal(sum(row_counts == 12), 1)
+  main_trace <- heatmap_traces[[which.max(row_counts)]]
   expect_equal(length(main_trace$x), 12)
   expect_equal(length(main_trace$y), 12)
 })


### PR DESCRIPTION
## Summary

Part of #190, item 4 ("shinytest2 depth"). The PCA and heatmap shinytest2 tests only checked that expected output IDs were registered, not what they rendered; several tests used fixed `Sys.sleep()`/iteration-count polling instead of a real wait condition.

- PCA test now parses the rendered plotly widget JSON and asserts one point per sample (12, matching `shinytest2_eselist()`) across both axes, plus a 12-row components datatable.
- Heatmap test parses the rendered widget and asserts the main sample-by-sample trace has the expected 12x12 shape, picking that trace by `which.max()` row count (mirroring `splitAnnotationLegend()`'s own disambiguation in `R/heatmap.R`, for the same reason: an annotation-strip trace of the same type could otherwise coincide in row count) with an explicit uniqueness check.
- The bookmark round-trip test's `Sys.sleep(2)`/`Sys.sleep(3)` calls are replaced with `app$wait_for_idle()`. The post-navigation fixed 20x2s polling loop is replaced with `app$wait_for_js()` against a real DOM-value predicate — `wait_for_idle()` alone isn't usable immediately after a full page navigation, since the old page's Shiny JS object is torn down and there's no stable busy-state to observe yet.
- Removed a bare `Sys.sleep(0.5)` in the `testServer`-based `differentialtable` test; `shiny::testServer()` flushes reactives synchronously and the test passes reliably without it.

All existing output-name-presence assertions are kept; the new content assertions are additive.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-shinytest2.R")` passes against real headless Chrome, run multiple times back-to-back to check for flakiness
- [x] `lintr::lint_package()` clean