### PR TITLE
test: add unit coverage for exported helpers and small pure-function modules

### DIFF
--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -30,6 +30,18 @@ test_that("nlines works", {
   expect_equal(as.character(hiddenInput("myid", "foo")), test_html)
 })
 
+# pushToList()
+
+test_that("pushToList appends an element to the end of a list", {
+  result <- pushToList(list("a", "b"), "c")
+  expect_equal(result, list("a", "b", "c"))
+})
+
+test_that("pushToList appends to an empty list", {
+  result <- pushToList(list(), "only")
+  expect_equal(result, list("only"))
+})
+
 # read_contrasts()
 
 test_that("read_contrasts parses YAML correctly", {

--- a/tests/testthat/test-boxplot.R
+++ b/tests/testthat/test-boxplot.R
@@ -134,3 +134,49 @@ test_that("plotly_boxplot bounds the number of outliers drawn", {
   total_outliers <- sum(vapply(outlier_traces, function(t) length(t$y), integer(1)))
   expect_lte(total_outliers, 20)
 })
+
+# ggplot_densityplot()
+
+test_that("ggplot_densityplot draws one density area per colorby level", {
+  set.seed(1)
+  mat <- matrix(rpois(80, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), paste0("s", 1:4)))
+  experiment <- data.frame(row.names = colnames(mat), condition = rep(c("control", "treated"), each = 2))
+
+  p <- ggplot_densityplot(mat, experiment, colorby = "condition")
+
+  expect_s3_class(p, "ggplot")
+  built <- ggplot2::ggplot_build(p)
+  expect_equal(length(unique(built$data[[1]]$fill)), 2)
+})
+
+test_that("ggplot_densityplot facets when given multiple matrices", {
+  mat1 <- matrix(rpois(40, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), c("s1", "s2")))
+  mat2 <- matrix(rpois(40, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"))
+
+  p <- ggplot_densityplot(list(Raw = mat1, Filtered = mat2), experiment)
+
+  expect_true("FacetWrap" %in% class(p$facet))
+})
+
+# plotly_densityplot()
+
+test_that("plotly_densityplot draws one density trace per colorby level", {
+  set.seed(1)
+  mat <- matrix(rpois(80, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), paste0("s", 1:4)))
+  experiment <- data.frame(row.names = colnames(mat), condition = rep(c("control", "treated"), each = 2))
+
+  built <- plotly::plotly_build(plotly_densityplot(mat, experiment, colorby = "condition"))
+
+  expect_length(built$x$data, 2)
+})
+
+test_that("plotly_densityplot subplots one panel per named matrix", {
+  mat1 <- matrix(rpois(40, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), c("s1", "s2")))
+  mat2 <- matrix(rpois(40, lambda = 30) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"), condition = c("control", "treated"))
+
+  built <- plotly::plotly_build(plotly_densityplot(list(Raw = mat1, Filtered = mat2), experiment, colorby = "condition"))
+
+  expect_length(built$x$data, 4)
+})

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -125,3 +125,50 @@ test_that("plotly_cluster_profiles uses a precomputed summarised_matrices_by_clu
   cluster3 <- built$x$data[[which(vapply(built$x$data, function(t) identical(as.character(t$name), "Cluster 3"), logical(1)))]]
   expect_true(all(as.numeric(cluster3$y) == 999))
 })
+
+# madScore()
+
+test_that("madScore flags a sample decorrelated from its group as an outlier", {
+  set.seed(1)
+  n_genes <- 50
+  base <- rnorm(n_genes)
+
+  # 4 samples correlated with each other, a 5th unrelated
+  correlated <- replicate(4, base + rnorm(n_genes, sd = 0.1))
+  outlier <- rnorm(n_genes)
+  mat <- cbind(correlated, outlier)
+  colnames(mat) <- paste0("s", 1:5)
+  rownames(mat) <- paste0("gene", seq_len(n_genes))
+
+  sample_sheet <- data.frame(group = rep("grp", 5), row.names = colnames(mat))
+
+  result <- madScore(mat, sample_sheet, groupby = "group")
+
+  expect_true(result["s5", "outlier"])
+  expect_false(any(result[paste0("s", 1:4), "outlier"]))
+})
+
+test_that("madScore warns and returns NULL when no group has enough replicates", {
+  mat <- matrix(rnorm(20), nrow = 5, dimnames = list(paste0("gene", 1:5), paste0("s", 1:4)))
+  sample_sheet <- data.frame(group = c("a", "a", "b", "b"), row.names = colnames(mat))
+
+  expect_warning(result <- madScore(mat, sample_sheet, groupby = "group"), "low replication")
+  expect_null(result)
+})
+
+test_that("madScore drops samples belonging to under-replicated groups before scoring", {
+  set.seed(2)
+  n_genes <- 30
+  base <- rnorm(n_genes)
+  valid_group <- replicate(3, base + rnorm(n_genes, sd = 0.1))
+  colnames(valid_group) <- paste0("v", 1:3)
+  invalid_group <- matrix(rnorm(n_genes * 2), nrow = n_genes, dimnames = list(NULL, c("i1", "i2")))
+
+  mat <- cbind(valid_group, invalid_group)
+  rownames(mat) <- paste0("gene", seq_len(n_genes))
+  sample_sheet <- data.frame(group = c(rep("valid", 3), rep("invalid", 2)), row.names = colnames(mat))
+
+  result <- madScore(mat, sample_sheet, groupby = "group")
+
+  expect_setequal(rownames(result), c("v1", "v2", "v3"))
+})

