### PR TITLE
test: add testServer coverage for medium composed table/UI modules

### DIFF
--- a/tests/testthat/helper-mediummodules.R
+++ b/tests/testthat/helper-mediummodules.R
@@ -1,0 +1,39 @@
+# make_medium_module_eselist()
+#
+# A small ExploratorySummarizedExperimentList shared by the assaydatatable,
+# rowmetatable, experimenttable and readreports module tests. Row metadata
+# includes a low-cardinality "biotype" column (alongside the near-unique
+# gene_id/gene_name columns) so categorycountplot has a valid field to tally,
+# and colData's "condition" column is similarly low-cardinality for the same
+# reason on the sample side.
+
+make_medium_module_eselist <- function(n_genes = 8, n_samples = 4, extra_assay = FALSE, read_reports = list()) {
+  gene_ids <- paste0("gene", seq_len(n_genes))
+  sample_ids <- paste0("s", seq_len(n_samples))
+
+  counts <- matrix(seq_len(n_genes * n_samples), nrow = n_genes, dimnames = list(gene_ids, sample_ids))
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = sample_ids,
+    condition = rep(c("ctrl", "treated"), each = n_samples / 2)
+  )
+
+  annotation <- data.frame(
+    gene_id = gene_ids,
+    gene_name = paste0("Gene", seq_len(n_genes)),
+    biotype = rep(c("protein_coding", "lncRNA"), length.out = n_genes),
+    row.names = gene_ids
+  )
+
+  assays_list <- list(counts = counts)
+  if (extra_assay) {
+    assays_list$norm <- counts / 2
+  }
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = assays_list, colData = coldata, annotation = annotation,
+    idfield = "gene_id", labelfield = "gene_name", read_reports = read_reports
+  )
+
+  ExploratorySummarizedExperimentList(list(counts = ese), group_vars = "condition", default_groupvar = "condition")
+}

