### PR TITLE
Configure an explicit app cache in generated apps

### DIFF
--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -463,7 +463,8 @@ build_app_bundle <- function(opt) {
       "library(shinyngs)",
       "library(markdown)",
       "# A Shiny server provides a default app cache for bindCache(); webR/shinylive does not.",
-      "shiny::shinyOptions(cache = cachem::cache_mem())",
+      "# max_size matches Shiny's own default (200 MB) so behaviour is identical on a server.",
+      "shiny::shinyOptions(cache = cachem::cache_mem(max_size = 200 * 1024^2))",
       'esel <- readRDS("data.rds")',
       'app <- prepareApp("rnaseq", esel)',
       "shiny::shinyApp(app$ui, app$server)"

--- a/exec/make_app_from_files.R
+++ b/exec/make_app_from_files.R
@@ -462,6 +462,8 @@ build_app_bundle <- function(opt) {
       "# https://github.com/pinin4fjords/shinyngs?tab=readme-ov-file#installation",
       "library(shinyngs)",
       "library(markdown)",
+      "# A Shiny server provides a default app cache for bindCache(); webR/shinylive does not.",
+      "shiny::shinyOptions(cache = cachem::cache_mem())",
       'esel <- readRDS("data.rds")',
       'app <- prepareApp("rnaseq", esel)',
       "shiny::shinyApp(app$ui, app$server)"


### PR DESCRIPTION
`make_app_from_files` writes an `app.R` that relies on Shiny's implicit application-level cache for the many `bindCache()` calls in shinyngs modules. A normal Shiny server sets that default cache up automatically, so it's never been a problem. **webR / shinylive does not**, so under shinylive `bindCache()` aborts with `cache must either be "app", "session", or a cache object …` and plot panels error.

This adds one line to the generated app:

```r
shiny::shinyOptions(cache = cachem::cache_mem(max_size = 200 * 1024^2))
```

- **Behaviourally identical on a server** — Shiny's own default app cache is `memoryCache()` = `cache_mem(max_size = 200 MB)`, LRU. This sets the same store with the same size and eviction, just explicitly, so caching behaviour on a server is unchanged.
- **Enables the generated app to run under webR/shinylive**, where no default is provided (Shiny resolves `cache = "app"` via `getShinyOption("cache", default = NULL)`, and webR never sets it).

`cachem` is a transitive Shiny dependency, so it's always available. Context in #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)