### PR TITLE
Document running make_app_from_files.R output via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,14 +242,15 @@ resulting from the above command.
 Or run it via Docker: the
 [image](https://quay.io/repository/biocontainers/r-shinyngs)
 mentioned above already has `shinyngs` and Shiny installed, so it can
-run the generated `app.R`/`data.rds` directly - pick a tag from the
+run the generated `app.R`/`data.rds` directly - there's no `latest`
+tag, so use the most recent one from the
 [image's tag list](https://quay.io/repository/biocontainers/r-shinyngs?tab=tags)
 and mount the directory containing them:
 
 ``` bash
 docker run --rm -p 3838:3838 \
     -v "$(pwd)/app":/data -w /data \
-    quay.io/biocontainers/r-shinyngs:<tag> \
+    quay.io/biocontainers/r-shinyngs:<latest-tag> \
     Rscript -e "shiny::runApp('/data', host = '0.0.0.0', port = 3838)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ If `--feature_metadata` includes `chromosome_name`, `start_position` and
 You can start the resulting app locally, by running the `app.R`
 resulting from the above command.
 
+Or run it via Docker: the
+[image](https://quay.io/repository/biocontainers/r-shinyngs)
+mentioned above already has `shinyngs` and Shiny installed, so it can
+run the generated `app.R`/`data.rds` directly - pick a tag from the
+[image's tag list](https://quay.io/repository/biocontainers/r-shinyngs?tab=tags)
+and mount the directory containing them:
+
+``` bash
+docker run --rm -p 3838:3838 \
+    -v "$(pwd)/app":/data -w /data \
+    quay.io/biocontainers/r-shinyngs:<tag> \
+    Rscript -e "shiny::runApp('/data', host = '0.0.0.0', port = 3838)"
+```
+
+Then browse to <http://localhost:3838>. `host = '0.0.0.0'` is required
+for the app to be reachable from outside the container, and `-w /data`
+ensures the app's working directory (and anything it writes) lands in
+the mounted directory rather than the container's own filesystem.
+
 See `make_app_from_files.R --help` for more info.
 
 ### shinyapps.io deployment

--- a/vignettes/shinyngs.Rmd
+++ b/vignettes/shinyngs.Rmd
@@ -471,12 +471,12 @@ make_app_from_files.R \
 
 This produces an `app.R` in `--output_dir`, which can be run directly. See `make_app_from_files.R --help` for the full set of options, including `--ensembl_species` (see [Included modules](#included-modules)) and `--deploy_app` for deploying straight to shinyapps.io.
 
-Or run it via Docker: the [Biocontainers image](https://quay.io/repository/biocontainers/r-shinyngs) already has `shinyngs` and Shiny installed and can run the generated `app.R`/`data.rds` directly - pick a tag from the [image's tag list](https://quay.io/repository/biocontainers/r-shinyngs?tab=tags) and mount `--output_dir`:
+Or run it via Docker: the [Biocontainers image](https://quay.io/repository/biocontainers/r-shinyngs) already has `shinyngs` and Shiny installed and can run the generated `app.R`/`data.rds` directly - there's no `latest` tag, so use the most recent one from the [image's tag list](https://quay.io/repository/biocontainers/r-shinyngs?tab=tags) and mount `--output_dir`:
 
 ```sh
 docker run --rm -p 3838:3838 \
   -v "$(pwd)/app":/data -w /data \
-  quay.io/biocontainers/r-shinyngs:<tag> \
+  quay.io/biocontainers/r-shinyngs:<latest-tag> \
   Rscript -e "shiny::runApp('/data', host = '0.0.0.0', port = 3838)"
 ```
 

--- a/vignettes/shinyngs.Rmd
+++ b/vignettes/shinyngs.Rmd
@@ -471,6 +471,17 @@ make_app_from_files.R \
 
 This produces an `app.R` in `--output_dir`, which can be run directly. See `make_app_from_files.R --help` for the full set of options, including `--ensembl_species` (see [Included modules](#included-modules)) and `--deploy_app` for deploying straight to shinyapps.io.
 
+Or run it via Docker: the [Biocontainers image](https://quay.io/repository/biocontainers/r-shinyngs) already has `shinyngs` and Shiny installed and can run the generated `app.R`/`data.rds` directly - pick a tag from the [image's tag list](https://quay.io/repository/biocontainers/r-shinyngs?tab=tags) and mount `--output_dir`:
+
+```sh
+docker run --rm -p 3838:3838 \
+  -v "$(pwd)/app":/data -w /data \
+  quay.io/biocontainers/r-shinyngs:<tag> \
+  Rscript -e "shiny::runApp('/data', host = '0.0.0.0', port = 3838)"
+```
+
+Then browse to `http://localhost:3838`.
+
 ### Building an app from files with enrichment results
 
 `exec/make_app_from_files.R` can also wire GSEA (or `roast`) results into an app from the command line. `--enrichment_filename_template` describes where the result files live, with `{contrast_name}` and `{geneset_type}` substituted per contrast and gene set type, and an optional `{target|reference}` token to point at the split up/down GSEA files:


### PR DESCRIPTION
## Summary
- Add a `docker run` example for launching the `app.R`/`data.rds` bundle produced by `make_app_from_files.R`, using the Biocontainers image already referenced elsewhere in the docs
- Added next to the existing `make_app_from_files.R` instructions in both the README and the vignette

## Test plan
- [x] Verified the `docker run` command against a real bundle generated from the `exec-smoke` test fixtures, confirmed the app served on the mapped port