### PR TITLE
Fix leftover rbindlist calls in contrasts labelling/summary tables

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -980,8 +980,8 @@ contrastLabelling <- function(eselist, selectmatrix_reactives, selectFinalFeatur
     }
 
     withProgress(message = "Making labelled table", value = 0, {
-      final_contrasts_table <- unique(rbindlist(lapply(filtered_contrast_tables, function(fcts) {
-        rbindlist(lapply(fcts, function(fct) {
+      final_contrasts_table <- unique(do.call(rbind, lapply(filtered_contrast_tables, function(fcts) {
+        do.call(rbind, lapply(fcts, function(fct) {
           labelMatrix(fct[sff, , drop = FALSE], ese = ese, metafields = metafields)
         }))
       })))
@@ -1044,7 +1044,7 @@ contrastQuerySummary <- function(output, selectmatrix_reactives, filteredContras
     if (length(summaries) == 1) {
       summaries[[1]][, -1]
     } else {
-      rbindlist(summaries)
+      do.call(rbind, summaries)
     }
   })
 


### PR DESCRIPTION
## Summary

- `contrastLabelling()` and `contrastQuerySummary()` in `R/contrasts.R` still called `rbindlist()` after the `data.table` dependency was dropped in #226, breaking any screen that builds a labelled contrasts table (e.g. the volcano plot's results table) with `could not find function "rbindlist"`.
- Replaced all three call sites with `do.call(rbind, ...)`, matching the pattern used elsewhere in the codebase after that dependency removal.

## Test plan

- [x] Rebuilt the package and launched the full RNA-seq app against the `zhangneurons` dataset
- [x] Confirmed the volcano plot and its results table render with data and no `shiny-output-error`, for a filtered contrast (`Astrocyte: yes vs no`)