--- a/tests/testthat/test-genesetbarcodeplot.R
+++ b/tests/testthat/test-genesetbarcodeplot.R
@@ -1,0 +1,94 @@
+# tricubeMovingAverage()
+
+test_that("tricubeMovingAverage returns a smoothed vector of the same length", {
+  set.seed(1)
+  x <- rnorm(50)
+  smoothed <- tricubeMovingAverage(x, span = 0.5)
+
+  expect_length(smoothed, length(x))
+  expect_true(all(is.finite(smoothed)))
+})
+
+test_that("tricubeMovingAverage smooths a step function towards its local average", {
+  x <- c(rep(0, 25), rep(10, 25))
+  smoothed <- tricubeMovingAverage(x, span = 0.3)
+
+  # points well inside a flat run stay at the flat value
+  expect_equal(smoothed[5], 0)
+  expect_equal(smoothed[45], 10)
+
+  # points straddling the step are pulled towards an intermediate value
+  expect_true(smoothed[25] > 0 && smoothed[25] < 10)
+})
+
+test_that("tricubeMovingAverage returns x unchanged for span <= 0", {
+  x <- rnorm(10)
+  expect_equal(tricubeMovingAverage(x, span = 0), x)
+})
+
+test_that("tricubeMovingAverage clamps span above 1", {
+  x <- rnorm(20)
+  expect_equal(tricubeMovingAverage(x, span = 2), tricubeMovingAverage(x, span = 1))
+})
+
+# quantileOfSorted()
+
+test_that("quantileOfSorted matches quantile() type 7 on an already-sorted vector", {
+  x <- sort(c(3, 1, 4, 1, 5, 9, 2, 6))
+  probs <- c(0, 0.25, 0.5, 0.75, 1)
+
+  expect_equal(quantileOfSorted(x, probs), unname(quantile(x, probs, type = 7)))
+})
+
+test_that("quantileOfSorted returns the endpoints for probs 0 and 1", {
+  x <- sort(c(10, 2, 7, 4))
+  expect_equal(quantileOfSorted(x, 0), x[1])
+  expect_equal(quantileOfSorted(x, 1), x[length(x)])
+})
+
+# plotly_barcodeplot()
+
+test_that("plotly_barcodeplot draws a rug-tick trace and an enrichment worm curve", {
+  set.seed(1)
+  gene_ids <- paste0("gene", 1:100)
+  fold_changes <- rnorm(100)
+  set_gene_ids <- sample(gene_ids, 15)
+
+  built <- plotly::plotly_build(plotly_barcodeplot(fold_changes, gene_ids, set_gene_ids))
+
+  trace_names <- vapply(built$x$data, function(t) as.character(t$name), character(1))
+  expect_setequal(trace_names, c("Gene set", "Enrichment"))
+})
+
+test_that("plotly_barcodeplot handles no gene set members found in the ranked list", {
+  gene_ids <- paste0("gene", 1:20)
+  fold_changes <- rnorm(20)
+
+  p <- suppressWarnings(plotly_barcodeplot(fold_changes, gene_ids, set_gene_ids = "not_present"))
+  built <- suppressWarnings(plotly::plotly_build(p))
+
+  trace_names <- vapply(built$x$data, function(t) if (is.null(t$name)) NA_character_ else as.character(t$name), character(1))
+  expect_false(any(trace_names %in% c("Gene set", "Enrichment")))
+  annotation_texts <- vapply(built$x$layout$annotations, function(a) a$text, character(1))
+  expect_true(any(grepl("No genes from this set", annotation_texts)))
+})
+
+test_that("plotly_barcodeplot drops NA fold changes before ranking", {
+  gene_ids <- paste0("gene", 1:10)
+  fold_changes <- c(rnorm(9), NA)
+  set_gene_ids <- gene_ids[1:3]
+
+  built <- plotly::plotly_build(plotly_barcodeplot(fold_changes, gene_ids, set_gene_ids))
+
+  # x axis range covers only the 9 non-NA genes
+  expect_equal(built$x$layout$xaxis$range, c(0.5, 9.5))
+})
+
+test_that("plotly_barcodeplot converts newlines in the title to <br> tags", {
+  gene_ids <- paste0("gene", 1:10)
+  fold_changes <- rnorm(10)
+
+  built <- plotly::plotly_build(plotly_barcodeplot(fold_changes, gene_ids, set_gene_ids = gene_ids[1], plot_title = "line one\nline two"))
+
+  expect_equal(built$x$layout$title, "line one<br>line two")
+})

--- a/tests/testthat/test-genesetselect.R
+++ b/tests/testthat/test-genesetselect.R
@@ -1,0 +1,16 @@
+# prettifyGeneSetName()
+
+test_that("prettifyGeneSetName keeps the first word and lower-cases the rest", {
+  expect_equal(prettifyGeneSetName("KEGG_GLYCOLYSIS_GLUCONEOGENESIS"), "KEGG glycolysis gluconeogenesis")
+})
+
+test_that("prettifyGeneSetName leaves a single-word name with a trailing space", {
+  expect_equal(prettifyGeneSetName("KEGG"), "KEGG ")
+})
+
+test_that("prettifyGeneSetName vectorises over multiple gene set names", {
+  expect_equal(
+    prettifyGeneSetName(c("KEGG_GLYCOLYSIS", "GO_CELL_CYCLE")),
+    c("KEGG glycolysis", "GO cell cycle")
+  )
+})

