### PR TITLE
Promote article groups to top-level navbar dropdowns

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -307,22 +307,40 @@ reference:
 
 navbar:
   structure:
-    left:  [intro, articles, reference, news]
+    left:  [intro, building-apps, using-extending, reference, news]
     right: [search, github]
+  components:
+    building-apps:
+      text: Building apps
+      menu:
+      - text: The data model
+        href: articles/data-model.html
+      - text: Building an app from files and YAML
+        href: articles/build-from-files.html
+      - text: Command-line interface reference
+        href: articles/cli.html
+    using-extending:
+      text: Using & extending
+      menu:
+      - text: Module and panel catalog
+        href: articles/modules.html
+      - text: Reusing components inside and outside Shiny
+        href: articles/reuse.html
+      - text: Theming, palettes and shareable views
+        href: articles/theming.html
+      - text: Developer guide
+        href: articles/developer.html
 
 articles:
 - title: Get started
-  navbar: ~
   contents:
   - shinyngs
 - title: Building apps
-  navbar: Building apps
   contents:
   - articles/data-model
   - articles/build-from-files
   - articles/cli
 - title: Using and extending
-  navbar: Using & extending
   contents:
   - articles/modules
   - articles/reuse


### PR DESCRIPTION
## Summary
- Replace the single "Articles" navbar dropdown with two top-level dropdowns, "Building apps" and "Using & extending", sitting alongside "Get started" and "Reference"
- No content changes, navbar structure only

## Test plan
- [x] Built the pkgdown site locally and confirmed the rendered navbar shows separate "Building apps" / "Using & extending" dropdowns with no "Articles" entry, and that "Get started" still links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)