--- a/tests/testthat/test-assaydatatable.R
+++ b/tests/testthat/test-assaydatatable.R
@@ -1,0 +1,71 @@
+test_that("assaydatatable displays the selected assay's matrix, labelled by gene name", {
+  eselist <- make_medium_module_eselist(extra_assay = TRUE)
+
+  shiny::testServer(assaydatatable, args = list(id = "assaydatatable", eselist = eselist), {
+    session$setInputs(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    session$elapse(400)
+
+    displayed <- selectmatrix_reactives$selectLabelledMatrix()
+    expect_setequal(rownames(displayed), paste0("gene", 1:8))
+    expect_setequal(colnames(displayed), c("Gene id", "s1", "s2", "s3", "s4"))
+  })
+})
+
+test_that("assaydatatable switches matrices when a different assay is selected", {
+  eselist <- make_medium_module_eselist(extra_assay = TRUE)
+
+  shiny::testServer(assaydatatable, args = list(id = "assaydatatable", eselist = eselist), {
+    session$setInputs(
+      "expression-experiment" = "counts",
+      "expression-assay" = "norm",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    session$elapse(400)
+
+    expect_equal(selectmatrix_reactives$getAssay(), "norm")
+    displayed <- selectmatrix_reactives$selectLabelledMatrix()
+    expect_equal(displayed[["s1"]], c(0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4))
+  })
+})
+
+test_that("assaydatatable restricts the displayed matrix to the selected samples", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(assaydatatable, args = list(id = "assaydatatable", eselist = eselist), {
+    session$setInputs(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "name",
+      "expression-selectmatrix-samples" = c("s1", "s2"),
+      "expression-selectmatrix-sampleGroupVal" = "ctrl",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    session$elapse(400)
+
+    displayed <- selectmatrix_reactives$selectLabelledMatrix()
+    expect_setequal(colnames(displayed), c("Gene id", "s1", "s2"))
+  })
+})
+
+test_that("assaydatatable's output title names the selected assay", {
+  eselist <- make_medium_module_eselist(extra_assay = TRUE)
+
+  shiny::testServer(assaydatatable, args = list(id = "assaydatatable", eselist = eselist), {
+    session$setInputs(
+      "expression-experiment" = "counts",
+      "expression-assay" = "norm",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    session$elapse(400)
+
+    rendered <- output$assaydatatable
+    expect_match(rendered[[1]], "Assay data: norm")
+  })
+})

--- a/tests/testthat/test-experimenttable.R
+++ b/tests/testthat/test-experimenttable.R
@@ -1,0 +1,70 @@
+test_that("experimenttable displays colData with prettified column names for the selected experiment", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(experimenttable, args = list(id = "experimenttable", eselist = eselist), {
+    session$setInputs(experiment = "counts", "categorycount-category" = "condition", "categorycount-fill" = "none")
+    session$elapse(400)
+
+    experiment <- getExperiment()
+    expect_equal(colnames(experiment), "Condition")
+    expect_equal(experiment$Condition, c("ctrl", "ctrl", "treated", "treated"))
+  })
+})
+
+test_that("experimenttable's raw experiment data keeps un-prettified column names", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(experimenttable, args = list(id = "experimenttable", eselist = eselist), {
+    session$setInputs(experiment = "counts", "categorycount-category" = "condition", "categorycount-fill" = "none")
+    session$elapse(400)
+
+    expect_equal(colnames(getRawExperiment()), "condition")
+  })
+})
+
+test_that("experimenttable switches to the newly selected experiment when more than one is available", {
+  eselist_a <- make_medium_module_eselist()[["counts"]]
+  eselist_b <- make_medium_module_eselist(n_genes = 3, n_samples = 2)[["counts"]]
+  SummarizedExperiment::colData(eselist_b)$condition <- c("only_b", "only_b")
+  eselist <- ExploratorySummarizedExperimentList(list(a = eselist_a, b = eselist_b), group_vars = "condition", default_groupvar = "condition")
+
+  shiny::testServer(experimenttable, args = list(id = "experimenttable", eselist = eselist), {
+    session$setInputs(experiment = "b", "categorycount-category" = "condition", "categorycount-fill" = "none")
+    session$elapse(400)
+
+    expect_equal(unique(getRawExperiment()$condition), "only_b")
+  })
+})
+
+test_that("experimenttable's category-count table tallies the selected experiment column", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(experimenttable, args = list(id = "experimenttable", eselist = eselist), {
+    session$setInputs(experiment = "counts", "categorycount-category" = "condition", "categorycount-fill" = "none")
+    session$elapse(400)
+
+    expect_false(is.null(output[["categorycount-table-datatable"]]))
+  })
+})
+
+# experimenttableInput()
+
+test_that("experimenttableInput hides the experiment selector behind a fixed value for a single experiment", {
+  eselist <- make_medium_module_eselist()
+
+  ui <- experimenttableInput("experiment", eselist)
+
+  rendered <- as.character(ui)
+  expect_match(rendered, "experiment-experiment", fixed = TRUE)
+  expect_no_match(rendered, "<select")
+})
+
+test_that("experimenttableInput offers a real select input when more than one experiment is available", {
+  eselist_a <- make_medium_module_eselist()[["counts"]]
+  eselist <- ExploratorySummarizedExperimentList(list(a = eselist_a, b = eselist_a))
+
+  ui <- experimenttableInput("experiment", eselist)
+
+  rendered <- as.character(ui)
+  expect_match(rendered, "<select", fixed = TRUE)
+})

