### PR TITLE
test: add coverage for large composed modules (dexseq, gene sets, gene, chipseq, illuminaarray)

### DIFF
--- a/tests/testthat/test-chipseq.R
+++ b/tests/testthat/test-chipseq.R
@@ -1,0 +1,176 @@
+# chipseq() composes many already-tested modules behind has_slot_data() gates
+# (read_reports, contrasts, contrast_stats, gene_set_analyses). Rather than
+# re-driving every nested module's own reactive graph (covered by their own
+# dedicated test files), this file checks: (1) the UI composition gating logic
+# by calling chipseqInput() directly against fixtures with/without each
+# optional slot and inspecting the rendered tab structure, and (2) that the
+# server function boots without error for both a minimal and a fully-featured
+# eselist, exercising each has_slot_data()-gated submodule call at least once.
+
+make_chipseq_eselist <- function(contrasts = FALSE, contrast_stats = FALSE, read_reports = FALSE, gene_set_analyses = FALSE) {
+  n_genes <- 20
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("s", seq_len(n_samples)))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", seq_len(n_genes)),
+    row.names = rownames(counts)
+  )
+
+  ese_args <- list(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id", labelfield = "gene_name"
+  )
+
+  if (contrast_stats) {
+    fold_changes <- matrix(stats::rnorm(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "1"))
+    ese_args$contrast_stats <- list(counts = list(fold_changes = fold_changes))
+  }
+
+  if (read_reports) {
+    ese_args$read_reports <- list(counts = matrix(
+      stats::runif(4 * n_samples),
+      nrow = 4, dimnames = list(paste0("metric", 1:4), colnames(counts))
+    ))
+  }
+
+  if (gene_set_analyses) {
+    ese_args$gene_set_analyses <- list(counts = list(KEGG = list(
+      "condition-control-treated" = data.frame(
+        "p value" = c(0.01), FDR = c(0.02), Direction = c("Up"),
+        row.names = "SET_A", check.names = FALSE
+      )
+    )))
+  }
+
+  ese <- do.call(ExploratorySummarizedExperiment, ese_args)
+
+  eselist_args <- list(
+    eses = list(counts = ese), group_vars = "condition", default_groupvar = "condition"
+  )
+  if (gene_set_analyses) {
+    eselist_args$gene_set_id_type <- "gene_id"
+    eselist_args$gene_sets <- list(KEGG = list(SET_A = paste0("g", 1:3)))
+  }
+
+  eselist <- do.call(ExploratorySummarizedExperimentList, eselist_args)
+
+  if (contrasts) {
+    eselist@contrasts <- list(
+      list(Variable = "condition", Group.1 = "control", Group.2 = "treated")
+    )
+  }
+
+  eselist
+}
+
+test_that("chipseqInput omits the Differential menu entirely when there are no contrasts", {
+  ui <- chipseqInput("chipseq", make_chipseq_eselist(contrasts = FALSE))
+  txt <- as.character(ui)
+
+  expect_false(grepl("Differential set intersection", txt))
+  expect_false(grepl("Fold change plots", txt))
+})
+
+test_that("chipseqInput includes the Differential menu's core tabs once contrasts are present", {
+  ui <- chipseqInput("chipseq", make_chipseq_eselist(contrasts = TRUE))
+  txt <- as.character(ui)
+
+  expect_true(grepl("Fold change plots", txt))
+  expect_true(grepl("MA plots", txt))
+  expect_false(grepl("Volcano plots", txt))
+  expect_false(grepl("Gene set analyses", txt))
+})
+
+test_that("chipseqInput adds Volcano plots and Top gene boxplots once contrast_stats is present", {
+  ui <- chipseqInput("chipseq", make_chipseq_eselist(contrasts = TRUE, contrast_stats = TRUE))
+  txt <- as.character(ui)
+
+  expect_true(grepl("Volcano plots", txt))
+  expect_true(grepl("Top gene boxplots", txt))
+})
+
+test_that("chipseqInput adds the gene set analysis tabs once gene_set_analyses is present", {
+  ui <- chipseqInput("chipseq", make_chipseq_eselist(contrasts = TRUE, gene_set_analyses = TRUE))
+  txt <- as.character(ui)
+
+  expect_true(grepl("Gene set analyses", txt))
+  expect_true(grepl("Gene set barcode plots", txt))
+})
+
+test_that("chipseqInput adds a Read reports tab only when read_reports is present", {
+  without_reports <- as.character(chipseqInput("chipseq", make_chipseq_eselist()))
+  with_reports <- as.character(chipseqInput("chipseq", make_chipseq_eselist(read_reports = TRUE)))
+
+  expect_false(grepl("Read reports", without_reports))
+  expect_true(grepl("Read reports", with_reports))
+})
+
+test_that("chipseqInput only adds Differential set intersection with more than one contrast", {
+  eselist_one <- make_chipseq_eselist(contrasts = TRUE)
+  eselist_two <- make_chipseq_eselist(contrasts = TRUE)
+  eselist_two@contrasts <- list(
+    list(Variable = "condition", Group.1 = "control", Group.2 = "treated"),
+    list(Variable = "condition", Group.1 = "treated", Group.2 = "control")
+  )
+
+  expect_false(grepl("Differential set intersection", as.character(chipseqInput("chipseq", eselist_one))))
+  expect_true(grepl("Differential set intersection", as.character(chipseqInput("chipseq", eselist_two))))
+})
+
+test_that("chipseq boots without error for a minimal eselist (no contrasts, no optional slots)", {
+  eselist <- make_chipseq_eselist()
+
+  expect_no_error(
+    withCallingHandlers(
+      shiny::testServer(chipseq, args = list(id = "chipseq", eselist = eselist), {
+        session$userData$plotFormat <- function() "png"
+        session$elapse(400)
+      }),
+      warning = function(w) invokeRestart("muffleWarning")
+    )
+  )
+})
+
+test_that("chipseq boots without error for a fully-featured eselist (contrasts, contrast_stats, read_reports, gene_set_analyses)", {
+  eselist <- make_chipseq_eselist(contrasts = TRUE, contrast_stats = TRUE, read_reports = TRUE, gene_set_analyses = TRUE)
+
+  expect_no_error(
+    withCallingHandlers(
+      shiny::testServer(chipseq, args = list(id = "chipseq", eselist = eselist), {
+        session$userData$plotFormat <- function() "png"
+        session$elapse(400)
+      }),
+      warning = function(w) invokeRestart("muffleWarning")
+    )
+  )
+})
+
+test_that("chipseq boots without error with more than one contrast (upset module active)", {
+  eselist <- make_chipseq_eselist(contrasts = TRUE, contrast_stats = TRUE)
+  eselist@contrasts <- list(
+    list(Variable = "condition", Group.1 = "control", Group.2 = "treated"),
+    list(Variable = "condition", Group.1 = "treated", Group.2 = "control")
+  )
+
+  expect_no_error(
+    withCallingHandlers(
+      shiny::testServer(chipseq, args = list(id = "chipseq", eselist = eselist), {
+        session$userData$plotFormat <- function() "png"
+        session$elapse(400)
+      }),
+      warning = function(w) invokeRestart("muffleWarning")
+    )
+  )
+})

