### PR TITLE
Pre-release cleanup: 3D scatter labels, exec CLI fixes, packaging hygiene

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,10 @@
 ^.*\.profraw$
 ^\.nf-test\.log$
 ^\.DS_Store$
+^Rplots\.pdf$
+^pkgdown$
+^\.lintr$
+^CONTRIBUTING\.md$
+^\.claude$
+^\.ruff_cache$
+^\.Rhistory$

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 *.profraw
 default.profraw
 
+# R plotting device default output
+Rplots.pdf
+
+# ruff cache
+.ruff_cache/
+
 # CI logs
 .nf-test.log
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     ggdendro,
     ggplot2,
     heatmaply,
+    htmltools,
     limma,
     markdown,
     matrixStats,

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -213,12 +213,13 @@ scatterplot <- function(id, getDatamatrix, getThreedee = NULL, getXAxis = NULL, 
           }
         } else {
           cb <- NULL
+          palette <- NULL
         }
 
         plotly_scatterplot(
           x = xdata(), y = ydata(), z = zdata(), colorby = cb, plot_type = plotType(), title = getTitle(),
           xlab = colnames(getDatamatrix())[getXAxis()], ylab = colnames(getDatamatrix())[getYAxis()],
-          zlab = colnames(getDatamatrix())[geZXAxis()], palette = palette, labels = getLabels(),
+          zlab = colnames(getDatamatrix())[getZAxis()], palette = palette, labels = getLabels(),
           show_labels = getShowLabels(), lines = getLines(), showlegend = showLegend(),
           point_size = getPointSize()
         ) %>%
@@ -398,7 +399,7 @@ adjustLayout <- function(p, title = "", legend_title = "", xlab = "x", ylab = "y
   layout_args <- c(list(p, hovermode = "closest", title = title), axis_layouts)
 
   if (plot_type == "scatter3d") {
-    axis_layouts$zaxis <- list(title = ylab)
+    axis_layouts$zaxis <- list(title = zlab)
     layout_args$scene <- axis_layouts
   }
 
@@ -510,7 +511,8 @@ plotly_scatterplot <- function(x, y, z = NULL, colorby = NULL, plot_type = "scat
       legend_title = legend_title,
       xlab = xlab,
       ylab = ylab,
-      zlab = zlab
+      zlab = zlab,
+      plot_type = plot_type
     )
 }
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -120,17 +120,22 @@ reference:
     listed here only so the reference index build succeeds; see the
     package vignette for the supported way to build and combine modules.
   contents:
+  - COLORBLIND_PALETTE
   - ExploratorySummarizedExperiment-class
   - ExploratorySummarizedExperimentList-class
+  - a11yControl
   - addPoints
   - addTextLabels
   - adjustLayout
+  - annotateDifferentialTable
   - assaydatatable
   - assaydatatableInput
   - assaydatatableOutput
   - barplot
   - barplotInput
   - barplotOutput
+  - bookmarkedInputValue
+  - box_summary
   - boxplot
   - boxplotInput
   - boxplotOutput
@@ -145,12 +150,15 @@ reference:
   - colormakerInput
   - combinedAnnotationColors
   - compile_contrast_data
+  - configureBookmarking
   - contrasts
   - contrastsInput
   - contrastsOutput
+  - defaultGroupvar
   - dendro
   - dendroInput
   - dendroOutput
+  - detailSamples
   - dexseqplot
   - dexseqplotInput
   - dexseqplotOutput
@@ -158,6 +166,9 @@ reference:
   - dexseqtableInput
   - dexseqtableInputFields
   - dexseqtableOutput
+  - differentialScatterInput
+  - differentialScatterOutput
+  - differentialScatterServer
   - differentialtable
   - differentialtableInput
   - differentialtableOutput
@@ -167,6 +178,7 @@ reference:
   - experimenttableInput
   - experimenttableOutput
   - fieldSets
+  - finiteAxisRange
   - fixedEffectsFormula
   - fixedEffectsModelMatrix
   - foldchangeplot
@@ -193,6 +205,8 @@ reference:
   - heatmap
   - heatmapInput
   - heatmapOutput
+  - homeNavTargets
+  - homeTab
   - illuminaarray
   - illuminaarrayInput
   - illuminaarrayqc
@@ -210,6 +224,9 @@ reference:
   - maplotOutput
   - modalInput
   - modalServer
+  - moduleLayout
+  - moduleMain
+  - navLink
   - pca
   - pcaInput
   - pcaOutput
@@ -231,9 +248,15 @@ reference:
   - scatterplotOutput
   - scatterplotcontrols
   - scatterplotcontrolsInput
+  - selectFoldchangeLines
+  - selectMaLines
+  - selectVolcanoLines
   - selectmatrix
   - selectmatrixInput
   - shinyngs
+  - shinyngsPageNavbar
+  - shinyngsPlotlyConfig
+  - shinyngsSpinnerColor
   - simpleApp
   - simpletable
   - simpletableInput
@@ -242,6 +265,8 @@ reference:
   - splitAnnotationLegend
   - summarisematrix
   - summarisematrixInput
+  - summaryTileSpecs
+  - summaryTileTag
   - summarytiles
   - summarytilesInput
   - summarytilesOutput

--- a/exec/differential_plots.R
+++ b/exec/differential_plots.R
@@ -183,7 +183,7 @@ feature_metadata <-
 
 # Label features with symbol as well as identifier
 