--- a/tests/testthat/test-labelselectfield.R
+++ b/tests/testthat/test-labelselectfield.R
@@ -1,0 +1,209 @@
+make_labelselectfield_ese <- function(with_labelfield = TRUE) {
+  gene_ids <- paste0("gene", 1:6)
+  mat <- matrix(1:24, nrow = 6, dimnames = list(gene_ids, paste0("s", 1:4)))
+  annotation <- data.frame(
+    gene_id = gene_ids,
+    gene_name = paste0("Gene", 1:6),
+    biotype = rep(c("protein_coding", "lncRNA"), each = 3),
+    row.names = gene_ids
+  )
+
+  ExploratorySummarizedExperiment(
+    assays = list(counts = mat),
+    colData = data.frame(row.names = colnames(mat)),
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = if (with_labelfield) "gene_name" else character(0)
+  )
+}
+
+test_that("the default (unfiltered) metaField hidden input uses the experiment's labelfield", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese)),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1")
+      expect_equal(getSelectedMetaField(), "gene_name")
+    }
+  )
+})
+
+test_that("the metaField falls back to idfield when the experiment has no labelfield set", {
+  ese <- make_labelselectfield_ese(with_labelfield = FALSE)
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese)),
+    {
+      session$setInputs(metaField = "gene_id", label = "gene1")
+      expect_equal(getSelectedMetaField(), "gene_id")
+    }
+  )
+})
+
+test_that("getValidLabels lists the sorted values of the selected metadata field", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1")
+      expect_equal(getValidLabels(), paste0("Gene", 1:6))
+    }
+  )
+})
+
+test_that("getValidLabels reflects the field chosen when field_selection is enabled", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE),
+    {
+      session$setInputs(metaField = "biotype", label = "lncRNA")
+      expect_equal(getValidLabels(), c("lncRNA", "protein_coding"))
+    }
+  )
+})
+
+test_that("getSelectedLabels returns the chosen label as-is when list_input is FALSE", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese)),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene2")
+      expect_equal(getSelectedLabels(), "Gene2")
+    }
+  )
+})
+
+test_that("getSelectedLabels splits a pasted, newline-separated list when list_input is TRUE", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), list_input = TRUE),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1\nGene3\nGene5")
+      expect_equal(getSelectedLabels(), c("Gene1", "Gene3", "Gene5"))
+    }
+  )
+})
+
+test_that("getAssociatedIds maps selected labels back to their row ids via the metadata field", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE),
+    {
+      session$setInputs(metaField = "biotype", label = "lncRNA")
+      expect_setequal(getAssociatedIds(), c("gene4", "gene5", "gene6"))
+    }
+  )
+})
+
+test_that("getAssociatedIds restricts to getNonEmptyRows when supplied", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(
+      id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE,
+      getNonEmptyRows = reactive(c("gene4", "gene5"))
+    ),
+    {
+      session$setInputs(metaField = "biotype", label = "lncRNA")
+      expect_setequal(getAssociatedIds(), c("gene4", "gene5"))
+    }
+  )
+})
+
+test_that("getSelectedIds returns all associated ids when id_selection is disabled", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE, id_selection = FALSE),
+    {
+      session$setInputs(metaField = "biotype", label = "lncRNA")
+      expect_setequal(getSelectedIds(), c("gene4", "gene5", "gene6"))
+    }
+  )
+})
+
+test_that("getSelectedIds is restricted to the user's picked ids when id_selection is enabled", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese), field_selection = TRUE, id_selection = TRUE),
+    {
+      session$setInputs(metaField = "biotype", label = "lncRNA", ids = "gene5")
+      expect_equal(getSelectedIds(), "gene5")
+    }
+  )
+})
+
+test_that("getValidLabels draws from every experiment when labels_from_all_experiments is TRUE", {
+  ese_a <- make_labelselectfield_ese()
+  ese_b <- make_labelselectfield_ese()
+  SummarizedExperiment::mcols(ese_b)$gene_name <- paste0("OtherGene", 1:6)
+  eselist <- ExploratorySummarizedExperimentList(list(a = ese_a, b = ese_b))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese_a), labels_from_all_experiments = TRUE),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1")
+      labels <- getValidLabels()
+      expect_true(all(paste0("Gene", 1:6) %in% labels))
+      expect_true(all(paste0("OtherGene", 1:6) %in% labels))
+    }
+  )
+})
+
+test_that("getValidLabels is restricted to the current experiment when labels_from_all_experiments is FALSE", {
+  ese_a <- make_labelselectfield_ese()
+  ese_b <- make_labelselectfield_ese()
+  SummarizedExperiment::mcols(ese_b)$gene_name <- paste0("OtherGene", 1:6)
+  eselist <- ExploratorySummarizedExperimentList(list(a = ese_a, b = ese_b))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese_a), labels_from_all_experiments = FALSE),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1")
+      expect_equal(getValidLabels(), paste0("Gene", 1:6))
+    }
+  )
+})
+
+test_that("updateLabelField runs without error and does not alter the currently selected labels", {
+  ese <- make_labelselectfield_ese()
+  eselist <- ExploratorySummarizedExperimentList(list(counts = ese))
+
+  shiny::testServer(
+    labelselectfield,
+    args = list(id = "lsf", eselist = eselist, getExperiment = reactive(ese)),
+    {
+      session$setInputs(metaField = "gene_name", label = "Gene1")
+      expect_silent(updateLabelField())
+    }
+  )
+})

