### PR TITLE
Fix duplicate input/output IDs in renderUI-backed controls

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -44,10 +44,10 @@ contrastsInput <- function(id, allow_filtering = TRUE, summarise = TRUE, dynamic
   if (dynamic_filters) {
     contrast_filters <- c(
       list(hiddenInput(ns("dynamic"), 1)), list(helpText("Build up a complex query by adding filters below"), hr()), contrast_filters,
-      list(hr(), uiOutput(ns("combine_operator")), actionButton(ns("insertBtn"), "Add"), HTML("&nbsp;"), actionButton(ns("removeBtn"), "Remove"))
+      list(hr(), uiOutput(ns("combine_operator_ui")), actionButton(ns("insertBtn"), "Add"), HTML("&nbsp;"), actionButton(ns("removeBtn"), "Remove"))
     )
   } else {
-    contrast_filters <- pushToList(contrast_filters, uiOutput(ns("combine_operator")))
+    contrast_filters <- pushToList(contrast_filters, uiOutput(ns("combine_operator_ui")))
   }
 
   # inputs <- pushToList(inputs, conditionalPanel(condition = paste0('input['', ns('filterRows'), ''] == true '), contrast_filters))
@@ -392,7 +392,7 @@ contrastNaming <- function(getAllContrasts) {
 #' state. Also owns the accessors that just read \code{filterset_values} (the
 #' "form value" reactives), since they're only meaningful together with this
 #' state and folding them in here removes what would otherwise be a forward
-#' reference (the insert observer and \code{output$combine_operator} use
+#' reference (the insert observer and \code{output$combine_operator_ui} use
 #' \code{getFilterRows()}/\code{getSelectedContrastNumbers()} before those
 #' would be defined, if they lived in a separate stage called later).
 #'
@@ -570,7 +570,7 @@ contrastFilterSetEngine <- function(ns, input, output, session, selectmatrix_rea
 
   # The combine_operator field is only necessary with more than one filter set
 
-  output$combine_operator <- renderUI({
+  output$combine_operator_ui <- renderUI({
     scn <- getSelectedContrastNumbers()
     if (length(scn) > 1) {
       inlineField(selectInput(ns("combine_operator"), NULL, c(and = "intersect", or = "union")),

--- a/R/geneselect.R
+++ b/R/geneselect.R
@@ -21,7 +21,7 @@ geneselectInput <- function(id, select_genes = TRUE) {
   ns <- NS(id)
 
   if (select_genes) {
-    uiOutput(ns("geneSelect"))
+    uiOutput(ns("geneSelect_ui"))
   } else {
     hiddenInput(ns("geneSelect"), "all")
   }
@@ -96,7 +96,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
 
     # Render the geneSelect UI element
 
-    output$geneSelect <- renderUI({
+    output$geneSelect_ui <- renderUI({
       withProgress(message = "Rendering row selection", value = 0, {
         ns <- session$ns
 

--- a/R/genesetselect.R
+++ b/R/genesetselect.R
@@ -20,7 +20,7 @@
 genesetselectInput <- function(id, multiple = TRUE) {
   ns <- NS(id)
 
-  tagList(uiOutput(ns("geneSetTypes")), selectizeInput(ns("geneSets"), "Gene sets", choices = NULL, options = list(
+  tagList(uiOutput(ns("geneSetTypes_ui")), selectizeInput(ns("geneSets"), "Gene sets", choices = NULL, options = list(
     placeholder = "Type a gene set keyword",
     maxItems = 5
   ), multiple = multiple), radioButtons(ns("overlapType"), withHelpIcon("Overlap type", "'Union' includes genes from any of the selected gene sets; 'intersect' includes only genes common to all of them."), c("union", "intersect")))
@@ -78,7 +78,7 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
 
     # Allow user to select the type of gene set
 
-    output$geneSetTypes <- renderUI({
+    output$geneSetTypes_ui <- renderUI({
       if (filter_by_type) {
         gene_set_types <- names(getGeneSetsForLabelfield())
         ns <- session$ns

--- a/R/readreports.R
+++ b/R/readreports.R
@@ -26,7 +26,7 @@ readreportsInput <- function(id, eselist) {
     naked_fields <- experiment_filter
   }
 
-  field_sets <- c(field_sets, list(report_type = uiOutput(ns("reportType")), bar_plot = uiOutput(ns("barplotControls")), export = simpletableInput(ns("readrep"))))
+  field_sets <- c(field_sets, list(report_type = uiOutput(ns("reportType_ui")), bar_plot = uiOutput(ns("barplotControls")), export = simpletableInput(ns("readrep"))))
 
   list(naked_fields, fieldSets(ns("fieldsets"), field_sets))
 }
@@ -74,7 +74,7 @@ readreports <- function(id, eselist) {
 
     # Render a select for the report type based on what's in the 'read_reports' slot
 
-    output$reportType <- renderUI({
+    output$reportType_ui <- renderUI({
       ese <- selectmatrix_reactives$getExperiment()
       selectInput(ns("reportType"), "Report type", structure(names(ese@read_reports), names = prettifyVariablename(names(ese@read_reports))))
     })

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -39,7 +39,7 @@ selectmatrixInput <- function(id, eselist, require_contrast_stats = FALSE) {
       has_slot_data(ese, "contrast_stats")
     })))]
   }
-  inputs <- list(selectInput(ns("experiment"), "Experiment", names(eselist)), uiOutput(ns("assay")), uiOutput(ns("samples")), uiOutput(ns("rows")), uiOutput(ns("meta")))
+  inputs <- list(selectInput(ns("experiment"), "Experiment", names(eselist)), uiOutput(ns("assay_ui")), uiOutput(ns("samples")), uiOutput(ns("rows")), uiOutput(ns("meta")))
 
   # Replace experiment with a hidden input if we've got just the one
 
@@ -114,7 +114,7 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
 
     ns <- session$ns
 
-    output$assay <- renderUI({
+    output$assay_ui <- renderUI({
       withProgress(message = "Rendering assay drop-down", value = 0, {
         ns <- session$ns
 

--- a/R/upset.R
+++ b/R/upset.R
@@ -32,7 +32,7 @@ upsetInput <- function(id, eselist) {
   ns <- NS(id)
 
   upset_fields <- list(
-    uiOutput(ns("nsets")), sliderInput(ns("nintersects"), label = "Number of intersections", min = 2, max = 40, step = 1, value = 20), uiOutput(ns("minorder")),
+    uiOutput(ns("nsets_ui")), sliderInput(ns("nintersects"), label = "Number of intersections", min = 2, max = 40, step = 1, value = 20), uiOutput(ns("minorder_ui")),
     checkboxInput(ns("separate_by_direction"), label = "Separate by direction of change?", value = TRUE), checkboxInput(ns("set_sort"), "Sort sets by size?", value = TRUE), checkboxInput(ns("bar_numbers"), "Show bar numbers?", value = FALSE), checkboxInput(ns("show_empty_intersections"),
       label = "Show empty intersections?", value = TRUE
     ), selectInput(ns("intersection_assignment_type"), "Intersection type", choices = c(
@@ -134,12 +134,12 @@ upset <- function(id, eselist, setlimit = 16) {
 
     ############################################################################# Render dynamic fields
 
-    output$nsets <- renderUI({
+    output$nsets_ui <- renderUI({
       max_sets <- getMaxSets()
       sliderInput(ns("nsets"), label = "Number of sets", min = 2, max = max_sets, step = 1, value = max_sets)
     })
 
-    output$minorder <- renderUI({
+    output$minorder_ui <- renderUI({
       assignment_type <- getIntersectionAssignmentType()
       max_order <- getMaxIntersectionOrder()
 

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -26,7 +26,7 @@ test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
   outputs <- names(app$get_values()$output)
   expect_true("rnaseq-pca-pca-scatter" %in% outputs)
   expect_true("rnaseq-pca-components-datatable" %in% outputs)
-  expect_true("rnaseq-pca-pca-selectmatrix-geneSelect" %in% outputs)
+  expect_true("rnaseq-pca-pca-selectmatrix-geneSelect_ui" %in% outputs)
 
   # 12 samples in shinytest2_eselist(); assert the scatter actually plots one
   # point per sample rather than just checking the output registered.
@@ -65,7 +65,7 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
 
   outputs <- names(app$get_values()$output)
   expect_true("rnaseq-heatmap-clustering-interactiveHeatmap" %in% outputs)
-  expect_true("rnaseq-heatmap-clustering-heatmap-selectmatrix-geneSelect" %in% outputs)
+  expect_true("rnaseq-heatmap-clustering-heatmap-selectmatrix-geneSelect_ui" %in% outputs)
 
   # 12 samples in shinytest2_eselist(); the clustering heatmap's main trace is
   # a 12x12 sample-by-sample matrix, so assert that shape rather than just


### PR DESCRIPTION
## Problem

Several modules give a `uiOutput()` container and the input rendered into it the **same** namespaced id — e.g. in `selectmatrix.R`:

```r
uiOutput(ns("assay"))                       # UI: the container
output$assay <- renderUI({                   # server: renders into it...
  selectInput(ns("assay"), "Matrix", ...)    # ...an input with the SAME id
})
```

A normal Shiny server tolerates this (it just logs `Shared input/output IDs were found`), so it's gone unnoticed. Under **shinylive/webR** the duplicate DOM id drives an infinite reactive loop and `Maximum call stack size exceeded`, which **freezes any panel that uses the affected module** — most visibly PCA and Assay data (both hang via `selectmatrix`).

## Fix

Rename the container to a distinct `<id>_ui` (the `uiOutput` and its `output$<id>` renderUI target), leaving the **inner input id unchanged** so `input$<id>` and `conditionalPanel("input['...-<id>']...")` references stay valid. Purely mechanical, no behavioural change.

Found by scanning every module for an id used as both an input and an output. Seven real collisions:

| File | id |
|---|---|
| `selectmatrix.R` | `assay` |
| `contrasts.R` | `combine_operator` |
| `geneselect.R` | `geneSelect` |
| `genesetselect.R` | `geneSetTypes` |
| `readreports.R` | `reportType` |
| `upset.R` | `nsets`, `minorder` |

(`genesetanalysistable`/`genesetbarcodeplot` reuse a *sub-module* id for distinct namespaced sub-modules — no DOM clash, left alone.)

## Verification

Ran the `rnaseq` app with the patched package: the previously-frozen **Assay data** and **PCA** panels render, and the `Shared input/output IDs` / `Maximum call stack size exceeded` console messages are gone. Input selections still work (controls drive the table/plot as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)