--- a/tests/testthat/test-dexseqplot.R
+++ b/tests/testthat/test-dexseqplot.R
@@ -1,0 +1,189 @@
+# Happy-path coverage for dexseqplot() with DEXSeq actually installed (a
+# Suggests-only dependency; this file is skipped when it's absent). See
+# test-dexseqtable.R for why a plain data.frame stands in for a DEXSeqResults
+# object here: dexseqplot() only ever passes it straight through to
+# DEXSeq::plotDEXSeq(), so mocking that one call (rather than building a real
+# DEXSeqResults via DEXSeq's full testForDEU()/estimateExonFoldChanges()
+# pipeline) is enough to exercise the module's own reactive logic.
+
+skip_if_not_installed("DEXSeq")
+
+make_dexseqplot_result_table <- function() {
+  data.frame(
+    groupID = rep(c("gene1", "gene2", "gene3"), each = 2),
+    featureID = rep(c("E001", "E002"), 3),
+    exonBaseMean = c(120, 80, 200, 150, 60, 40),
+    dispersion = c(0.05, 0.06, 0.04, 0.05, 0.07, 0.08),
+    stat = c(8.1, 2.1, 7.5, 1.9, 6.2, 1.1),
+    pvalue = c(0.0001, 0.2, 0.0005, 0.3, 0.001, 0.4),
+    padj = c(0.001, 0.4, 0.003, 0.5, 0.006, 0.6),
+    control = c(0.2, 0.8, 0.3, 0.7, 0.5, 0.5),
+    treated = c(0.7, 0.3, 0.6, 0.4, 0.2, 0.8),
+    log2fold_treated_control = c(1, -1, 2, -2, 0.5, -0.5),
+    row.names = paste0("gene", rep(1:3, each = 2), ":", rep(c("E001", "E002"), 3))
+  )
+}
+
+make_dexseqplot_eselist <- function() {
+  # 60 genes so selectmatrix's variance slider (always instantiated, even
+  # though dexseqplot hides row selection) has enough rows for its default
+  # range; only the first 3 are referenced by the DEXSeq stand-in results.
+  n_genes <- 60
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("gene", 1:n_genes), paste0("s", 1:n_samples))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", 1:n_genes),
+    row.names = rownames(counts)
+  )
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts),
+    colData = coldata,
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = "gene_name",
+    dexseq_results = list(make_dexseqplot_result_table())
+  )
+
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(counts = ese),
+    group_vars = "condition",
+    default_groupvar = "condition"
+  )
+  eselist@contrasts <- list(
+    list(Variable = "condition", Group.1 = "control", Group.2 = "treated")
+  )
+  eselist
+}
+
+mock_dexseq_counts <- matrix(
+  c(
+    10, 12, 40, 42,
+    100, 102, 5, 7,
+    30, 32, 70, 72,
+    60, 62, 40, 42,
+    50, 52, 20, 22,
+    15, 17, 55, 57
+  ),
+  nrow = 6, byrow = TRUE,
+  dimnames = list(rownames(make_dexseqplot_result_table()), paste0("s", 1:4))
+)
+
+run_dexseqplot_server <- function(eselist, extra_inputs = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "deuPlotTable-expression-experiment" = "counts",
+      "deuPlotTable-expression-assay" = "counts",
+      "deuPlotTable-expression-selectmatrix-sampleSelect" = "all",
+      "deuPlotTable-expression-selectmatrix-geneSelect" = "all",
+      "deuPlotTable-deuContrast-filterRows" = FALSE,
+      "deuPlotTable-deuContrast-contrasts0" = "1",
+      "genesymbol-metaField" = "gene_name",
+      "genesymbol-label" = "Gene1",
+      "deuQvalPlotMax" = 0.1,
+      "deuNorcounts" = FALSE,
+      "deuSplicing" = TRUE,
+      "deuDisplayTranscripts" = TRUE,
+      "deuExpression" = TRUE
+    ),
+    extra_inputs
+  )
+
+  testthat::local_mocked_bindings(counts = function(object, normalized = TRUE) mock_dexseq_counts, .package = "DEXSeq")
+
+  shiny::testServer(dexseqplot, args = list(id = "dexseqplot", eselist = eselist), {
+    do.call(session$setInputs, inputs)
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("getSelectedDEUResult returns the DEXSeq results for the selected contrast", {
+  run_dexseqplot_server(make_dexseqplot_eselist(), expr = quote({
+    result <- getSelectedDEUResult()
+    expect_identical(result, make_dexseqplot_result_table())
+  }))
+})
+
+test_that("getSelectedDEUResult reports a validation message when the selected contrast has no DEU results", {
+  eselist <- make_dexseqplot_eselist()
+
+  run_dexseqplot_server(eselist,
+    extra_inputs = list("deuPlotTable-deuContrast-contrasts0" = "2"),
+    expr = quote({
+      err <- tryCatch(getSelectedDEUResult(), error = function(e) e)
+      expect_s3_class(err, "validation")
+    })
+  )
+})
+
+test_that("getDEUGeneID resolves a composite exon groupID from the selected gene label", {
+  run_dexseqplot_server(make_dexseqplot_eselist(), expr = quote({
+    expect_equal(getDEUGeneID(), "gene1")
+  }))
+})
+
+test_that("dexseqplot draws a DEU plot via DEXSeq::plotDEXSeq with the resolved gene, contrast and control values", {
+  recorded_calls <- list()
+  testthat::local_mocked_bindings(
+    plotDEXSeq = function(object, geneID, FDR, fitExpToVar, norCounts, splicing, displayTranscripts, expression, ...) {
+      recorded_calls[[length(recorded_calls) + 1]] <<- list(
+        geneID = geneID, FDR = FDR, fitExpToVar = fitExpToVar, norCounts = norCounts,
+        splicing = splicing, displayTranscripts = displayTranscripts, expression = expression
+      )
+      graphics::plot.new()
+    },
+    .package = "DEXSeq"
+  )
+
+  run_dexseqplot_server(make_dexseqplot_eselist(), expr = quote({
+    output$deuPlot
+  }))
+
+  expect_length(recorded_calls, 1)
+  expect_equal(recorded_calls[[1]]$geneID, "gene1")
+  expect_equal(recorded_calls[[1]]$FDR, 0.1)
+  expect_equal(recorded_calls[[1]]$fitExpToVar, "condition")
+  expect_false(recorded_calls[[1]]$norCounts)
+  expect_true(recorded_calls[[1]]$splicing)
+})
+
+test_that("makeDEUPlotForDownload calls DEXSeq::plotDEXSeq with the same resolved values as the on-screen plot", {
+  recorded_calls <- list()
+  testthat::local_mocked_bindings(
+    plotDEXSeq = function(object, geneID, FDR, fitExpToVar, ...) {
+      recorded_calls[[length(recorded_calls) + 1]] <<- list(geneID = geneID, FDR = FDR, fitExpToVar = fitExpToVar)
+      graphics::plot.new()
+    },
+    .package = "DEXSeq"
+  )
+
+  run_dexseqplot_server(make_dexseqplot_eselist(), expr = quote({
+    makeDEUPlotForDownload()
+  }))
+
+  expect_true(length(recorded_calls) >= 1)
+  expect_equal(recorded_calls[[length(recorded_calls)]]$geneID, "gene1")
+})
+
+test_that("dexseqplot's plot output reports a friendly message when DEXSeq is missing", {
+  testthat::local_mocked_bindings(requireNamespace = function(...) FALSE)
+
+  run_dexseqplot_server(make_dexseqplot_eselist(), expr = quote({
+    err <- tryCatch(output$deuPlot, error = function(e) e)
+    expect_s3_class(err, "validation")
+    expect_match(conditionMessage(err), "DEXSeq package must be installed")
+  }))
+})

--- a/tests/testthat/test-dexseqtable.R
+++ b/tests/testthat/test-dexseqtable.R
@@ -1,0 +1,192 @@
+# Happy-path coverage for dexseqtable() with DEXSeq actually installed (it is
+# a Suggests-only dependency, so this file is skipped when it's absent; the
+# DEXSeq-missing fallback path is already covered in test-optional-heavy-deps.R).
+#
+# DEXSeqResults objects are S4 DataFrame subclasses normally produced by
+# DEXSeq's own testForDEU()/estimateExonFoldChanges() pipeline. Building a real
+# one for a test fixture would mean running that whole pipeline. Since
+# dexseqtable() only ever touches its DEXSeqResults objects via plain
+# data.frame-style indexing (`d$mean1 <-`, `d[, fccol]`, `colnames(d)`,
+# `as.data.frame(d[, deucols])`) plus one call to `DEXSeq::counts()`, a plain
+# data.frame stand-in plus a mocked `DEXSeq::counts()` reproduces the module's
+# real behaviour without needing genuine DEXSeq internals.
+
+skip_if_not_installed("DEXSeq")
+
+make_dexseq_result_table <- function() {
+  data.frame(
+    groupID = rep(c("gene1", "gene2", "gene3"), each = 2),
+    featureID = rep(c("E001", "E002"), 3),
+    exonBaseMean = c(120, 80, 200, 150, 60, 40),
+    dispersion = c(0.05, 0.06, 0.04, 0.05, 0.07, 0.08),
+    stat = c(8.1, 2.1, 7.5, 1.9, 6.2, 1.1),
+    pvalue = c(0.0001, 0.2, 0.0005, 0.3, 0.001, 0.4),
+    padj = c(0.001, 0.4, 0.003, 0.5, 0.006, 0.6),
+    control = c(0.2, 0.8, 0.3, 0.7, 0.5, 0.5),
+    treated = c(0.7, 0.3, 0.6, 0.4, 0.2, 0.8),
+    log2fold_treated_control = c(1, -1, 2, -2, 0.5, -0.5),
+    row.names = paste0("gene", rep(1:3, each = 2), ":", rep(c("E001", "E002"), 3))
+  )
+}
+
+make_dexseqtable_eselist <- function() {
+  # 60 genes so selectmatrix's (unused, but always instantiated) variance
+  # slider has enough rows for its default range; only the first 3 are
+  # referenced by the DEXSeq stand-in results below.
+  n_genes <- 60
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("gene", 1:n_genes), paste0("s", 1:n_samples))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", 1:n_genes),
+    row.names = rownames(counts)
+  )
+
+  pvals <- matrix(stats::runif(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+  qvals <- matrix(stats::p.adjust(pvals[, 1], method = "BH"), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+  fold_changes <- matrix(stats::rnorm(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "V1"))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts),
+    colData = coldata,
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = "gene_name",
+    contrast_stats = list(counts = list(pvals = pvals, qvals = qvals, fold_changes = fold_changes)),
+    dexseq_results = list(make_dexseq_result_table())
+  )
+
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(counts = ese),
+    group_vars = "condition",
+    default_groupvar = "condition"
+  )
+  eselist@contrasts <- list(
+    list(id = "condition_control_treated", Variable = "condition", Group.1 = "control", Group.2 = "treated")
+  )
+  eselist
+}
+
+# A fixed mock counts() matrix, same row order as make_dexseq_result_table(),
+# columns matching make_dexseqtable_eselist()'s sample names.
+mock_dexseq_counts <- matrix(
+  c(
+    10, 12, 40, 42,
+    100, 102, 5, 7,
+    30, 32, 70, 72,
+    60, 62, 40, 42,
+    50, 52, 20, 22,
+    15, 17, 55, 57
+  ),
+  nrow = 6, byrow = TRUE,
+  dimnames = list(rownames(make_dexseq_result_table()), paste0("s", 1:4))
+)
+
+run_dexseqtable_server <- function(eselist, extra_inputs = list(), args = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all",
+      "deuContrast-filterRows" = TRUE,
+      "deuContrast-contrasts0" = "1",
+      "deuContrast-fold_change_card0" = ">= or <= -",
+      "deuContrast-fold_change0" = 0,
+      "deuContrast-p_value_card0" = "<=",
+      "deuContrast-p_value0" = 1,
+      "deuContrast-q_value_card0" = "<=",
+      "deuContrast-q_value0" = 1,
+      "deuMostSigExon" = FALSE
+    ),
+    extra_inputs
+  )
+
+  testthat::local_mocked_bindings(counts = function(object, normalized = TRUE) mock_dexseq_counts, .package = "DEXSeq")
+
+  server_args <- modifyList(list(id = "deutable", eselist = eselist), args)
+
+  shiny::testServer(dexseqtable, args = server_args, {
+    do.call(session$setInputs, inputs)
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("makeDEUTables computes a DEU table per contrast from the DEXSeq results", {
+  run_dexseqtable_server(make_dexseqtable_eselist(), expr = quote({
+    tables <- makeDEUTables()
+
+    expect_length(tables, 1)
+    expect_equal(nrow(tables[[1]]), 6)
+    expect_true(all(c("groupID", "Exon", "Relative exon usage fold change", "P value", "FDR corrected p value") %in% colnames(tables[[1]])))
+  }))
+})
+
+test_that("makeDEUTables converts log2 fold changes to signed linear fold changes", {
+  run_dexseqtable_server(make_dexseqtable_eselist(), expr = quote({
+    table <- makeDEUTables()[[1]]
+    ordered_by_exon <- table[order(table$groupID, table$Exon), ]
+
+    expect_equal(
+      ordered_by_exon[["Relative exon usage fold change"]],
+      round(c(2, -2, 4, -4, 2^0.5, -1 / 2^-0.5), 2)
+    )
+  }))
+})
+
+test_that("makeDEUTable orders results by FDR corrected p value", {
+  run_dexseqtable_server(make_dexseqtable_eselist(), expr = quote({
+    table <- makeDEUTable()
+
+    expect_equal(table[["FDR corrected p value"]], sort(table[["FDR corrected p value"]]))
+    expect_equal(nrow(table), 6)
+  }))
+})
+
+test_that("makeDEUTable keeps only the most significant exon per gene when deuMostSigExon is TRUE", {
+  run_dexseqtable_server(make_dexseqtable_eselist(),
+    extra_inputs = list("deuMostSigExon" = TRUE),
+    expr = quote({
+      table <- makeDEUTable()
+
+      expect_equal(nrow(table), 3)
+      expect_equal(sort(unique(table[[prettifyVariablename("gene_id")]])), c("gene1", "gene2", "gene3"))
+    })
+  )
+})
+
+test_that("makeDEUTable applies fold change and p/q value cardinality filters", {
+  run_dexseqtable_server(make_dexseqtable_eselist(),
+    extra_inputs = list("deuContrast-p_value0" = 0.01),
+    expr = quote({
+      table <- makeDEUTable()
+
+      expect_true(all(table[["P value"]] <= 0.01))
+      expect_true(nrow(table) < 6)
+    })
+  )
+})
+
+test_that("dexseqtable renders a simpletable datatable from the DEU results", {
+  run_dexseqtable_server(make_dexseqtable_eselist(), expr = quote({
+    expect_false(is.null(output[["dexseqtable-datatable"]]))
+  }))
+})
+
+test_that("dexseqtable's getSelectedContrastNumbers reflects the selected contrast", {
+  run_dexseqtable_server(make_dexseqtable_eselist(), expr = quote({
+    expect_equal(contrast_reactives$getSelectedContrastNumbers()[[1]][[1]], "1")
+  }))
+})

--- a/tests/testthat/test-differentialtable.R
+++ b/tests/testthat/test-differentialtable.R
@@ -1,0 +1,168 @@
+# Extends the single testServer example of differentialtable() in
+# test-shinytest2.R (a basic "computes a table without error" smoke test)
+# with dedicated coverage of contrast selection and fold-change/p/q-value
+# filtering, using the shared shinytest2_eselist() fixture (60 genes x 12
+# samples, one contrast, with fold_changes/pvals/qvals populated).
+
+run_differentialtable_server <- function(eselist, extra_inputs = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-obs" = 60,
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all",
+      "differential-filterRows" = FALSE,
+      "differential-contrasts-summaryType" = "colMeans",
+      "differential-contrasts0" = "1",
+      "differential-combine_operator" = "intersect"
+    ),
+    extra_inputs
+  )
+
+  # differentialtable() hardcodes selectmatrix(..., var_n = 1000); fixtures
+  # with fewer genes than that harmlessly warn that the (unused, since
+  # geneSelect is "all" here) variance slider's default exceeds its max.
+  withCallingHandlers(
+    shiny::testServer(differentialtable, args = list(id = "differential", eselist = eselist), {
+      do.call(session$setInputs, inputs)
+      session$elapse(400)
+      eval(expr, envir = environment())
+    }),
+    warning = function(w) {
+      if (grepl("should be less than or equal to", conditionMessage(w))) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+}
+
+test_that("differentialtable computes an unfiltered table covering every gene when filterRows is off", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist, expr = quote({
+    table <- contrast_reactives$labelledContrastsTable()
+    expect_equal(nrow(table), 60)
+  }))
+})
+
+test_that("differentialtable's fold change cardinality filter matches the raw contrast_stats fold changes", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist,
+    extra_inputs = list(
+      "differential-filterRows" = TRUE,
+      "differential-fold_change_card0" = ">= or <= -",
+      "differential-fold_change0" = 1,
+      "differential-p_value_card0" = "<=",
+      "differential-p_value0" = 1,
+      "differential-q_value_card0" = "<=",
+      "differential-q_value0" = 1
+    ),
+    expr = quote({
+      table <- contrast_reactives$labelledContrastsTable()
+      fold_changes <- eselist[["counts"]]@contrast_stats$counts$fold_changes[, 1]
+
+      expect_equal(nrow(table), sum(abs(fold_changes) >= 1))
+      expect_true(all(abs(table[["Fold change"]]) >= 1))
+    })
+  )
+})
+
+test_that("differentialtable's p value cardinality filter matches the raw contrast_stats p values", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist,
+    extra_inputs = list(
+      "differential-filterRows" = TRUE,
+      "differential-fold_change_card0" = ">= or <= -",
+      "differential-fold_change0" = 0,
+      "differential-p_value_card0" = "<=",
+      "differential-p_value0" = 0.5,
+      "differential-q_value_card0" = "<=",
+      "differential-q_value0" = 1
+    ),
+    expr = quote({
+      table <- contrast_reactives$labelledContrastsTable()
+      pvals <- eselist[["counts"]]@contrast_stats$counts$pvals[, 1]
+
+      expect_equal(nrow(table), sum(pvals <= 0.5))
+    })
+  )
+})
+
+test_that("differentialtable returns an empty table when filters exclude every row", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist,
+    extra_inputs = list(
+      "differential-filterRows" = TRUE,
+      "differential-fold_change_card0" = ">= or <= -",
+      "differential-fold_change0" = 1000,
+      "differential-p_value_card0" = "<=",
+      "differential-p_value0" = 1,
+      "differential-q_value_card0" = "<=",
+      "differential-q_value0" = 1
+    ),
+    expr = quote({
+      table <- contrast_reactives$labelledContrastsTable()
+      expect_equal(nrow(table), 0)
+    })
+  )
+})
+
+test_that("differentialtable's rendered UI title tracks the selected assay", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist, expr = quote({
+    rendered <- output$differentialtable
+    expect_match(rendered[[1]], "Differential expression in assay: counts")
+  }))
+})
+
+test_that("differentialtable renders a simpletable datatable of the differential expression results", {
+  eselist <- shinytest2_eselist()
+
+  run_differentialtable_server(eselist, expr = quote({
+    expect_false(is.null(output[["differentialtable-datatable"]]))
+  }))
+})
+
+test_that("differentialtable selects among multiple contrasts independently", {
+  n_genes <- 12
+  counts <- matrix(
+    stats::rnbinom(n_genes * 4, mu = 200, size = 5),
+    nrow = n_genes, ncol = 4,
+    dimnames = list(paste0("gene", seq_len(n_genes)), paste0("s", 1:4))
+  )
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    grpA = c("ctrl", "ctrl", "treatA", "treatA"),
+    grpB = c("ctrl", "treatB", "ctrl", "treatB")
+  )
+  annotation <- data.frame(gene_id = rownames(counts), row.names = rownames(counts))
+
+  fc1 <- matrix(rep(c(3, -3), each = 6), nrow = n_genes, dimnames = list(rownames(counts), "1"))
+  fc2 <- matrix(rep(c(-5, 5), each = 6), nrow = n_genes, dimnames = list(rownames(counts), "2"))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id",
+    contrast_stats = list(counts = list(fold_changes = cbind(fc1, fc2)))
+  )
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(counts = ese), group_vars = c("grpA", "grpB"), default_groupvar = "grpA"
+  )
+  eselist@contrasts <- list(
+    list(Variable = "grpA", Group.1 = "ctrl", Group.2 = "treatA"),
+    list(Variable = "grpB", Group.1 = "ctrl", Group.2 = "treatB")
+  )
+
+  run_differentialtable_server(eselist,
+    extra_inputs = list("differential-contrasts0" = "2"),
+    expr = quote({
+      table <- contrast_reactives$labelledContrastsTable()
+      expect_equal(table[["Fold change"]], rep(c(-5, 5), each = 6))
+    })
+  )
+})