--- a/tests/testthat/test-groupby.R
+++ b/tests/testthat/test-groupby.R
@@ -1,0 +1,79 @@
+make_groupby_eselist <- function() {
+  mat <- matrix(1:8, nrow = 2, dimnames = list(c("g1", "g2"), paste0("s", 1:4)))
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(mat),
+    condition = c("ctrl", "ctrl", "treated", "treated"),
+    batch = c("b1", "b2", "b1", "b2")
+  )
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat), colData = coldata,
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  ExploratorySummarizedExperimentList(list(counts = ese), group_vars = c("condition", "batch"), default_groupvar = "condition")
+}
+
+test_that("getGroupby returns the selected grouping variable", {
+  eselist <- make_groupby_eselist()
+
+  shiny::testServer(groupby, args = list(id = "grp", eselist = eselist), {
+    session$setInputs(groupby = "batch", "groupby-palette_name" = "colorblind")
+    expect_equal(getGroupby(), "batch")
+  })
+})
+
+test_that("getGroupby returns NULL when group_vars is empty (hidden 'NULL' field)", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat), colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese), group_vars = character(0))
+
+  shiny::testServer(groupby, args = list(id = "grp", eselist = eselist), {
+    session$setInputs(groupby = "NULL", "groupby-palette_name" = "colorblind")
+    expect_null(getGroupby())
+  })
+})
+
+test_that("getNumberCategories counts the unique values of the selected group in the supplied experiment data", {
+  eselist <- make_groupby_eselist()
+  coldata <- data.frame(condition = c("ctrl", "ctrl", "treated", "treated"), row.names = paste0("s", 1:4))
+
+  shiny::testServer(
+    groupby,
+    args = list(id = "grp", eselist = eselist, selectColData = reactive(coldata)),
+    {
+      session$setInputs(groupby = "condition", "groupby-palette_name" = "colorblind")
+      expect_equal(getNumberCategories(), 2)
+    }
+  )
+})
+
+test_that("getPalette returns one colour per category", {
+  eselist <- make_groupby_eselist()
+  coldata <- data.frame(condition = c("ctrl", "ctrl", "treated", "treated"), row.names = paste0("s", 1:4))
+
+  shiny::testServer(
+    groupby,
+    args = list(id = "grp", eselist = eselist, selectColData = reactive(coldata)),
+    {
+      session$setInputs(groupby = "condition", "groupby-palette_name" = "colorblind")
+      expect_length(getPalette(), 2)
+    }
+  )
+})
+
+test_that("groupby returns a checkbox-backed multi-selection when multiple = TRUE", {
+  eselist <- make_groupby_eselist()
+
+  shiny::testServer(
+    groupby,
+    args = list(id = "grp", eselist = eselist, multiple = TRUE),
+    {
+      session$setInputs(groupby = c("condition", "batch"), "groupby-palette_name" = "colorblind")
+      expect_equal(getGroupby(), c("condition", "batch"))
+    }
+  )
+})

--- a/tests/testthat/test-hometab.R
+++ b/tests/testthat/test-hometab.R
@@ -1,0 +1,66 @@
+# navLink()
+
+test_that("navLink builds an anchor that shows the target tabPanel client-side", {
+  result <- navLink("Sample metadata", "Experiment")
+  html <- as.character(result)
+
+  expect_true(grepl("Sample metadata", html, fixed = TRUE))
+  expect_true(grepl("data-value=&quot;Experiment&quot;", html, fixed = TRUE))
+  expect_true(grepl("tab(&#39;show&#39;)", html, fixed = TRUE))
+})
+
+test_that("navLink includes an optional icon and class", {
+  result <- navLink("PCA", "pca", class = "my-class", icon = shiny::icon("cube"))
+  html <- as.character(result)
+
+  expect_true(grepl('class="my-class"', html, fixed = TRUE))
+  expect_true(grepl("fa-cube", html, fixed = TRUE))
+})
+
+# homeNavTargets()
+
+test_that("homeNavTargets returns the expected named tab targets", {
+  targets <- homeNavTargets()
+
+  expect_equal(
+    targets,
+    c(
+      samples = "Experiment", pca = "pca", assay = "assay_tables",
+      differential = "diff_tables", genesets = "geneset_analyses", geneinfo = "geneinfo"
+    )
+  )
+})
+
+# homeTab()
+
+make_hometab_eselist <- function(with_contrasts = FALSE) {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  contrasts <- if (with_contrasts) list(list(id = "c1")) else list()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese), title = "My Study", author = "A. Person", description = "A description")
+  eselist@contrasts <- contrasts
+  eselist
+}
+
+test_that("homeTab produces a Home nav_panel with the study title and author", {
+  eselist <- make_hometab_eselist()
+  result <- homeTab(shiny::NS("app"), eselist)
+
+  html <- as.character(result)
+  expect_true(grepl("My Study", html, fixed = TRUE))
+  expect_true(grepl("A. Person", html, fixed = TRUE))
+  expect_true(grepl("A description", html, fixed = TRUE))
+})
+
+test_that("homeTab only links to differential results when contrasts are present", {
+  without_contrasts <- as.character(homeTab(shiny::NS("app"), make_hometab_eselist(with_contrasts = FALSE)))
+  with_contrasts <- as.character(homeTab(shiny::NS("app"), make_hometab_eselist(with_contrasts = TRUE)))
+
+  expect_false(grepl("Differential results", without_contrasts, fixed = TRUE))
+  expect_true(grepl("Differential results", with_contrasts, fixed = TRUE))
+})