--- a/tests/testthat/test-readreports.R
+++ b/tests/testthat/test-readreports.R
@@ -1,0 +1,120 @@
+make_readreports_eselist <- function() {
+  sample_ids <- paste0("s", 1:4)
+
+  read_reports <- list(
+    read_attrition = matrix(
+      c(
+        100, 100, 100, 100,
+        90, 88, 92, 85,
+        80, 75, 85, 70
+      ),
+      nrow = 4, dimnames = list(sample_ids, c("raw", "trimmed", "aligned"))
+    ),
+    other_metric = matrix(
+      c(
+        50, 40, 60, 45,
+        20, 22, 18, 25,
+        2, 1, 3, 2
+      ),
+      nrow = 4, dimnames = list(sample_ids, c("high_count", "mid_count", "low_count"))
+    )
+  )
+
+  make_medium_module_eselist(read_reports = read_reports)
+}
+
+run_readreports_server <- function(eselist, report_type, expr) {
+  shiny::testServer(readreports, args = list(id = "readreports", eselist = eselist), {
+    session$userData$plotFormat <- function() "png"
+    session$setInputs(
+      "readreports-experiment" = "counts",
+      "readreports-assay" = "counts",
+      "readreports-selectmatrix-sampleSelect" = "all",
+      "readreports-selectmatrix-geneSelect" = "all",
+      reportType = report_type,
+      "barplot-barMode" = "stack"
+    )
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("getReportTable drops columns with no sample above the reporting threshold and orders the rest by descending mean", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "other_metric", expr = quote({
+    tbl <- getReportTable()
+
+    expect_equal(colnames(tbl), c("High count", "Mid count"))
+    expect_equal(unname(tbl[, "High count"]), c(50, 40, 60, 45))
+  }))
+})
+
+test_that("getReportTable keeps and orders columns that clear the threshold, with prettified names", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "read_attrition", expr = quote({
+    tbl <- getReportTable()
+
+    expect_equal(colnames(tbl), c("Raw", "Trimmed", "Aligned"))
+  }))
+})
+
+test_that("getPlotmatrix transposes the report table so columns are samples", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "read_attrition", expr = quote({
+    pm <- getPlotmatrix()
+
+    expect_equal(colnames(pm), paste0("s", 1:4))
+    expect_equal(rownames(pm), c("Raw", "Trimmed", "Aligned"))
+  }))
+})
+
+test_that("getDefaultMode is 'overlay' for read_attrition and 'stack' for other report types", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "read_attrition", expr = quote({
+    expect_equal(getDefaultMode(), "overlay")
+  }))
+
+  run_readreports_server(eselist, "other_metric", expr = quote({
+    expect_equal(getDefaultMode(), "stack")
+  }))
+})
+
+test_that("readreports renders a bar plot and a table for the selected report type", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "read_attrition", expr = quote({
+    expect_false(is.null(output[["barplot-barPlot"]]))
+    expect_false(is.null(output[["readrep-datatable"]]))
+  }))
+})
+
+test_that("readreports' plot and table titles name the selected, prettified report type", {
+  eselist <- make_readreports_eselist()
+
+  run_readreports_server(eselist, "other_metric", expr = quote({
+    expect_match(output$plotTitle[[1]], "Other metric plot")
+    expect_match(output$tableTitle[[1]], "Other metric data")
+  }))
+})
+
+# readreportsInput() - filters out experiments without a read_reports slot
+
+test_that("readreportsInput excludes experiments lacking a read_reports slot from the experiment picker", {
+  with_reports <- make_readreports_eselist()[["counts"]]
+  without_reports <- make_medium_module_eselist(n_genes = 3, n_samples = 2)[["counts"]]
+
+  eselist <- ExploratorySummarizedExperimentList(
+    list(has_reports = with_reports, no_reports = without_reports),
+    group_vars = "condition", default_groupvar = "condition"
+  )
+
+  ui <- readreportsInput("readreports", eselist)
+
+  rendered <- as.character(tagList(ui))
+  expect_match(rendered, "has_reports", fixed = TRUE)
+  expect_no_match(rendered, "no_reports")
+})

