### PR TITLE
Fix density-plot crash on samples with zero values

### DIFF
--- a/R/utils-matrix.R
+++ b/R/utils-matrix.R
@@ -74,7 +74,8 @@ ggplotify <- function(plotmatrices, experiment, colorby = NULL, value_type = "ex
   allplotdata <- do.call(rbind, lapply(names(plotmatrices), function(pm) {
     if (value_type == "density") {
       plotdata <- do.call(rbind, lapply(colnames(plotmatrices[[pm]]), function(s) {
-        dens <- density(cond_log2_transform_matrix(plotmatrices[[pm]][, s], rmzeros = TRUE, should_transform = should_transform), n = 100)
+        transformed <- cond_log2_transform_matrix(plotmatrices[[pm]][, s], rmzeros = TRUE, should_transform = should_transform)
+        dens <- density(transformed[is.finite(transformed)], n = 100)
         data.frame(name = s, value = dens$x, density = dens$y)
       }))
     } else {

--- a/tests/testthat/test-utils-matrix.R
+++ b/tests/testthat/test-utils-matrix.R
@@ -1,0 +1,17 @@
+# ggplotify()
+
+test_that("ggplotify computes a density trace when a sample has zero values", {
+  # rmzeros turns zeros into NA ahead of the log2 transform, so a sample
+  # with any zero entries reproduces the crash from issue #249 unless
+  # those NAs are dropped before stats::density() is called.
+  mat <- matrix(
+    c(0, 10, 100, 1000, 5, 50, 500, 5000),
+    nrow = 4, dimnames = list(paste0("gene", 1:4), c("s1", "s2"))
+  )
+  experiment <- data.frame(row.names = c("s1", "s2"))
+
+  plotdata <- ggplotify(mat, experiment, value_type = "density")
+
+  expect_setequal(unique(plotdata$name), c("s1", "s2"))
+  expect_true(all(is.finite(plotdata$density)))
+})


### PR DESCRIPTION
## Summary
- `ggplotify(..., value_type = "density")` in `R/utils-matrix.R` calls `cond_log2_transform_matrix(..., rmzeros = TRUE)`, which turns zero entries into `NA` ahead of the log2 transform
- That `NA`-laden vector was fed straight into `stats::density()`, which errors with `'x' contains missing values` whenever a sample has any zero-valued entries
- `box_summary()` already filters to finite values for the equivalent boxplot path; the density path now does the same before computing the density

## Test plan
- [x] Added a regression test in `tests/testthat/test-utils-matrix.R` that reproduces the crash (a sample with a zero entry) and confirms the fix resolves it
- [x] Full `testthat::test_dir()` run: 442 passed, 0 failed
- [x] `lintr::lint_package()` clean on changed files

Fixes #249