--- a/tests/testthat/test-gene.R
+++ b/tests/testthat/test-gene.R
@@ -1,0 +1,158 @@
+# Plain function coverage: geneBarplot(), geneModelBiotypeColors()
+#
+# geneModelGenomeInfo() and the igvShiny-missing fallback for the gene model
+# view are already covered in test-optional-heavy-deps.R.
+
+test_that("geneBarplot draws one bar-chart panel per row, colored by the grouping variable", {
+  expression <- matrix(
+    c(10, 20, 30, 40, 5, 15, 25, 35),
+    nrow = 2, byrow = TRUE,
+    dimnames = list(c("Gene1", "Gene2"), paste0("s", 1:4))
+  )
+  experiment <- data.frame(
+    condition = c("control", "control", "treated", "treated"),
+    row.names = paste0("s", 1:4)
+  )
+
+  p <- geneBarplot(expression, experiment, colorby = "condition", palette = c("#111111", "#222222"))
+  built <- plotly::plotly_build(p)
+
+  bar_traces <- Filter(function(t) identical(t$type, "bar"), built$x$data)
+  expect_length(bar_traces, 4)
+})
+
+test_that("geneBarplot draws without color grouping when colorby is NULL", {
+  expression <- matrix(c(10, 20, 30, 40), nrow = 1, dimnames = list("Gene1", paste0("s", 1:4)))
+  experiment <- data.frame(condition = rep(c("control", "treated"), each = 2), row.names = paste0("s", 1:4))
+
+  p <- geneBarplot(expression, experiment, colorby = NULL)
+  built <- plotly::plotly_build(p)
+
+  expect_equal(length(built$x$data), 1)
+})
+
+test_that("geneModelBiotypeColors returns a fixed biotype-to-color mapping with a default fallback", {
+  colors <- geneModelBiotypeColors()
+
+  expect_true(all(c("protein_coding", "default") %in% names(colors)))
+  expect_equal(colors$default, "black")
+})
+
+# Happy-path testServer coverage of the gene module's reactive graph, using
+# the shared shinytest2_eselist() fixture (60 genes x 12 samples, with
+# contrasts/contrast_stats populated - see helper-shinytest2.R).
+
+run_gene_server <- function(eselist, extra_inputs = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "gene-experiment" = "counts",
+      "gene-assay" = "counts",
+      "gene-selectmatrix-sampleSelect" = "name",
+      "gene-selectmatrix-samples" = colnames(eselist[[1]]),
+      "gene-selectmatrix-sampleGroupVal" = "control",
+      "gene-selectmatrix-geneSelect" = "all",
+      "gene-metafields" = "gene_name",
+      "gene_label-metaField" = "gene_name",
+      "gene_label-label" = "Gene1",
+      "gene_label-ids" = "gene1",
+      "gene-filterRows" = FALSE,
+      "gene-contrasts-summaryType" = "colMeans",
+      "gene-contrasts0" = "1",
+      "gene-combine_operator" = "intersect",
+      "gene-groupby" = "condition",
+      "gene-groupby-palette_name" = "colorblind"
+    ),
+    extra_inputs
+  )
+
+  # gene() hardcodes selectmatrix(..., var_n = 1000) for its variance-based
+  # row selection UI; shinytest2_eselist() only has 60 genes, so the (unused,
+  # since geneSelect is "all" here) variance slider harmlessly warns that its
+  # default value exceeds its max.
+  withCallingHandlers(
+    shiny::testServer(gene, args = list(id = "gene", eselist = eselist), {
+      session$userData$plotFormat <- function() "png"
+      do.call(session$setInputs, inputs)
+      session$elapse(400)
+      eval(expr, envir = environment())
+    }),
+    warning = function(w) {
+      if (grepl("should be less than or equal to", conditionMessage(w))) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
+}
+
+test_that("getSelectedIdsWithData resolves the row id for the selected gene label", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    expect_equal(getSelectedIdsWithData(), "gene1")
+  }))
+})
+
+test_that("output$title and output$info reflect the selected experiment name", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    title <- output$title
+    expect_match(title[[1]], "Counts")
+
+    info <- output$info
+    expect_true(any(grepl("Counts", as.character(info))))
+  }))
+})
+
+test_that("output$barPlot renders a bar chart for the selected gene", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    rendered <- output$barPlot
+    expect_false(is.null(rendered))
+
+    parsed <- jsonlite::fromJSON(rendered, simplifyVector = FALSE)
+    types <- vapply(parsed$x$data, function(t) if (is.null(t$type)) NA_character_ else t$type, character(1))
+    expect_true("bar" %in% types)
+  }))
+})
+
+test_that("output$model only offers a gene model link when ensembl_species is set", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    expect_null(output$model)
+  }))
+
+  eselist_with_species <- shinytest2_eselist()
+  eselist_with_species@ensembl_species <- "hsapiens"
+
+  run_gene_server(eselist_with_species, expr = quote({
+    rendered <- output$model
+    expect_false(is.null(rendered))
+  }))
+})
+
+test_that("getGeneContrastsTable restricts the contrasts table to the selected gene", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    table <- getGeneContrastsTable()
+
+    expect_true(nrow(table) >= 1)
+    expect_true(all(table[[prettifyVariablename("gene_id")]] == "gene1"))
+  }))
+})
+
+test_that("gene renders a simpletable of the selected gene's contrast data", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    expect_false(is.null(output[["geneContrastsTable-datatable"]]))
+  }))
+})
+
+test_that("output$geneInfoTable renders the annotation row for the selected gene", {
+  run_gene_server(shinytest2_eselist(), expr = quote({
+    rendered <- output$geneInfoTable
+    expect_false(is.null(rendered))
+  }))
+})
+
+test_that("getSelectedIdsWithData reports a validation message when the label has no data in the current assay", {
+  run_gene_server(shinytest2_eselist(),
+    extra_inputs = list("gene_label-label" = "Gene1", "gene_label-ids" = "not_a_real_id"),
+    expr = quote({
+      err <- tryCatch(getSelectedIdsWithData(), error = function(e) e)
+      expect_s3_class(err, "validation")
+    })
+  )
+})