--- a/tests/testthat/test-scatterplotcontrols.R
+++ b/tests/testthat/test-scatterplotcontrols.R
@@ -1,0 +1,80 @@
+make_scatterplot_matrix <- function() {
+  matrix(1:12, nrow = 4, dimnames = list(paste0("s", 1:4), c("PC1", "PC2", "PC3")))
+}
+
+test_that("getXAxis/getYAxis/getZAxis return the selected axis columns in 3D mode", {
+  m <- make_scatterplot_matrix()
+
+  shiny::testServer(
+    scatterplotcontrols,
+    args = list(id = "scatter", getDatamatrix = reactive(m)),
+    {
+      session$setInputs(threedee = "TRUE", xAxis = 1, yAxis = 2, zAxis = 3, showLabels = FALSE, pointSize = 5)
+      session$elapse(400)
+
+      expect_equal(getXAxis(), 1)
+      expect_equal(getYAxis(), 2)
+      expect_equal(getZAxis(), 3)
+      expect_true(getThreedee())
+    }
+  )
+})
+
+test_that("getZAxis is NULL in 2D mode even if a zAxis input exists", {
+  m <- make_scatterplot_matrix()
+
+  shiny::testServer(
+    scatterplotcontrols,
+    args = list(id = "scatter", getDatamatrix = reactive(m)),
+    {
+      session$setInputs(threedee = "FALSE", xAxis = 1, yAxis = 2, showLabels = FALSE, pointSize = 5)
+      session$elapse(400)
+
+      expect_false(getThreedee())
+      expect_null(getZAxis())
+    }
+  )
+})
+
+test_that("getShowLabels and getPointSize reflect their inputs", {
+  m <- make_scatterplot_matrix()
+
+  shiny::testServer(
+    scatterplotcontrols,
+    args = list(id = "scatter", getDatamatrix = reactive(m)),
+    {
+      session$setInputs(threedee = "TRUE", xAxis = 1, yAxis = 2, zAxis = 3, showLabels = TRUE, pointSize = 12)
+      session$elapse(400)
+
+      expect_true(getShowLabels())
+      expect_equal(getPointSize(), 12)
+    }
+  )
+})
+
+test_that("supplying makeColors adds a getScatterPalette reactive to the returned list", {
+  m <- make_scatterplot_matrix()
+
+  shiny::testServer(
+    scatterplotcontrols,
+    args = list(id = "scatter", getDatamatrix = reactive(m), makeColors = reactive(3)),
+    {
+      session$setInputs(threedee = "FALSE", xAxis = 1, yAxis = 2, showLabels = FALSE, pointSize = 5, "scatterplot-palette_name" = "colorblind")
+      session$elapse(400)
+
+      expect_length(reactives$getScatterPalette(), 3)
+    }
+  )
+})
+
+test_that("no getScatterPalette reactive is in the returned list when makeColors is not supplied", {
+  m <- make_scatterplot_matrix()
+
+  shiny::testServer(
+    scatterplotcontrols,
+    args = list(id = "scatter", getDatamatrix = reactive(m)),
+    {
+      expect_null(reactives$getScatterPalette)
+    }
+  )
+})

--- a/tests/testthat/test-selectmatrix.R
+++ b/tests/testthat/test-selectmatrix.R
@@ -1,0 +1,107 @@
+make_labelled_ese <- function() {
+  mat <- matrix(1:6, nrow = 3, dimnames = list(c("g1", "g2", "g3"), c("s1", "s2")))
+  annotation <- data.frame(
+    gene_id = c("g1", "g2", "g3"),
+    gene_name = c("GeneA", "GeneB", NA),
+    row.names = c("g1", "g2", "g3")
+  )
+  ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = "gene_name"
+  )
+}
+
+# idToLabel()
+
+test_that("idToLabel combines the label field with the id, separated by sep", {
+  ese <- make_labelled_ese()
+
+  expect_equal(idToLabel(c("g1", "g2"), ese), c("GeneA / g1", "GeneB / g2"))
+})
+
+test_that("idToLabel falls back to the bare id where the label is NA", {
+  ese <- make_labelled_ese()
+
+  expect_equal(idToLabel("g3", ese), "g3")
+})
+
+test_that("idToLabel returns ids unchanged when no labelfield is set", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+
+  expect_equal(idToLabel(c("g1", "g2"), ese), c("g1", "g2"))
+})
+
+test_that("idToLabel accepts a custom separator", {
+  ese <- make_labelled_ese()
+  expect_equal(idToLabel("g1", ese, sep = "-"), "GeneA-g1")
+})
+
+# convertIds()
+
+test_that("convertIds maps row names to a metadata column", {
+  ese <- make_labelled_ese()
+
+  expect_equal(convertIds(c("g1", "g2"), ese, "gene_name"), c("GeneA", "GeneB"))
+})
+
+test_that("convertIds splits and re-joins space-separated multi-value ids", {
+  ese <- make_labelled_ese()
+
+  expect_equal(convertIds("g1 g2", ese, "gene_name"), "GeneA GeneB")
+})
+
+test_that("convertIds can drop unmatched/NA results", {
+  ese <- make_labelled_ese()
+
+  expect_equal(convertIds(c("g1", "g3"), ese, "gene_name", remove_na = TRUE), "GeneA")
+})
+
+# singleValidMatrix()
+
+test_that("singleValidMatrix is TRUE for a single experiment with a single assay", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  expect_true(singleValidMatrix(eselist))
+})
+
+test_that("singleValidMatrix is FALSE when the single experiment has multiple assays", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat, norm = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  expect_false(singleValidMatrix(eselist))
+})
+
+test_that("singleValidMatrix is FALSE for multiple experiments", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+  eselist <- ExploratorySummarizedExperimentList(list(a = ese, b = ese))
+
+  expect_false(singleValidMatrix(eselist))
+})