--- a/tests/testthat/test-rowmetatable.R
+++ b/tests/testthat/test-rowmetatable.R
@@ -1,0 +1,55 @@
+test_that("rowmetatable returns the row metadata of the selected experiment", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(rowmetatable, args = list(id = "rowmetatable", eselist = eselist), {
+    session$setInputs(
+      "rowmetatable-experiment" = "counts",
+      "rowmetatable-assay" = "counts",
+      "rowmetatable-selectmatrix-sampleSelect" = "all",
+      "rowmetatable-selectmatrix-geneSelect" = "all",
+      "categorycount-category" = "biotype",
+      "categorycount-fill" = "none"
+    )
+    session$elapse(400)
+
+    meta <- getRowMeta()
+    expect_setequal(colnames(meta), c("gene_id", "gene_name", "biotype"))
+    expect_setequal(rownames(meta), paste0("gene", 1:8))
+  })
+})
+
+test_that("rowmetatable's linked metadata prettifies column names", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(rowmetatable, args = list(id = "rowmetatable", eselist = eselist), {
+    session$setInputs(
+      "rowmetatable-experiment" = "counts",
+      "rowmetatable-assay" = "counts",
+      "rowmetatable-selectmatrix-sampleSelect" = "all",
+      "rowmetatable-selectmatrix-geneSelect" = "all",
+      "categorycount-category" = "biotype",
+      "categorycount-fill" = "none"
+    )
+    session$elapse(400)
+
+    expect_setequal(colnames(getLinkedRowMeta()), c("Gene id", "Gene name", "Biotype"))
+  })
+})
+
+test_that("rowmetatable's category-count table tallies a row-metadata column", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(rowmetatable, args = list(id = "rowmetatable", eselist = eselist), {
+    session$setInputs(
+      "rowmetatable-experiment" = "counts",
+      "rowmetatable-assay" = "counts",
+      "rowmetatable-selectmatrix-sampleSelect" = "all",
+      "rowmetatable-selectmatrix-geneSelect" = "all",
+      "categorycount-category" = "biotype",
+      "categorycount-fill" = "none"
+    )
+    session$elapse(400)
+
+    expect_false(is.null(output[["categorycount-table-datatable"]]))
+  })
+})