--- a/tests/testthat/test-genesetanalysistable.R
+++ b/tests/testthat/test-genesetanalysistable.R
@@ -1,0 +1,138 @@
+make_genesetanalysistable_eselist <- function() {
+  n_genes <- 60
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("s", seq_len(n_samples)))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", seq_len(n_genes)),
+    row.names = rownames(counts)
+  )
+
+  fold_changes <- matrix(stats::rnorm(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "1"))
+  # g1, g2, g5 up; g3, g4, g6 down - the values genesetselect's "SET_A" test
+  # below depends on.
+  fold_changes[1:6, 1] <- c(2, 3, -2, -3, 1.5, -1.5)
+
+  gene_set_analyses <- list(counts = list(KEGG = list(
+    "condition-control-treated" = data.frame(
+      "p value" = c(0.01, 0.2), FDR = c(0.02, 0.3), Direction = c("Up", "Down"),
+      row.names = c("SET_A", "SET_B"), check.names = FALSE
+    )
+  )))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts),
+    colData = coldata,
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = "gene_name",
+    contrast_stats = list(counts = list(fold_changes = fold_changes)),
+    gene_set_analyses = gene_set_analyses
+  )
+
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(counts = ese),
+    group_vars = "condition",
+    default_groupvar = "condition",
+    gene_set_id_type = "gene_id",
+    gene_sets = list(KEGG = list(
+      SET_A = c("g1", "g2", "g3"),
+      SET_B = c("g4", "g5")
+    ))
+  )
+  eselist@contrasts <- list(
+    list(Variable = "condition", Group.1 = "control", Group.2 = "treated")
+  )
+  eselist
+}
+
+run_genesetanalysistable_server <- function(eselist, extra_inputs = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all",
+      "genesetanalysistable-filterRows" = FALSE,
+      "genesetanalysistable-contrasts-summaryType" = "colMeans",
+      "genesetanalysistable-contrasts0" = "1",
+      "genesetanalysistable-geneSetTypes" = "KEGG",
+      "genesetanalysistable-geneSets" = "1-1",
+      "genesetanalysistable-overlapType" = "union",
+      "pval" = 0.05,
+      "fdr" = 0.1
+    ),
+    extra_inputs
+  )
+
+  shiny::testServer(genesetanalysistable, args = list(id = "genesetanalysistable", eselist = eselist), {
+    do.call(session$setInputs, inputs)
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("getEnrichmentInfo resolves the KEGG enrichment table for the selected contrast", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
+    enrichment <- getEnrichmentInfo()
+
+    expect_equal(enrichment$tool, "roast")
+    expect_equal(rownames(enrichment$gst), c("SET_A", "SET_B"))
+  }))
+})
+
+test_that("getGeneSetAnalysis filters gene sets by p value and FDR and annotates significant genes", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
+    gst <- getGeneSetAnalysis()
+
+    expect_equal(nrow(gst), 1)
+    expect_equal(gst$gene_set_id, "SET_A")
+    expect_equal(gst$significant_genes, "Gene1 Gene2")
+  }))
+})
+
+test_that("getGeneSetAnalysis reports no results when the p/FDR filters exclude everything", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(),
+    extra_inputs = list(pval = 0.001),
+    expr = quote({
+      err <- tryCatch(getGeneSetAnalysis(), error = function(e) e)
+      expect_s3_class(err, "validation")
+    })
+  )
+})
+
+test_that("getGeneSetAnalysis restricts to a specific selected gene set", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(),
+    extra_inputs = list(pval = 1, fdr = 1, "genesetanalysistable-geneSets" = "1-2"),
+    expr = quote({
+      gst <- getGeneSetAnalysis()
+
+      expect_equal(gst$gene_set_id, "SET_B")
+      expect_equal(gst$significant_genes, "Gene4")
+    })
+  )
+})
+
+test_that("genesetanalysistable renders a simpletable datatable of the filtered gene sets", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
+    expect_false(is.null(output[["genesetanalysistable-datatable"]]))
+  }))
+})
+
+test_that("output$enrichmentMethod reports the resolved enrichment tool", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
+    rendered <- output$enrichmentMethod
+    expect_match(rendered[[1]], "ROAST")
+  }))
+})

