### PR TITLE
Fix wasm release build blocked by pkgdepends 0.9.1 regression (#74)

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -26,12 +26,6 @@ jobs:
       repository-projects: read
 
     steps:
-      - name: Validate event is release
-        if: github.event_name != 'release'
-        run: |
-          echo "This workflow should only be triggered by release events"
-          exit 1
-
       - name: Checkout calling repository
         uses: actions/checkout@v4
 
@@ -51,11 +45,10 @@ jobs:
         run: |
           set -euo pipefail
           perl -0pi -e 'my ($o, $n) = ($ENV{OLD_INSTALL}, $ENV{NEW_INSTALL}); s/\Q$o\E/$n/g' "$CODE_R"
-          if ! grep -qF 'r-lib/pkgdepends@026e5c1' "$CODE_R"; then
+          if grep -qF "$OLD_INSTALL" "$CODE_R" || ! grep -qF "$NEW_INSTALL" "$CODE_R"; then
             echo "::error::pkgdepends pin failed to apply; upstream code.R install line changed. Re-check the workaround for pinin4fjords/shinyngs#74."
             exit 1
           fi
-          grep -n 'pak::pak' "$CODE_R"
 
       - name: Find `Config/Needs/wasm` in DESCRIPTION
         id: needs

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,14 +1,9 @@
 # Workflow derived from https://github.com/r-wasm/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 #
-# The steps below inline r-wasm/actions' release-file-system-image.yml reusable
-# workflow so a patch step can run between checkout and build. CRAN's pkgdepends
-# 0.9.1 aborts rwasm::add_pkg() with "`nrow(out)` must equal `1`"
-# (https://github.com/r-lib/pkgdepends/issues/462); the fix is on r-lib/pkgdepends
-# main but unreleased on CRAN, and the build container reinstalls rwasm (pulling
-# CRAN pkgdepends) from scratch. The patch step forces the fixed pkgdepends commit
-# into that install. Once the fix reaches CRAN, drop the two workaround steps and
-# revert to `uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2`.
+# Temporary workaround for pinin4fjords/shinyngs#74: the "Pin fixed pkgdepends"
+# step patches the r-wasm build container to use a pkgdepends commit CRAN has not
+# released. When it lands on CRAN, delete the workaround steps and revert to:
+#   uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
 on:
   release:
     # Must republish release to update assets

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,5 +1,14 @@
 # Workflow derived from https://github.com/r-wasm/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# The steps below inline r-wasm/actions' release-file-system-image.yml reusable
+# workflow so a patch step can run between checkout and build. CRAN's pkgdepends
+# 0.9.1 aborts rwasm::add_pkg() with "`nrow(out)` must equal `1`"
+# (https://github.com/r-lib/pkgdepends/issues/462); the fix is on r-lib/pkgdepends
+# main but unreleased on CRAN, and the build container reinstalls rwasm (pulling
+# CRAN pkgdepends) from scratch. The patch step forces the fixed pkgdepends commit
+# into that install. Once the fix reaches CRAN, drop the two workaround steps and
+# revert to `uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2`.
 on:
   release:
     # Must republish release to update assets
@@ -9,9 +18,76 @@ name: Build and deploy wasm R package image
 
 jobs:
   release-file-system-image:
-    uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2
+    runs-on: ubuntu-22.04
+
+    concurrency:
+      group: release
+      cancel-in-progress: true
+
     permissions:
       # For publishing artifact files to the release
       contents: write
       # To download GitHub Packages within action
       repository-projects: read
+
+    steps:
+      - name: Validate event is release
+        if: github.event_name != 'release'
+        run: |
+          echo "This workflow should only be triggered by release events"
+          exit 1
+
+      - name: Checkout calling repository
+        uses: actions/checkout@v4
+
+      - name: Checkout r-wasm/actions repository
+        uses: actions/checkout@v4
+        with:
+          ref: v2
+          repository: r-wasm/actions
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: .actions
+
+      - name: Pin fixed pkgdepends in the build container
+        env:
+          CODE_R: ./.actions/build-rwasm/code.R
+          OLD_INSTALL: pak::pak(c("r-wasm/rwasm"))
+          NEW_INSTALL: pak::pak(c("r-lib/pkgdepends@026e5c1b655b6c1860e9b98f4af4b533a243eb3d", "r-wasm/rwasm"))
+        run: |
+          set -euo pipefail
+          perl -0pi -e 'my ($o, $n) = ($ENV{OLD_INSTALL}, $ENV{NEW_INSTALL}); s/\Q$o\E/$n/g' "$CODE_R"
+          if ! grep -qF 'r-lib/pkgdepends@026e5c1' "$CODE_R"; then
+            echo "::error::pkgdepends pin failed to apply; upstream code.R install line changed. Re-check the workaround for pinin4fjords/shinyngs#74."
+            exit 1
+          fi
+          grep -n 'pak::pak' "$CODE_R"
+
+      - name: Find `Config/Needs/wasm` in DESCRIPTION
+        id: needs
+        shell: Rscript {0}
+        run: |
+          has_wasm_need <-
+            file.exists("DESCRIPTION") &&
+            "Config/Needs/wasm" %in% names(as.list(read.dcf("DESCRIPTION")[1,]))
+          pkg <- if (has_wasm_need) as.list(read.dcf("DESCRIPTION")[1,])$`Config/Needs/wasm` else ""
+          pkg <- paste0(strsplit(pkg, "[[:space:],]+")[[1]], collapse = ",")
+          cat("pkg=", pkg, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+
+      - name: Build wasm image
+        uses: ./.actions/build-rwasm
+        with:
+          packages: |
+            .
+            ${{ steps.needs.outputs.pkg }}
+          strip: "NULL"
+          image-path: ._rwasm
+          compress: false
+
+      - name: Upload wasm image to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "._rwasm/*"
+          tag: ${{ github.ref }}
+          file_glob: true
+          overwrite: true


### PR DESCRIPTION
Fixes the `release-wasm.yml` build, which currently fails on every release (v2.4.0 and v3.0.0 shipped with no wasm assets attached).

## Problem

The build dies at dependency resolution with `` `nrow(out)` must equal `1` `` ([r-lib/pkgdepends#462](https://github.com/r-lib/pkgdepends/issues/462)), a regression in CRAN `pkgdepends` 0.9.1 that aborts `rwasm::add_pkg()`. The fix is merged on `r-lib/pkgdepends` `main` (commit `026e5c1`) but is not yet released to CRAN. Pinning the `webr-image` does not help, because `r-wasm/actions`' build container reinstalls `rwasm` (and pulls CRAN's broken `pkgdepends`) from scratch on every run.

## Change

Inline the `r-wasm/actions` `release-file-system-image.yml` reusable workflow so a step can run between checkout and build, and have that step rewrite the container's single `pak::pak()` install to pull the fixed `pkgdepends` commit. A guard fails the job loudly if the upstream install line ever changes, so this can't silently regress.

Once the `pkgdepends` fix reaches CRAN, drop the two workaround steps and revert to `uses: r-wasm/actions/.github/workflows/release-file-system-image.yml@v2`.

## Verification

On an x86_64 runner (matching CI): the unpatched build reproduces the resolver error exactly, and the patched build resolves and compiles shinyngs into a working wasm library image (verified against both `webr:main` and a pinned `webr:v0.4.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)