--- a/tests/testthat/test-simpletable.R
+++ b/tests/testthat/test-simpletable.R
@@ -1,0 +1,81 @@
+test_that("simpletable renders the display matrix as a datatable", {
+  df <- data.frame(gene = c("g1", "g2"), value = c(1, 2))
+
+  shiny::testServer(
+    simpletable,
+    args = list(id = "tbl", displayMatrix = reactive(df), filename = "mytable"),
+    {
+      session$elapse(400)
+      expect_false(is.null(output$datatable))
+    }
+  )
+})
+
+test_that("simpletable's download handler writes downloadMatrix, not displayMatrix, to CSV", {
+  display_df <- data.frame(gene = c("g1", "g2"), value = c("<b>1</b>", "<b>2</b>"))
+  download_df <- data.frame(gene = c("g1", "g2"), value = c(1, 2))
+
+  shiny::testServer(
+    simpletable,
+    args = list(
+      id = "tbl", displayMatrix = reactive(display_df), downloadMatrix = reactive(download_df),
+      filename = "mytable"
+    ),
+    {
+      path <- output$downloadTable
+      expect_equal(read.csv(path), download_df)
+    }
+  )
+})
+
+test_that("simpletable falls back to displayMatrix for download when downloadMatrix is not supplied", {
+  df <- data.frame(gene = c("g1", "g2"), value = c(1, 2))
+
+  shiny::testServer(
+    simpletable,
+    args = list(id = "tbl", displayMatrix = reactive(df), filename = "mytable"),
+    {
+      path <- output$downloadTable
+      expect_equal(read.csv(path), df)
+    }
+  )
+})
+
+test_that("simpletable's download filename uses the supplied filename with a .csv extension", {
+  df <- data.frame(gene = "g1", value = 1)
+
+  shiny::testServer(
+    simpletable,
+    args = list(id = "tbl", displayMatrix = reactive(df), filename = "my_custom_name"),
+    {
+      path <- output$downloadTable
+      expect_equal(basename(path), "my_custom_name.csv")
+    }
+  )
+})
+
+test_that("simpletable accepts a reactive filename", {
+  df <- data.frame(gene = "g1", value = 1)
+
+  shiny::testServer(
+    simpletable,
+    args = list(id = "tbl", displayMatrix = reactive(df), filename = reactive("reactive_name")),
+    {
+      path <- output$downloadTable
+      expect_equal(basename(path), "reactive_name.csv")
+    }
+  )
+})
+
+test_that("simpletable's download omits row names by default", {
+  df <- data.frame(value = c(1, 2), row.names = c("g1", "g2"))
+
+  shiny::testServer(
+    simpletable,
+    args = list(id = "tbl", displayMatrix = reactive(df), filename = "mytable"),
+    {
+      path <- output$downloadTable
+      expect_false("X" %in% colnames(read.csv(path)))
+    }
+  )
+})

--- a/tests/testthat/test-summarisematrix.R
+++ b/tests/testthat/test-summarisematrix.R
@@ -1,0 +1,72 @@
+# summarizeMatrix()
+
+test_that("summarizeMatrix averages columns by treatment group", {
+  m <- matrix(1:8, nrow = 2, dimnames = list(c("g1", "g2"), paste0("s", 1:4)))
+  treatment <- c("A", "A", "B", "B")
+
+  summarized <- summarizeMatrix(m, treatment)
+
+  expect_equal(colnames(summarized), c("A", "B"))
+  expect_equal(summarized["g1", "A"], mean(m["g1", 1:2]))
+  expect_equal(summarized["g1", "B"], mean(m["g1", 3:4]))
+})
+
+test_that("summarizeMatrix accepts a character vector and coerces it to a factor", {
+  m <- matrix(1:8, nrow = 2, dimnames = list(c("g1", "g2"), paste0("s", 1:4)))
+  by_factor <- summarizeMatrix(m, factor(c("A", "A", "B", "B")))
+  by_character <- summarizeMatrix(m, c("A", "A", "B", "B"))
+
+  expect_equal(by_factor, by_character)
+})
+
+test_that("summarizeMatrix replaces NA treatment levels with a group of their own", {
+  m <- matrix(1:8, nrow = 2, dimnames = list(c("g1", "g2"), paste0("s", 1:4)))
+  treatment <- c("A", NA, "B", "B")
+
+  summarized <- summarizeMatrix(m, treatment)
+
+  expect_true("NA" %in% colnames(summarized))
+  expect_equal(summarized["g1", "NA"], m["g1", 2])
+})
+
+test_that("summarizeMatrix supports colGeomMeans and colMedians as summary functions", {
+  m <- matrix(c(1, 2, 4, 8), nrow = 1, dimnames = list("g1", paste0("s", 1:4)))
+  treatment <- c("A", "A", "B", "B")
+
+  geom <- summarizeMatrix(m, treatment, summaryFunc = "colGeomMeans")
+  med <- summarizeMatrix(m, treatment, summaryFunc = "colMedians")
+
+  expect_equal(geom["g1", "A"], sqrt(1 * 2))
+  expect_equal(med["g1", "B"], median(c(4, 8)))
+})
+
+# colGeomMeans()
+
+test_that("colGeomMeans computes the geometric mean of each column", {
+  x <- matrix(c(1, 4, 2, 8), nrow = 2, dimnames = list(NULL, c("a", "b")))
+
+  result <- colGeomMeans(x)
+
+  expect_equal(unname(result), c(sqrt(1 * 4), sqrt(2 * 8)))
+  expect_equal(names(result), c("a", "b"))
+})
+
+test_that("colGeomMeans ignores non-positive and missing values", {
+  x <- matrix(c(1, 4, NA, 0, -1, 9), nrow = 3, dimnames = list(NULL, c("a", "b")))
+
+  result <- colGeomMeans(x)
+
+  # column a: only 1 and 4 are positive
+  expect_equal(unname(result["a"]), exp((log(1) + log(4)) / 3))
+})
+
+# colMedians()
+
+test_that("colMedians computes the median of each column", {
+  x <- matrix(c(1, 2, 3, 10, 20, 30), nrow = 3, dimnames = list(NULL, c("a", "b")))
+
+  result <- colMedians(x)
+
+  expect_equal(unname(result), c(2, 20))
+  expect_equal(names(result), c("a", "b"))
+})

