### PR TITLE
Fix top-gene boxplot legend rendering off the bottom of the figure

### DIFF
--- a/R/topgeneboxplot.R
+++ b/R/topgeneboxplot.R
@@ -39,16 +39,26 @@ topgeneRankOptions <- function(available_columns) {
 # text. These are fixed absolute pixel targets rather than a constant margin
 # *fraction* of the total figure, because a fixed fraction shrinks in
 # absolute terms as the figure gets shorter (fewer rows) - which is what let
-# a low gene count's rows visually overlap. The values below (and the legend
-# y offset in plotly_topgene_boxplots()) were tuned empirically against
-# rendered output rather than derived analytically, since plotly's own
-# spacing between an axis title and a legend anchored below it isn't exposed
-# as a documented, computable quantity; they may need revisiting if the
-# facet title's font size or line count changes materially.
+# a low gene count's rows visually overlap. The values below were tuned
+# empirically against rendered output rather than derived analytically,
+# since plotly's own spacing between an axis title and a legend anchored
+# below it isn't exposed as a documented, computable quantity; they may need
+# revisiting if the facet title's font size or line count changes
+# materially.
 topgeneboxplot_row_px <- 220
 topgeneboxplot_gap_px <- 230
 topgeneboxplot_outer_top_px <- 30
 topgeneboxplot_outer_bottom_px <- 170
+
+# How far above the very bottom of the figure (in pixels) the legend sits.
+# The legend is positioned with yref = "container" so this is a fixed
+# distance from the figure's bottom edge regardless of row count; anchoring
+# it in "paper" coordinates instead (the plotly default) places it relative
+# to the plotting area's height, which grows with each extra row, so the
+# same fractional offset pushes the legend further below the fixed
+# topgeneboxplot_outer_bottom_px margin - and off the bottom of the figure -
+# as more rows are added.
+topgeneboxplot_legend_bottom_px <- 15
 
 #' Compute the total plot height and inter-row margin fraction needed to lay
 #' out \code{n_genes} faceted boxplots over \code{ncol} columns without rows
@@ -472,7 +482,11 @@ plotly_topgene_boxplots <- function(assay, groupby, genes, annotations = NULL, l
   # overall figure is made
   p %>%
     layout(
-      legend = list(title = list(text = "Group"), orientation = "h", xanchor = "center", x = 0.5, y = -0.6),
+      legend = list(
+        title = list(text = "Group"), orientation = "h",
+        xref = "container", xanchor = "center", x = 0.5,
+        yref = "container", yanchor = "bottom", y = topgeneboxplot_legend_bottom_px / layout_spec$height
+      ),
       margin = list(t = topgeneboxplot_outer_top_px, b = topgeneboxplot_outer_bottom_px), hovermode = "closest"
     )
 }

--- a/tests/testthat/test-topgeneboxplot.R
+++ b/tests/testthat/test-topgeneboxplot.R
@@ -100,6 +100,27 @@ test_that("plotly_topgene_boxplots shows the y axis title on every row, not just
   expect_false(has_title("yaxis6"))
 })
 
+test_that("plotly_topgene_boxplots keeps the legend inside the figure regardless of row count", {
+  groupby <- rep(c("A", "B"), each = 3)
+
+  # legend.y is anchored to the figure container (not the plotting area), so
+  # its pixel offset from the bottom should stay constant as more rows are
+  # added, rather than scaling with (and eventually exceeding) the fixed
+  # bottom margin reserved for it
+  for (n_genes in c(1, 4, 9)) {
+    mat <- matrix(rpois(n_genes * 6, lambda = 200) + 1, nrow = n_genes, dimnames = list(paste0("gene", 1:n_genes), paste0("s", 1:6)))
+
+    built <- plotly::plotly_build(plotly_topgene_boxplots(mat, groupby, rownames(mat)))
+    legend <- built$x$layout$legend
+    height <- built$x$layout$height
+    margin_b <- built$x$layout$margin$b
+
+    expect_equal(legend$yref, "container")
+    legend_px_from_bottom <- legend$y * height
+    expect_true(legend_px_from_bottom > 0 && legend_px_from_bottom < margin_b)
+  }
+})
+
 test_that("plotly_topgene_boxplots titles facets with the supplied label instead of the raw gene id", {
   mat <- make_topgene_matrix()
   groupby <- rep(c("A", "B"), each = 3)


### PR DESCRIPTION
## Summary

* `plotly_topgene_boxplots()` anchored the "Group" legend at a fixed `y` in plotly's "paper" coordinate system, which is scaled relative to the plotting area's height. That height grows with each extra facet row, so the same fractional offset pushed the legend further past the fixed bottom margin - and off the bottom of the figure entirely - once there was more than one row of facets.
* The legend is now anchored to the figure container (`yref = "container"`) at a fixed pixel distance from the bottom, so it stays inside the reserved margin regardless of how many rows of gene facets are drawn.

Fixes #250.

## Test plan

- [x] Added a regression test asserting the legend's pixel offset from the figure bottom stays constant and within the reserved margin across 1, 4 and 9 gene facets (1, 2 and 3 rows) - fails on the old code, passes with the fix.
- [x] Full `testthat` suite passes.
- [x] Manually verified in the running `rnaseq` app against the `zhangneurons` dataset (Differential > Top gene boxplots), with 3 genes (1 row) and 12 genes (4 rows) - the "Group" legend renders correctly below the facets in both cases.