-differential$label <- feature_metadata[differential[[opt$feature_id_col]], opt$feature_name_col]
+differential$label <- feature_metadata[differential[[opt$diff_feature_id_col]], opt$feature_name_col]
 
 # We'll color by whether features are differential according to supplied thresholds
 

--- a/exec/exploratory_plots.R
+++ b/exec/exploratory_plots.R
@@ -354,7 +354,8 @@ plotdata <-
   madScore(
     matrix = assay_data[[final_assay]],
     sample_sheet = sample_metadata,
-    groupby = opt$contrast_variable
+    groupby = opt$contrast_variable,
+    outlier_threshold = opt$outlier_mad_threshold
   )
 
 if (!is.null(plotdata)) {
@@ -362,7 +363,7 @@ if (!is.null(plotdata)) {
     x = plotdata$group,
     y = plotdata$mad,
     color = plotdata$outlier,
-    hline_thresholds = c("Outlier threshold" = -5),
+    hline_thresholds = c("Outlier threshold" = opt$outlier_mad_threshold),
     legend_title = "Outlier status",
     labels = rownames(plotdata),
     show_labels = TRUE,

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -514,7 +514,8 @@ validate_mandatory_args <- function(opt) {
     "assay_files",
     "assay_entity_name",
     "output_directory",
-    "contrast_stats_assay"
+    "contrast_stats_assay",
+    "differential_results"
   )
 
   invisible(shinyngs::checkListIsSubset(mandatory, names(opt), "mandatory arguments", "provided options"))

--- a/exec/validate_fom_components.R
+++ b/exec/validate_fom_components.R
@@ -180,7 +180,7 @@ if (! is.null(opt$output_directory)){
   
   if ('differential_stats' %in% names(validated_parts)){
     for (ds in names(validated_parts[['differential_stats']])){
-      write_table(validated_parts[['differential_stats']][[ds]], ds)
+      write_table(validated_parts[['differential_stats']][[ds]], ds, 'differential')
     }
   }
   

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -41,3 +41,15 @@ test_that("threshold lines span the full plotted axis range instead of stopping 
   expect_equal(sort(hline_trace$x), sort(xaxis_range))
   expect_equal(sort(vline_trace$y), sort(yaxis_range))
 })
+
+test_that("3D scatter labels each scene axis with its own title", {
+  p <- plotly_scatterplot(
+    x = c(1, 2, 3), y = c(4, 5, 6), z = c(7, 8, 9),
+    plot_type = "scatter3d", xlab = "xtitle", ylab = "ytitle", zlab = "ztitle"
+  )
+  scene <- p$x$layoutAttrs[[1]]$scene
+
+  expect_equal(scene$xaxis$title, "xtitle")
+  expect_equal(scene$yaxis$title, "ytitle")
+  expect_equal(scene$zaxis$title, "ztitle")
+})


### PR DESCRIPTION
A batch of fixes surfaced by a pre-release review, scoped to items no other open PR (#198-#201) covers. The MA-plot cardinality bug from the same review is already fixed by #197 and is not included here.

## Functional bugs

**3D scatter plots (`R/scatterplot.R`)**
- `plotly_scatterplot()` never passed `plot_type` to `adjustLayout()`, so the `scatter3d` branch never fired and 3D plots got no scene axis titles at all. Now threaded through.
- That branch also labelled the z-axis with `ylab`; corrected to `zlab`.
- Fixed a `getZAxis()` reference that was mistyped `geZXAxis()` (a latent "could not find function" crash, dormant only because the argument was never forced).
- Default `palette` to `NULL` when no `colorby` is supplied, so the plot builds its own scale instead of falling through to `base::palette`.
- Added a regression test asserting each 3D scene axis carries its own title.

**exec/ CLI (public contract for nf-core/differentialabundance)**
- `validate_fom_components.R`: the differential-stats write-back called `write_table()` without its mandatory `suffix` argument, erroring whenever `--differential_results` and `--output_directory` were both given (a path CI does not exercise). Verified fixed end-to-end against the smoke fixtures.
- `differential_plots.R`: feature labels indexed the differential table by `--feature_id_col` instead of `--diff_feature_id_col`, producing all-`NA` labels when the two differ.
- `exploratory_plots.R`: `--outlier_mad_threshold` was accepted but ignored (both the outlier call and the plotted line hardcoded `-5`); now wired into `madScore()` and the threshold line.
- `make_app_from_files.R`: building without `--differential_results` crashed with a cryptic names-length error; made it a mandatory argument so the failure is explicit and early.

## Packaging / hygiene
- Declare `htmltools` in `Imports` (used via `::` in `R/apps.R`).
- Add the 25 documented topics missing from the `_pkgdown.yml` reference index (including several `differentialscatter.R` pages introduced in #197), so the site build stops warning.
- Ignore `Rplots.pdf` and `.ruff_cache/`; build-ignore non-standard top-level entries (`pkgdown/`, `.lintr`, `CONTRIBUTING.md`, `.claude/`, `.ruff_cache/`, `Rplots.pdf`, `.Rhistory`) so they stay out of the package tarball.

## Verification
- `lintr::lint_package()`: 0 lints.
- Full `devtools::test()` suite: green, no failures.
- Ran all four exec scripts against the smoke fixtures: all exit 0, including the previously-crashing `validate_fom` differential write-back and the new clean error from `make_app` without `--differential_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)