--- a/tests/testthat/test-ui-fields.R
+++ b/tests/testthat/test-ui-fields.R
@@ -1,0 +1,84 @@
+# withHelpIcon()
+
+test_that("withHelpIcon returns the label unchanged when no tooltip is given", {
+  expect_equal(withHelpIcon("Some label"), "Some label")
+})
+
+test_that("withHelpIcon attaches a tooltip-triggering icon when tooltip is given", {
+  result <- withHelpIcon("Some label", "Explains the field")
+  html <- as.character(result)
+
+  expect_true(grepl("Some label", html, fixed = TRUE))
+  expect_true(grepl("circle-info", html, fixed = TRUE))
+  expect_true(grepl("Explains the field", html, fixed = TRUE))
+})
+
+# inlineField()
+
+test_that("inlineField wraps a field definition with an inline bold label", {
+  result <- inlineField(shiny::numericInput("foo", label = NULL, value = 50), "FOO")
+  html <- as.character(result)
+
+  expect_true(grepl("<b>FOO:</b>", html, fixed = TRUE))
+  expect_true(grepl("id=\"foo\"", html, fixed = TRUE))
+})
+
+test_that("inlineField passes a tooltip through to the label", {
+  result <- inlineField(shiny::numericInput("foo", label = NULL, value = 50), "FOO", tooltip = "A tooltip")
+  html <- as.character(result)
+
+  expect_true(grepl("A tooltip", html, fixed = TRUE))
+})
+
+# a11yControl()
+
+test_that("a11yControl sets an aria-label and wraps the tag in a tooltip", {
+  result <- a11yControl(shiny::actionButton("btn", "Click"), label = "Click the button")
+  html <- as.character(result)
+
+  expect_true(grepl('aria-label="Click the button"', html, fixed = TRUE))
+})
+
+test_that("a11yControl defaults the tooltip text to the label", {
+  with_label_only <- as.character(a11yControl(shiny::actionButton("btn", "Click"), label = "Click the button"))
+  with_explicit_tooltip <- as.character(a11yControl(shiny::actionButton("btn", "Click"), label = "Click the button", tooltip = "Click the button"))
+
+  expect_equal(with_label_only, with_explicit_tooltip)
+})
+
+# cardinalNumericField()
+
+test_that("cardinalNumericField builds a labelled numeric field with a cardinality selector", {
+  result <- cardinalNumericField("val", "val_cardinality", "Fold change", value = 2, cardinality = ">=")
+  html <- as.character(result)
+
+  expect_true(grepl("<b>Fold change:</b>", html, fixed = TRUE))
+  expect_true(grepl('id="val"', html, fixed = TRUE))
+  expect_true(grepl('id="val_cardinality"', html, fixed = TRUE))
+  expect_true(grepl("shinyngs-cardinalfield", html, fixed = TRUE))
+})
+
+# evaluateCardinalFilter()
+
+test_that("evaluateCardinalFilter applies '<=' and '>='", {
+  values <- c(-5, -1, 0, 1, 5, NA)
+
+  expect_equal(evaluateCardinalFilter(values, "<=", 1), c(TRUE, TRUE, TRUE, TRUE, FALSE, FALSE))
+  expect_equal(evaluateCardinalFilter(values, ">=", 1), c(FALSE, FALSE, FALSE, TRUE, TRUE, FALSE))
+})
+
+test_that("evaluateCardinalFilter applies the symmetric '>= or <= -' cardinality", {
+  values <- c(-5, -1, 0, 1, 5, NA)
+
+  expect_equal(evaluateCardinalFilter(values, ">= or <= -", 2), c(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE))
+})
+
+test_that("evaluateCardinalFilter applies the symmetric '<= and >= -' cardinality", {
+  values <- c(-5, -1, 0, 1, 5, NA)
+
+  expect_equal(evaluateCardinalFilter(values, "<= and >= -", 2), c(FALSE, TRUE, TRUE, TRUE, FALSE, FALSE))
+})
+
+test_that("evaluateCardinalFilter errors on an unrecognised cardinality", {
+  expect_error(evaluateCardinalFilter(1:3, "nonsense", 1), "invalid cardinality")
+})