--- a/tests/testthat/test-sampleselect.R
+++ b/tests/testthat/test-sampleselect.R
@@ -1,0 +1,147 @@
+make_sampleselect_eselist <- function(with_group_vars = TRUE) {
+  mat <- matrix(1:16, nrow = 2, dimnames = list(c("g1", "g2"), paste0("s", 1:8)))
+
+  # ExploratorySummarizedExperimentList() auto-detects group_vars from colData
+  # (any non-numeric column shared by more than one sample) when group_vars
+  # isn't supplied explicitly, so the "no group vars" case needs a colData
+  # with no such column rather than just omitting the group_vars argument.
+  coldata <- if (with_group_vars) {
+    S4Vectors::DataFrame(row.names = colnames(mat), condition = rep(c("ctrl", "treated"), each = 4))
+  } else {
+    S4Vectors::DataFrame(row.names = colnames(mat))
+  }
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = list(counts = mat), colData = coldata,
+    annotation = data.frame(gene_id = c("g1", "g2"), row.names = c("g1", "g2")),
+    idfield = "gene_id"
+  )
+
+  if (with_group_vars) {
+    ExploratorySummarizedExperimentList(list(counts = ese), group_vars = "condition", default_groupvar = "condition")
+  } else {
+    ExploratorySummarizedExperimentList(list(counts = ese))
+  }
+}
+
+test_that("selectSamples returns every column when sampleSelect is 'all', ignoring name/group inputs", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
+    {
+      session$setInputs(sampleSelect = "all")
+      expect_equal(selectSamples(), paste0("s", 1:8))
+    }
+  )
+})
+
+test_that("selectSamples returns exactly the samples picked by name", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
+    {
+      session$setInputs(sampleSelect = "name", samples = c("s1", "s3"), sampleGroupVal = "ctrl")
+      expect_equal(selectSamples(), c("s1", "s3"))
+    }
+  )
+})
+
+test_that("selectSamples returns the samples belonging to the selected group value(s)", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
+    {
+      session$setInputs(sampleSelect = "group", samples = character(0), sampleGroupVar = "condition", sampleGroupVal = "ctrl")
+      expect_equal(selectSamples(), paste0("s", 1:4))
+    }
+  )
+})
+
+test_that("selectSamples treats NA group values as an empty-string group", {
+  eselist <- make_sampleselect_eselist()
+  SummarizedExperiment::colData(eselist[["counts"]])$condition[1] <- NA
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
+    {
+      session$setInputs(sampleSelect = "group", samples = character(0), sampleGroupVar = "condition", sampleGroupVal = "")
+      expect_equal(selectSamples(), "s1")
+    }
+  )
+})
+
+test_that("getSampleGroupVar reflects the chosen grouping variable", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
+    {
+      session$setInputs(sampleSelect = "group", sampleGroupVar = "condition", sampleGroupVal = "ctrl")
+      expect_equal(getSampleGroupVar(), "condition")
+    }
+  )
+})
+
+test_that("getSummaryType reads the nested summarisematrix input when summarisation is allowed", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]], allow_summarise = TRUE),
+    {
+      session$setInputs(sampleSelect = "all", "summarise-summaryType" = "colMeans")
+      expect_equal(reactives$getSummaryType(), "colMeans")
+    }
+  )
+})
+
+test_that("the returned reactives omit getSummaryType when summarisation is disallowed", {
+  eselist <- make_sampleselect_eselist()
+
+  shiny::testServer(
+    sampleselect,
+    args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]], allow_summarise = FALSE),
+    {
+      session$setInputs(sampleSelect = "all")
+      expect_null(reactives$getSummaryType)
+    }
+  )
+})
+
+# sampleselectInput()
+
+test_that("sampleselectInput renders only a hidden 'all' input when select_samples is FALSE", {
+  eselist <- make_sampleselect_eselist()
+
+  ui <- sampleselectInput("sampleselect", eselist, getExperiment = function() eselist[["counts"]], select_samples = FALSE)
+
+  rendered <- as.character(ui)
+  expect_match(rendered, "display: none", fixed = TRUE)
+  expect_no_match(rendered, "<select")
+})
+
+test_that("sampleselectInput offers a 'group' selection option when the eselist has group_vars", {
+  eselist <- make_sampleselect_eselist(with_group_vars = TRUE)
+
+  ui <- sampleselectInput("sampleselect", eselist, getExperiment = function() eselist[["counts"]])
+
+  rendered <- as.character(ui)
+  expect_match(rendered, "sampleGroupVar", fixed = TRUE)
+})
+
+test_that("sampleselectInput omits the 'group' selection option when the eselist has no group_vars", {
+  eselist <- make_sampleselect_eselist(with_group_vars = FALSE)
+
+  ui <- sampleselectInput("sampleselect", eselist, getExperiment = function() eselist[["counts"]])
+
+  rendered <- as.character(ui)
+  expect_no_match(rendered, "sampleGroupVar", fixed = TRUE)
+})