--- a/tests/testthat/test-genesetbarcodeplot-module.R
+++ b/tests/testthat/test-genesetbarcodeplot-module.R
@@ -1,0 +1,154 @@
+# Module-level testServer coverage for genesetbarcodeplot(). The plain
+# exported helper functions in R/genesetbarcodeplot.R (plotly_barcodeplot(),
+# tricubeMovingAverage(), quantileOfSorted()) are covered separately in
+# test-genesetbarcodeplot.R on a sibling PR branch; this file only exercises
+# the Shiny module's own reactive logic, and is named distinctly
+# (test-genesetbarcodeplot-module.R) to avoid colliding with that file when
+# the two branches are eventually merged.
+
+make_genesetbarcodeplot_eselist <- function() {
+  n_genes <- 60
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("s", seq_len(n_samples)))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", seq_len(n_genes)),
+    row.names = rownames(counts)
+  )
+
+  fold_changes <- matrix(stats::rnorm(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "1"))
+  fold_changes[1:6, 1] <- c(2, 3, -2, -3, 1.5, -1.5)
+
+  gene_set_analyses <- list(counts = list(KEGG = list(
+    "condition-control-treated" = data.frame(
+      "p value" = c(0.01, 0.2), FDR = c(0.02, 0.3), Direction = c("Up", "Down"),
+      row.names = c("SET_A", "SET_B"), check.names = FALSE
+    )
+  )))
+
+  ese <- ExploratorySummarizedExperiment(
+    assays = S4Vectors::SimpleList(counts = counts),
+    colData = coldata,
+    annotation = annotation,
+    idfield = "gene_id",
+    labelfield = "gene_name",
+    contrast_stats = list(counts = list(fold_changes = fold_changes)),
+    gene_set_analyses = gene_set_analyses
+  )
+
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(counts = ese),
+    group_vars = "condition",
+    default_groupvar = "condition",
+    gene_set_id_type = "gene_id",
+    gene_sets = list(KEGG = list(
+      SET_A = c("g1", "g2", "g3"),
+      SET_B = c("g4", "g5"),
+      SET_C = c("g10", "g11")
+    ))
+  )
+  eselist@contrasts <- list(
+    list(Variable = "condition", Group.1 = "control", Group.2 = "treated")
+  )
+  eselist
+}
+
+run_genesetbarcodeplot_server <- function(eselist, extra_inputs = list(), expr) {
+  inputs <- modifyList(
+    list(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "all",
+      "expression-selectmatrix-geneSelect" = "all",
+      "expression-metafields" = "gene_name",
+      "genesetbarcodeplot-filterRows" = FALSE,
+      "genesetbarcodeplot-contrasts-summaryType" = "colMeans",
+      "genesetbarcodeplot-contrasts0" = "1",
+      "genesetbarcodeplot-combine_operator" = "intersect",
+      "genesetbarcodeplot-geneSets" = "1-1",
+      "genesetbarcodeplot-overlapType" = "union"
+    ),
+    extra_inputs
+  )
+
+  shiny::testServer(genesetbarcodeplot, args = list(id = "genesetbarcodeplot", eselist = eselist), {
+    session$userData$plotFormat <- function() "png"
+    do.call(session$setInputs, inputs)
+    session$elapse(400)
+    eval(expr, envir = environment())
+  })
+}
+
+test_that("getContrastsTable/getFoldChanges/getGeneIDs/getLabels resolve the ranking data for all genes", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(), expr = quote({
+    ct <- getContrastsTable()
+    expect_equal(nrow(ct), 60)
+
+    fc <- getFoldChanges()
+    expect_equal(fc[1:6], c(2, 3, -2, -3, 1.5, -1.5))
+
+    ids <- getGeneIDs()
+    expect_true(all(c("g1", "g2", "g3", "g4", "g5", "g6") %in% ids))
+
+    labels <- getLabels()
+    expect_true(any(grepl("Gene1", labels)))
+  }))
+})
+
+test_that("barcodeplotTitle includes the gene set name, contrast and resolved enrichment stats", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(), expr = quote({
+    title <- barcodeplotTitle()
+
+    expect_match(title, "SET a", fixed = TRUE)
+    expect_match(title, "Direction: Up")
+    expect_match(title, "FDR: 0.02")
+    expect_match(title, "ROAST")
+  }))
+})
+
+test_that("barcodeplotTitle notes the lack of association when no enrichment result matches", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(),
+    extra_inputs = list("genesetbarcodeplot-geneSets" = "1-3"),
+    expr = quote({
+      title <- barcodeplotTitle()
+      expect_match(title, "no association", fixed = TRUE)
+    })
+  )
+})
+
+test_that("genesetbarcodeplot renders a barcode plotly widget for the selected gene set", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(), expr = quote({
+    rendered <- output$genesetbarcodeplot
+    expect_false(is.null(rendered))
+
+    parsed <- jsonlite::fromJSON(rendered, simplifyVector = FALSE)
+    types <- vapply(parsed$x$data, function(t) if (is.null(t$type)) NA_character_ else t$type, character(1))
+    expect_true(any(types %in% c("bar", "scatter")))
+  }))
+})
+
+test_that("gsbpContrastsTable subsets the contrasts table down to the selected gene set's members", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(), expr = quote({
+    table <- gsbpContrastsTable()
+
+    expect_equal(nrow(table), 3)
+    expect_setequal(table[[prettifyVariablename("gene_name")]], c("Gene1", "Gene2", "Gene3"))
+  }))
+})
+
+test_that("genesetbarcodeplot renders a simpletable of the gene set's contrast data", {
+  run_genesetbarcodeplot_server(make_genesetbarcodeplot_eselist(), expr = quote({
+    expect_false(is.null(output[["genesetbarcodeplot-datatable"]]))
+  }))
+})