--- a/tests/testthat/test-utils-matrix.R
+++ b/tests/testthat/test-utils-matrix.R
@@ -1,0 +1,114 @@
+# melt_matrix()
+
+test_that("melt_matrix reshapes a matrix to long format with named dimensions", {
+  m <- matrix(1:6, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2", "c3")))
+
+  out <- melt_matrix(m)
+
+  expect_equal(colnames(out), c("Var1", "Var2", "value"))
+  expect_equal(nrow(out), 6)
+  expect_equal(out$value, as.integer(m))
+  expect_equal(as.character(out$Var1), rep(c("r1", "r2"), 3))
+})
+
+test_that("melt_matrix uses integer indices when dimnames are absent", {
+  m <- matrix(1:4, nrow = 2)
+
+  out <- melt_matrix(m)
+
+  expect_true(is.integer(out$Var1))
+  expect_true(is.integer(out$Var2))
+  expect_equal(out$Var1, rep(1:2, 2))
+})
+
+test_that("melt_matrix accepts custom varnames and value.name", {
+  m <- matrix(1:4, nrow = 2, dimnames = list(c("r1", "r2"), c("c1", "c2")))
+
+  out <- melt_matrix(m, varnames = c("gene", "sample"), value.name = "expr")
+
+  expect_equal(colnames(out), c("gene", "sample", "expr"))
+})
+
+# interleaveColumns()
+
+test_that("interleaveColumns alternates columns from the two input matrices", {
+  mat1 <- matrix(1:4, nrow = 2, dimnames = list(NULL, c("a1", "a2")))
+  mat2 <- matrix(5:8, nrow = 2, dimnames = list(NULL, c("b1", "b2")))
+
+  result <- interleaveColumns(mat1, mat2)
+
+  expect_equal(colnames(result), c("a1", "b1", "a2", "b2"))
+  expect_equal(result[, "a1"], mat1[, "a1"])
+  expect_equal(result[, "b2"], mat2[, "b2"])
+})
+
+test_that("interleaveColumns preserves row count and dimension", {
+  mat1 <- matrix(1:6, nrow = 3, dimnames = list(NULL, c("a1", "a2")))
+  mat2 <- matrix(7:12, nrow = 3, dimnames = list(NULL, c("b1", "b2")))
+
+  result <- interleaveColumns(mat1, mat2)
+
+  expect_equal(dim(result), c(3, 4))
+})
+
+# ggplotify()
+
+test_that("ggplotify melts a matrix, dropping non-positive values", {
+  mat <- matrix(c(0, 2, 4, 8), nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"), grp = c("A", "B"))
+
+  out <- ggplotify(mat, experiment, should_transform = FALSE)
+
+  expect_true(all(c("gene", "name", "value", "type") %in% colnames(out)))
+  expect_equal(nrow(out), 3) # the single zero value (g1/s1) is dropped
+  expect_true(all(out$value > 0))
+})
+
+test_that("ggplotify adds a colorby column, ordering samples by group", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"), grp = c("B", "A"))
+
+  out <- ggplotify(mat, experiment, colorby = "grp", should_transform = FALSE)
+
+  expect_true("colorby" %in% colnames(out))
+  expect_equal(levels(out$colorby), c("B", "A")) # experiment's own row order, not alphabetical
+})
+
+test_that("ggplotify annotates sample names with their group when requested", {
+  mat <- matrix(1:4, nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"), grp = c("A", "B"))
+
+  out <- ggplotify(mat, experiment, colorby = "grp", annotate_samples = TRUE, should_transform = FALSE)
+
+  expect_true(all(grepl("\\(A\\)|\\(B\\)", as.character(out$name))))
+})
+
+test_that("ggplotify respects should_transform = TRUE by log2-transforming values", {
+  mat <- matrix(c(1, 2, 4, 8), nrow = 2, dimnames = list(c("g1", "g2"), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"))
+
+  out <- ggplotify(mat, experiment, should_transform = TRUE)
+
+  expect_equal(sort(out$value), sort(log2(c(1, 2, 4, 8))))
+})
+
+test_that("ggplotify computes densities when value_type is 'density'", {
+  set.seed(1)
+  mat <- matrix(rpois(40, lambda = 20) + 1, nrow = 20, dimnames = list(paste0("g", 1:20), c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"))
+
+  out <- ggplotify(mat, experiment, value_type = "density", should_transform = FALSE)
+
+  expect_true(all(c("name", "value", "density") %in% colnames(out)))
+})
+
+test_that("ggplotify concatenates a named list of matrices, tagging each with its type", {
+  mat1 <- matrix(c(1, 2), nrow = 1, dimnames = list("g1", c("s1", "s2")))
+  mat2 <- matrix(c(3, 4), nrow = 1, dimnames = list("g1", c("s1", "s2")))
+  experiment <- data.frame(row.names = c("s1", "s2"))
+
+  out <- ggplotify(list(Raw = mat1, Filtered = mat2), experiment, should_transform = FALSE)
+
+  expect_setequal(as.character(unique(out$type)), c("Raw", "Filtered"))
+  expect_equal(levels(out$type), c("Raw", "Filtered")) # first-seen order preserved
+})

--- a/tests/testthat/test-utils-string.R
+++ b/tests/testthat/test-utils-string.R
@@ -1,0 +1,100 @@
+# simpleSplit()
+
+test_that("simpleSplit splits a delimited string into a character vector", {
+  expect_equal(simpleSplit("a,b,c"), c("a", "b", "c"))
+})
+
+test_that("simpleSplit supports a custom separator", {
+  expect_equal(simpleSplit("a;b;c", sep = ";"), c("a", "b", "c"))
+})
+
+test_that("simpleSplit returns NA unchanged", {
+  expect_equal(simpleSplit(NA), NA)
+})
+
+# getExtension()
+
+test_that("getExtension extracts a lower-cased file extension", {
+  expect_equal(getExtension("data.CSV"), "csv")
+  expect_equal(getExtension("/some/path/data.tsv"), "tsv")
+})
+
+test_that("getExtension uses the last extension of a multi-dot filename", {
+  expect_equal(getExtension("archive.tar.gz"), "gz")
+})
+
+# getSeparator()
+
+test_that("getSeparator infers tab for tsv/txt and comma for csv", {
+  expect_equal(getSeparator("data.tsv"), "\t")
+  expect_equal(getSeparator("data.txt"), "\t")
+  expect_equal(getSeparator("data.csv"), ",")
+})
+
+test_that("getSeparator errors for an unrecognised extension", {
+  expect_error(getSeparator("data.xyz"), "Unknown separator")
+})
+
+# stringsToNamedVector()
+
+test_that("stringsToNamedVector names elements from their own prettified values by default", {
+  result <- stringsToNamedVector("foo_bar,baz_qux")
+
+  expect_equal(unname(result), c("foo_bar", "baz_qux"))
+  expect_equal(names(result), c("Foo bar", "Baz qux"))
+})
+
+test_that("stringsToNamedVector uses a separate names string when supplied", {
+  result <- stringsToNamedVector("a,b", names_string = "First,Second", prettify_names = FALSE)
+
+  expect_equal(unname(result), c("a", "b"))
+  expect_equal(names(result), c("First", "Second"))
+})
+
+test_that("stringsToNamedVector errors when elements and names differ in length", {
+  expect_error(
+    stringsToNamedVector("a,b,c", names_string = "First,Second"),
+    "different length"
+  )
+})
+
+test_that("stringsToNamedVector simplifies file paths to names when requested", {
+  result <- stringsToNamedVector(
+    "/path/to/sample_one.tsv,/path/to/sample_two.tsv",
+    simplify_files = TRUE, prettify_names = FALSE
+  )
+
+  expect_equal(names(result), c("sample one", "sample two"))
+})
+
+# splitStringToFixedwidthLines()
+
+test_that("splitStringToFixedwidthLines wraps a long string at word boundaries", {
+  result <- splitStringToFixedwidthLines("once upon a time there was a giant", linewidth = 10)
+
+  lines <- strsplit(result, "\n")[[1]]
+  expect_true(length(lines) > 1)
+  expect_equal(paste(lines, collapse = " "), "once upon a time there was a giant")
+})
+
+test_that("splitStringToFixedwidthLines leaves a short string on one line", {
+  expect_equal(splitStringToFixedwidthLines("short string", linewidth = 30), "short string")
+})
+
+# na.replace()
+
+test_that("na.replace substitutes NAs in a character vector", {
+  expect_equal(na.replace(c("a", NA, "b")), c("a", "NA", "b"))
+})
+
+test_that("na.replace accepts a custom replacement value", {
+  expect_equal(na.replace(c("a", NA), replacement = "missing"), c("a", "missing"))
+})
+
+test_that("na.replace preserves factor class and levels", {
+  f <- factor(c("a", NA, "b"))
+  result <- na.replace(f)
+
+  expect_true(is.factor(result))
+  expect_equal(as.character(result), c("a", "NA", "b"))
+})

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -1,0 +1,61 @@
+# validateOrCatch()
+
+test_that("validateOrCatch returns the value of a successful expression", {
+  expect_equal(validateOrCatch(1 + 1), 2)
+})
+
+test_that("validateOrCatch converts an error into a shiny.silent.error carrying the original message", {
+  err <- tryCatch(
+    validateOrCatch(stop("boom")),
+    error = function(e) e
+  )
+
+  expect_s3_class(err, "shiny.silent.error")
+  expect_equal(conditionMessage(err), "boom")
+})
+
+# validate_indices()
+
+test_that("validate_indices accepts a comma-separated list of integer indices", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3), c = matrix(1:6, ncol = 2))
+
+  expect_equal(validate_indices(assay_data, "1,2"), c(1, 2))
+})
+
+test_that("validate_indices accepts a comma-separated list of assay names, prettified to match", {
+  # prettify_names defaults to TRUE, so the supplied names must be matched
+  # against assay names in their prettified form
+  assay_data <- list(A = matrix(1:9, ncol = 3), B = matrix(1:12, ncol = 3), C = matrix(1:6, ncol = 2))
+
+  expect_equal(validate_indices(assay_data, "a,b"), c("A", "B"))
+})
+
+test_that("validate_indices can skip name prettification", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3))
+
+  expect_equal(validate_indices(assay_data, "a,b", prettify_names = FALSE), c("a", "b"))
+})
+
+test_that("validate_indices errors on an invalid assay name", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3))
+
+  expect_error(validate_indices(assay_data, "a,nonsense", prettify_names = FALSE), "Invalid assays")
+})
+
+test_that("validate_indices errors on an out-of-range integer index", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3))
+
+  expect_error(validate_indices(assay_data, "1,5"), "Invalid assays")
+})
+
+test_that("validate_indices can invert a name-based selection", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3), c = matrix(1:6, ncol = 2))
+
+  expect_equal(validate_indices(assay_data, "a,b", invert_assays = TRUE, prettify_names = FALSE), "c")
+})
+
+test_that("validate_indices can invert an integer-index selection", {
+  assay_data <- list(a = matrix(1:9, ncol = 3), b = matrix(1:12, ncol = 3), c = matrix(1:6, ncol = 2))
+
+  expect_equal(validate_indices(assay_data, "1,2", invert_assays = TRUE), 3)
+})