--- a/tests/testthat/test-ui-helpers.R
+++ b/tests/testthat/test-ui-helpers.R
@@ -1,0 +1,123 @@
+# configureBookmarking() is not covered here: it calls shiny::enableBookmarking()
+# unconditionally, which walks the session's ancestor chain looking for a real
+# ShinySession and errors ("ShinySession not found") under shiny::testServer()'s
+# MockShinySession, regardless of what the rest of the function does. Exercising
+# it would require a real browser-backed session (shinytest2), which is out of
+# scope for this test file.
+
+# bookmarkedInputValue()
+
+test_that("bookmarkedInputValue reads the namespaced key first", {
+  state <- list(input = list("mod-label" = "namespaced", "label" = "bare"))
+  session <- list(ns = function(id) paste0("mod-", id))
+
+  expect_equal(bookmarkedInputValue(state, session, "label"), "namespaced")
+})
+
+test_that("bookmarkedInputValue falls back to the bare id when the namespaced key is absent", {
+  state <- list(input = list("label" = "bare"))
+  session <- list(ns = function(id) paste0("mod-", id))
+
+  expect_equal(bookmarkedInputValue(state, session, "label"), "bare")
+})
+
+test_that("bookmarkedInputValue returns NULL when neither key is present", {
+  state <- list(input = list())
+  session <- list(ns = function(id) paste0("mod-", id))
+
+  expect_null(bookmarkedInputValue(state, session, "label"))
+})
+
+# moduleLayout()
+
+test_that("moduleLayout places controls in the sidebar and main content in the body", {
+  layout <- moduleLayout(controls = tags$div(id = "the-controls"), main = tags$div(id = "the-main"))
+
+  rendered <- as.character(layout)
+  expect_match(rendered, "the-controls", fixed = TRUE)
+  expect_match(rendered, "the-main", fixed = TRUE)
+})
+
+test_that("moduleLayout's sidebar defaults to 320px wide", {
+  layout <- moduleLayout(controls = tags$div("controls"), main = tags$div("main"))
+
+  expect_match(as.character(layout), "320px", fixed = TRUE)
+})
+
+# moduleMain()
+
+test_that("moduleMain renders a section title before the body content", {
+  main <- moduleMain("My Section", tags$p("body content"))
+
+  rendered <- as.character(main)
+  expect_match(rendered, "<h3", fixed = TRUE)
+  expect_match(rendered, "My Section", fixed = TRUE)
+  expect_match(rendered, "body content", fixed = TRUE)
+})
+
+test_that("moduleMain omits the heading entirely when title is NULL", {
+  main <- moduleMain(NULL, tags$p("body content"))
+
+  expect_no_match(as.character(main), "<h3", fixed = TRUE)
+})
+
+test_that("moduleMain includes the help trigger when supplied", {
+  main <- moduleMain("Title", tags$p("body"), help = tags$a(id = "help-link", "help"))
+
+  expect_match(as.character(main), "help-link", fixed = TRUE)
+})
+
+# shinyngsSpinnerColor()
+
+test_that("shinyngsSpinnerColor returns the brand accent hex colour", {
+  expect_equal(shinyngsSpinnerColor(), SHINYNGS_ACCENT)
+  expect_match(shinyngsSpinnerColor(), "^#[0-9a-f]{6}$")
+})
+
+# shinyngsPlotlyConfig()
+
+test_that("shinyngsPlotlyConfig drops the plotly logo and the noisier selection buttons", {
+  p <- plotly::plot_ly(x = 1:3, y = 1:3, type = "scatter", mode = "markers")
+
+  configured <- shinyngsPlotlyConfig(p, filename = "my_plot", format = "svg")
+
+  expect_false(configured$x$config$displaylogo)
+  expect_true(all(c("sendDataToCloud", "lasso2d", "select2d") %in% configured$x$config$modeBarButtonsToRemove))
+})
+
+test_that("shinyngsPlotlyConfig names the downloaded image after the plot, in the requested format", {
+  p <- plotly::plot_ly(x = 1:3, y = 1:3, type = "scatter", mode = "markers")
+
+  configured <- shinyngsPlotlyConfig(p, filename = "my_plot", format = "svg")
+
+  expect_equal(configured$x$config$toImageButtonOptions$filename, "my_plot")
+  expect_equal(configured$x$config$toImageButtonOptions$format, "svg")
+})
+
+test_that("shinyngsPlotlyConfig defaults to a generic filename and PNG format", {
+  p <- plotly::plot_ly(x = 1:3, y = 1:3, type = "scatter", mode = "markers")
+
+  configured <- shinyngsPlotlyConfig(p)
+
+  expect_equal(configured$x$config$toImageButtonOptions$filename, "shinyngs_plot")
+  expect_equal(configured$x$config$toImageButtonOptions$format, "png")
+})
+
+# fieldSets()
+
+test_that("fieldSets renders one panel per named element, titled with a prettified name", {
+  fs <- fieldSets("myfields", list(select_assay_data = tags$div(id = "assay-controls"), export = tags$div(id = "export-controls")))
+
+  rendered <- as.character(fs)
+  expect_match(rendered, "Select assay data", fixed = TRUE)
+  expect_match(rendered, "Export", fixed = TRUE)
+  expect_match(rendered, "assay-controls", fixed = TRUE)
+  expect_match(rendered, "export-controls", fixed = TRUE)
+})
+
+test_that("fieldSets' panels are all open by default", {
+  fs <- fieldSets("myfields", list(a = tags$div("A"), b = tags$div("B")))
+
+  rendered <- as.character(fs)
+  expect_equal(lengths(regmatches(rendered, gregexpr("accordion-collapse collapse show", rendered))), 2)
+})


### PR DESCRIPTION
## Summary
- Adds `shiny::testServer()`-based coverage for `assaydatatable`, `rowmetatable`, `experimenttable`, `readreports`, `sampleselect`, and `labelselectfield` — the medium-complexity modules that compose `selectmatrix`/`simpletable`/`modalServer`.
- Adds coverage for the previously-untested reactive helpers in `ui-helpers.R`: `bookmarkedInputValue`, `moduleLayout`, `moduleMain`, `shinyngsSpinnerColor`, `shinyngsPlotlyConfig`, `fieldSets`.
- `configureBookmarking()` is left uncovered: it calls `shiny::enableBookmarking()` unconditionally, which requires a real `ShinySession` and errors under `testServer()`'s mock session regardless of the rest of the function. It's already exercised end-to-end by the shinytest2 bookmarking test.
- No changes to `R/` source, tests only.

Part 2 of 4 addressing #242 (test coverage gaps).

## Test plan
- [x] `NOT_CRAN=true devtools::test()` — 0 failures (606 pass; pre-existing warnings only, none introduced by this change)
- [x] `lintr::lint_package()` — no lints

🤖 Generated with [Claude Code](https://claude.com/claude-code)