--- a/tests/testthat/test-illuminaarray.R
+++ b/tests/testthat/test-illuminaarray.R
@@ -1,0 +1,161 @@
+# illuminaarray() follows the same has_slot_data()-gated composition pattern
+# as chipseq() (see test-chipseq.R), plus two illuminaarray-specific gates:
+# a dexseq_results slot (adds the DEU table/plot tabs) and a "control"-named
+# experiment (adds the Control probe QC tab). As with chipseq, this file
+# checks UI composition gating directly and confirms the server boots without
+# error, rather than re-driving every nested module's own reactive graph.
+
+make_illuminaarray_eselist <- function(contrasts = FALSE, contrast_stats = FALSE, gene_set_analyses = FALSE,
+                                       dexseq_results = FALSE, with_control = FALSE) {
+  n_genes <- 20
+  n_samples <- 4
+
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_samples, mu = 200, size = 5),
+    nrow = n_genes, ncol = n_samples,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("s", seq_len(n_samples)))
+  )
+
+  coldata <- S4Vectors::DataFrame(
+    row.names = colnames(counts),
+    condition = c("control", "control", "treated", "treated")
+  )
+
+  annotation <- data.frame(
+    gene_id = rownames(counts),
+    gene_name = paste0("Gene", seq_len(n_genes)),
+    row.names = rownames(counts)
+  )
+
+  ese_args <- list(
+    assays = S4Vectors::SimpleList(counts = counts), colData = coldata, annotation = annotation,
+    idfield = "gene_id", labelfield = "gene_name"
+  )
+
+  if (contrast_stats) {
+    fold_changes <- matrix(stats::rnorm(n_genes), nrow = n_genes, dimnames = list(rownames(counts), "1"))
+    ese_args$contrast_stats <- list(counts = list(fold_changes = fold_changes))
+  }
+
+  if (gene_set_analyses) {
+    ese_args$gene_set_analyses <- list(counts = list(KEGG = list(
+      "condition-control-treated" = data.frame(
+        "p value" = c(0.01), FDR = c(0.02), Direction = c("Up"),
+        row.names = "SET_A", check.names = FALSE
+      )
+    )))
+  }
+
+  if (dexseq_results) {
+    ese_args$dexseq_results <- list(data.frame(
+      groupID = c("g1", "g1"), featureID = c("E001", "E002"),
+      exonBaseMean = c(10, 20), dispersion = c(0.1, 0.1), stat = c(1, 1),
+      pvalue = c(0.01, 0.5), padj = c(0.02, 0.6),
+      control = c(0.3, 0.7), treated = c(0.6, 0.4),
+      log2fold_treated_control = c(1, -1)
+    ))
+  }
+
+  ese <- do.call(ExploratorySummarizedExperiment, ese_args)
+
+  eses <- list(counts = ese)
+
+  if (with_control) {
+    control_counts <- matrix(
+      stats::runif(4 * n_samples, 100, 200),
+      nrow = 4, dimnames = list(paste0("ctrl_probe", 1:4), colnames(counts))
+    )
+    control_annotation <- data.frame(
+      probe_id = rownames(control_counts), reporterGroup = rep("housekeeping", 4),
+      row.names = rownames(control_counts)
+    )
+    control_ese <- ExploratorySummarizedExperiment(
+      assays = S4Vectors::SimpleList(counts = control_counts), colData = coldata,
+      annotation = control_annotation, idfield = "probe_id", labelfield = "probe_id"
+    )
+    eses$control <- control_ese
+  }
+
+  eselist_args <- list(eses = eses, group_vars = "condition", default_groupvar = "condition")
+  if (gene_set_analyses) {
+    eselist_args$gene_set_id_type <- "gene_id"
+    eselist_args$gene_sets <- list(KEGG = list(SET_A = paste0("g", 1:3)))
+  }
+
+  eselist <- do.call(ExploratorySummarizedExperimentList, eselist_args)
+
+  if (contrasts) {
+    eselist@contrasts <- list(
+      list(Variable = "condition", Group.1 = "control", Group.2 = "treated")
+    )
+  }
+
+  eselist
+}
+
+test_that("illuminaarrayInput adds Feature-wise clustering unconditionally", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist())
+  expect_true(grepl("Feature-wise clustering", as.character(ui)))
+})
+
+test_that("illuminaarrayInput omits the Control probe QC tab without a 'control' experiment", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist(with_control = FALSE))
+  expect_false(grepl("Control probe QC", as.character(ui)))
+})
+
+test_that("illuminaarrayInput adds the Control probe QC tab when a 'control' experiment is present", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist(with_control = TRUE))
+  expect_true(grepl("Control probe QC", as.character(ui)))
+})
+
+test_that("illuminaarrayInput omits the DEU tabs without dexseq_results", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist(contrasts = TRUE, dexseq_results = FALSE))
+  expect_false(grepl("Differential exon usage table", as.character(ui)))
+})
+
+test_that("illuminaarrayInput adds the DEU table and plot tabs once dexseq_results is present", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist(contrasts = TRUE, dexseq_results = TRUE))
+  txt <- as.character(ui)
+
+  expect_true(grepl("Differential exon usage table", txt))
+  expect_true(grepl("Differential exon usage plot", txt))
+})
+
+test_that("illuminaarrayInput adds the gene set analysis tabs once gene_set_analyses is present", {
+  ui <- illuminaarrayInput("illuminaarray", make_illuminaarray_eselist(contrasts = TRUE, gene_set_analyses = TRUE))
+  txt <- as.character(ui)
+
+  expect_true(grepl("Gene set analyses", txt))
+  expect_true(grepl("Gene set barcode plots", txt))
+})
+
+test_that("illuminaarray boots without error for a minimal eselist", {
+  eselist <- make_illuminaarray_eselist()
+
+  expect_no_error(
+    withCallingHandlers(
+      shiny::testServer(illuminaarray, args = list(id = "illuminaarray", eselist = eselist), {
+        session$userData$plotFormat <- function() "png"
+        session$elapse(400)
+      }),
+      warning = function(w) invokeRestart("muffleWarning")
+    )
+  )
+})
+
+test_that("illuminaarray boots without error for a fully-featured eselist (contrasts, contrast_stats, gene_set_analyses, dexseq_results, control probes)", {
+  eselist <- make_illuminaarray_eselist(
+    contrasts = TRUE, contrast_stats = TRUE, gene_set_analyses = TRUE,
+    dexseq_results = TRUE, with_control = TRUE
+  )
+
+  expect_no_error(
+    withCallingHandlers(
+      shiny::testServer(illuminaarray, args = list(id = "illuminaarray", eselist = eselist), {
+        session$userData$plotFormat <- function() "png"
+        session$elapse(400)
+      }),
+      warning = function(w) invokeRestart("muffleWarning")
+    )
+  )
+})