### PR DESCRIPTION
## Summary
- Adds direct unit tests for 21 previously-untested exported helper functions: `plotly_barcodeplot`, `summarizeMatrix`/`colGeomMeans`/`colMedians`, `madScore`, `idToLabel`/`convertIds`/`singleValidMatrix`, `interleaveColumns`, `prettifyGeneSetName`, `ggplot_densityplot`/`plotly_densityplot`, the `utils-string` helpers (`na.replace`, `pushToList`, `stringsToNamedVector`, `simpleSplit`, `getExtension`, `getSeparator`, `splitStringToFixedwidthLines`), `validate_indices`, `validateOrCatch`
- Adds coverage for 6 small modules that are mostly plain/pure functions: `ui-fields`, `utils-matrix`, `hometab`, `groupby`, `scatterplotcontrols`, `simpletable`
- No changes to `R/` source, tests only

Part 1 of 4 addressing #242 (test coverage gaps). The remaining parts (medium composed-module tests, large/composed-module tests, and the shinytest2 smoke-test extension to chipseq/illuminaarray/heatmap) will follow as separate PRs.

## Test plan
- [x] `devtools::test()` — 0 failures (684 pass, pre-existing warnings only, in files not touched by this PR)
- [x] `lintr::lint_package()` — no lints

🤖 Generated with [Claude Code](https://claude.com/claude-code)