### PR DESCRIPTION
## Summary
- Adds `testServer`-based coverage for the remaining large/composed modules from #242: `dexseqtable` happy path (extending the existing DEXSeq-missing fallback test in `test-optional-heavy-deps.R`), `dexseqplot` (previously fully untested), `genesetanalysistable`, the `genesetbarcodeplot` module's reactive logic (its plain exported helper functions are covered separately, see below), `gene`'s happy path plus direct unit tests of `geneBarplot()`/`geneModelBiotypeColors()`, and extended `differentialtable` coverage beyond its one existing smoke test (multiple contrasts, fold-change/p/q-value filtering, empty-result edge case).
- `chipseq` and `illuminaarray` are whole-app compositions of already-tested modules behind `has_slot_data()` gates — covered via UI composition-gating tests (each optional tab appears/disappears correctly) plus boot-without-error checks across minimal and fully-featured fixtures, rather than re-driving every nested submodule's reactive graph.
- DEXSeq is a Suggests-only dependency. Since `dexseqtable`/`dexseqplot` only touch `DEXSeqResults` objects via plain data.frame-style indexing plus `DEXSeq::counts()`/`plotDEXSeq()`, a plain data.frame stand-in with those two calls mocked reproduces real module behaviour without needing a full `DEXSeq::testForDEU()` pipeline.
- `tests/testthat/test-genesetbarcodeplot-module.R` is named distinctly (not `test-genesetbarcodeplot.R`) to avoid a filename collision with the sibling PR that added `plotly_barcodeplot()`/`tricubeMovingAverage()`/`quantileOfSorted()` helper-function tests under that name.
- No changes to `R/` source, tests only.

Part 4 of 4 (final part) addressing #242 (test coverage gaps).

## Test plan
- [x] `NOT_CRAN=true devtools::test()` — 0 failures (626 pass; pre-existing warnings only, none introduced by this change)
- [x] `lintr::lint_package()` — no lints

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)