### PR TITLE
perf: parallelize test suite

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -12,9 +12,6 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.R_CI }}
       R_KEEP_PKG_SOURCE: yes
-      # testthat defaults to 2 parallel test-file workers regardless of
-      # available cores; ubuntu-latest GitHub-hosted runners have 4 cores.
-      TESTTHAT_CPUS: "4"
       TEST_DATA_BASE: "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression"
       FEATURE_META_FILE: "SRP254919.gene_meta.tsv"
       SAMPLE_META_FILE: "SRP254919.samplesheet.csv"

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -12,6 +12,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.R_CI }}
       R_KEEP_PKG_SOURCE: yes
+      # testthat defaults to 2 parallel test-file workers regardless of
+      # available cores; ubuntu-latest GitHub-hosted runners have 4 cores.
+      TESTTHAT_CPUS: "4"
       TEST_DATA_BASE: "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression"
       FEATURE_META_FILE: "SRP254919.gene_meta.tsv"
       SAMPLE_META_FILE: "SRP254919.samplesheet.csv"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,3 +63,4 @@ biocViews: Software
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
 Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/tests/testthat/test-differentialtable.R
+++ b/tests/testthat/test-differentialtable.R
@@ -1,8 +1,7 @@
-# Extends the single testServer example of differentialtable() in
-# test-shinytest2.R (a basic "computes a table without error" smoke test)
-# with dedicated coverage of contrast selection and fold-change/p/q-value
-# filtering, using the shared shinytest2_eselist() fixture (60 genes x 12
-# samples, one contrast, with fold_changes/pvals/qvals populated).
+# Dedicated coverage of differentialtable()'s contrast selection and
+# fold-change/p/q-value filtering, using the shared shinytest2_eselist()
+# fixture (60 genes x 12 samples, one contrast, with
+# fold_changes/pvals/qvals populated).
 
 run_differentialtable_server <- function(eselist, extra_inputs = list(), expr) {
   inputs <- modifyList(

--- a/tests/testthat/test-shinytest2-bookmark.R
+++ b/tests/testthat/test-shinytest2-bookmark.R
@@ -1,0 +1,58 @@
+# URL bookmarking round-trip
+#
+# Runs from an on-disk app.R (see shinytest2_bookmark_app_driver) so bookmarking
+# is enabled at session construction, as in real use. Restored values are read
+# from the DOM: updateNumericInput() etc. set the control's value on restore but
+# the client input registry only reflects it once the input reports.
+#
+# Split into its own file (rather than living alongside the other rnaseq
+# AppDriver tests) since its 40s timeouts and separate on-disk-app process
+# make it the single heaviest shinytest2 test; giving it its own file lets
+# testthat's parallel workers pick it up independently of the others.
+
+test_that("a bookmark URL restores the active tab and a contrast filter value", {
+  skip_on_cran()
+
+  app <- shinytest2_bookmark_app_driver("rnaseq", "rnaseq-bookmark")
+  withr::defer(app$stop())
+  app$wait_for_idle(timeout = 40000)
+
+  expect_true(app$get_js("!!document.getElementById('shinyngs_share_view')"))
+
+  app$set_inputs(`rnaseq-rnaseq` = "diff_tables")
+  app$wait_for_idle(timeout = 40000)
+  app$set_inputs(`rnaseq-differential-differential-fold_change0` = 7)
+  app$wait_for_idle(timeout = 40000)
+
+  app$click("shinyngs_share_view")
+  app$wait_for_idle(timeout = 40000)
+  url <- app$get_js("window.location.href")
+
+  expect_match(url, "\\?", info = "bookmark should put state in the address bar")
+  expect_true(grepl("contrast_filtersets", utils::URLdecode(url)))
+  expect_false(grepl("plotly_", url), info = "transient plotly inputs are excluded")
+  expect_false(grepl("_rows_", url), info = "transient DataTable inputs are excluded")
+
+  # A full page navigation tears down the old page's Shiny JS object and boots
+  # a fresh session; wait_for_idle() errors ("An error occurred while waiting
+  # for Shiny to be stable") if called immediately afterwards, since there is
+  # no stable Shiny busy-state to observe yet. Poll the DOM directly instead.
+  app$run_js(sprintf("window.location.href = %s;", jsonlite::toJSON(url, auto_unbox = TRUE)))
+
+  restored_condition <- paste(
+    "(function(){",
+    "var e = document.getElementById('rnaseq-differential-differential-fold_change0');",
+    "return !!e && e.value === '7';",
+    "})()"
+  )
+  app$wait_for_js(restored_condition, timeout = 40000, interval = 200)
+
+  restored <- app$get_js(
+    "(function(){var e=document.getElementById('rnaseq-differential-differential-fold_change0'); return e ? String(e.value) : 'NOEL';})()"
+  )
+  expect_equal(restored, "7")
+  expect_equal(
+    app$get_js("(window.Shiny && Shiny.shinyapp) ? String(Shiny.shinyapp.$inputValues['rnaseq-rnaseq']) : 'NA'"),
+    "diff_tables"
+  )
+})

--- a/tests/testthat/test-shinytest2-chipseq.R
+++ b/tests/testthat/test-shinytest2-chipseq.R
@@ -1,0 +1,30 @@
+# chipseq shares prepareApp()'s multi-panel branch with rnaseq, so a boot +
+# one composed-module check is enough to confirm the branch wires up
+# correctly for this platform label and homeTab()/PCA composition, without
+# re-testing every rnaseq-covered panel (see test-shinytest2-rnaseq.R)
+
+test_that("the chipseq app boots and shows its ChIP-seq home tab", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("chipseq", "chipseq-boot")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+
+  expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
+  expect_match(app$get_text("body"), "downstream ChIP-seq")
+})
+
+test_that("the chipseq app's PCA tab renders a scatterplot", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("chipseq", "chipseq-pca")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+  app$set_inputs(`chipseq-chipseq` = "pca")
+  app$wait_for_idle(timeout = 20000)
+
+  outputs <- names(app$get_values()$output)
+  expect_true("chipseq-pca-pca-scatter" %in% outputs)
+})

--- a/tests/testthat/test-shinytest2-heatmap.R
+++ b/tests/testthat/test-shinytest2-heatmap.R
@@ -1,0 +1,30 @@
+# the standalone "heatmap" app type takes prepareApp()'s simpleApp() branch
+# instead of the multi-panel one (a single nav_panel wrapping one module's
+# Input/Output directly, under the "pages" nav id rather than "<type>-<type>"),
+# so it needs its own smoke test rather than reusing the rnaseq-embedded
+# heatmap tab test in test-shinytest2-rnaseq.R
+
+test_that("the standalone heatmap app renders an interactive heatmap", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("heatmap", "heatmap-standalone")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+
+  outputs <- names(app$get_values()$output)
+  expect_true("heatmap-interactiveHeatmap" %in% outputs)
+  expect_true("heatmap-heatmap-selectmatrix-geneSelect_ui" %in% outputs)
+
+  # 12 samples in shinytest2_eselist(); the expression heatmap's main trace is
+  # a gene-by-sample matrix, so its column count should match sample number.
+  widget <- jsonlite::fromJSON(
+    app$get_value(output = "heatmap-interactiveHeatmap"),
+    simplifyVector = FALSE
+  )
+  heatmap_traces <- Filter(function(tr) identical(tr$type, "heatmap"), widget$x$data)
+  expect_gt(length(heatmap_traces), 0)
+
+  main_trace <- heatmap_traces[[which.max(vapply(heatmap_traces, function(tr) length(tr$z), integer(1)))]]
+  expect_equal(length(main_trace$x), 12)
+})

--- a/tests/testthat/test-shinytest2-illuminaarray.R
+++ b/tests/testthat/test-shinytest2-illuminaarray.R
@@ -1,0 +1,30 @@
+# illuminaarray shares prepareApp()'s multi-panel branch with rnaseq, so a
+# boot + one composed-module check is enough to confirm the branch wires up
+# correctly for this platform label and homeTab()/PCA composition, without
+# re-testing every rnaseq-covered panel (see test-shinytest2-rnaseq.R)
+
+test_that("the illuminaarray app boots and shows its expression array home tab", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("illuminaarray", "illuminaarray-boot")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+
+  expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
+  expect_match(app$get_text("body"), "downstream expression array")
+})
+
+test_that("the illuminaarray app's PCA tab renders a scatterplot", {
+  skip_on_cran()
+
+  app <- shinytest2_app_driver("illuminaarray", "illuminaarray-pca")
+  withr::defer(app$stop())
+
+  app$wait_for_idle(timeout = 20000)
+  app$set_inputs(`illuminaarray-illuminaarray` = "pca")
+  app$wait_for_idle(timeout = 20000)
+
+  outputs <- names(app$get_values()$output)
+  expect_true("illuminaarray-pca-pca-scatter" %in% outputs)
+})

--- a/tests/testthat/test-shinytest2-rnaseq.R
+++ b/tests/testthat/test-shinytest2-rnaseq.R
@@ -87,56 +87,6 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
   expect_equal(length(main_trace$y), 12)
 })
 
-# URL bookmarking round-trip
-#
-# Runs from an on-disk app.R (see shinytest2_bookmark_app_driver) so bookmarking
-# is enabled at session construction, as in real use. Restored values are read
-# from the DOM: updateNumericInput() etc. set the control's value on restore but
-# the client input registry only reflects it once the input reports.
-
-test_that("a bookmark URL restores the active tab and a contrast filter value", {
-  skip_on_cran()
-
-  app <- shinytest2_bookmark_app_driver("rnaseq", "rnaseq-bookmark")
-  withr::defer(app$stop())
-  app$wait_for_idle(timeout = 40000)
-
-  expect_true(app$get_js("!!document.getElementById('shinyngs_share_view')"))
-
-  app$set_inputs(`rnaseq-rnaseq` = "diff_tables")
-  app$wait_for_idle(timeout = 40000)
-  app$set_inputs(`rnaseq-differential-differential-fold_change0` = 7)
-  app$wait_for_idle(timeout = 40000)
-
-  app$click("shinyngs_share_view")
-  app$wait_for_idle(timeout = 40000)
-  url <- app$get_js("window.location.href")
-
-  expect_match(url, "\\?", info = "bookmark should put state in the address bar")
-  expect_true(grepl("contrast_filtersets", utils::URLdecode(url)))
-  expect_false(grepl("plotly_", url), info = "transient plotly inputs are excluded")
-  expect_false(grepl("_rows_", url), info = "transient DataTable inputs are excluded")
-
-  # A full page navigation tears down the old page's Shiny JS object and boots
-  # a fresh session; wait_for_idle() errors ("An error occurred while waiting
-  # for Shiny to be stable") if called immediately afterwards, since there is
-  # no stable Shiny busy-state to observe yet. Poll the DOM directly instead.
-  app$run_js(sprintf("window.location.href = %s;", jsonlite::toJSON(url, auto_unbox = TRUE)))
-
-  restored_condition <- paste(
-    "(function(){",
-    "var e = document.getElementById('rnaseq-differential-differential-fold_change0');",
-    "return !!e && e.value === '7';",
-    "})()"
-  )
-  app$wait_for_js(restored_condition, timeout = 40000, interval = 200)
-
-  restored <- app$get_js(
-    "(function(){var e=document.getElementById('rnaseq-differential-differential-fold_change0'); return e ? String(e.value) : 'NOEL';})()"
-  )
-  expect_equal(restored, "7")
-  expect_equal(
-    app$get_js("(window.Shiny && Shiny.shinyapp) ? String(Shiny.shinyapp.$inputValues['rnaseq-rnaseq']) : 'NA'"),
-    "diff_tables"
-  )
-})
+# URL bookmarking round-trip is covered separately in
+# test-shinytest2-bookmark.R (its own file, so its 40s timeouts and separate
+# on-disk-app process don't make this file the parallel-worker bottleneck).

--- a/tests/testthat/test-shinytest2-rnaseq.R
+++ b/tests/testthat/test-shinytest2-rnaseq.R
@@ -11,93 +11,6 @@ test_that("the rnaseq app boots and shows its home tab", {
   expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
 })
 
-# the other "big" app types (chipseq, illuminaarray) share prepareApp()'s
-# multi-panel branch with rnaseq, so a boot + one composed-module check each
-# is enough to confirm the branch wires up correctly for their platform label
-# and homeTab()/PCA composition, without re-testing every rnaseq-covered panel
-
-test_that("the chipseq app boots and shows its ChIP-seq home tab", {
-  skip_on_cran()
-
-  app <- shinytest2_app_driver("chipseq", "chipseq-boot")
-  withr::defer(app$stop())
-
-  app$wait_for_idle(timeout = 20000)
-
-  expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
-  expect_match(app$get_text("body"), "downstream ChIP-seq")
-})
-
-test_that("the chipseq app's PCA tab renders a scatterplot", {
-  skip_on_cran()
-
-  app <- shinytest2_app_driver("chipseq", "chipseq-pca")
-  withr::defer(app$stop())
-
-  app$wait_for_idle(timeout = 20000)
-  app$set_inputs(`chipseq-chipseq` = "pca")
-  app$wait_for_idle(timeout = 20000)
-
-  outputs <- names(app$get_values()$output)
-  expect_true("chipseq-pca-pca-scatter" %in% outputs)
-})
-
-test_that("the illuminaarray app boots and shows its expression array home tab", {
-  skip_on_cran()
-
-  app <- shinytest2_app_driver("illuminaarray", "illuminaarray-boot")
-  withr::defer(app$stop())
-
-  app$wait_for_idle(timeout = 20000)
-
-  expect_match(app$get_text("h3.shinyngs-eyebrow"), "Jump to analysis")
-  expect_match(app$get_text("body"), "downstream expression array")
-})
-
-test_that("the illuminaarray app's PCA tab renders a scatterplot", {
-  skip_on_cran()
-
-  app <- shinytest2_app_driver("illuminaarray", "illuminaarray-pca")
-  withr::defer(app$stop())
-
-  app$wait_for_idle(timeout = 20000)
-  app$set_inputs(`illuminaarray-illuminaarray` = "pca")
-  app$wait_for_idle(timeout = 20000)
-
-  outputs <- names(app$get_values()$output)
-  expect_true("illuminaarray-pca-pca-scatter" %in% outputs)
-})
-
-# the standalone "heatmap" app type takes prepareApp()'s simpleApp() branch
-# instead (a single nav_panel wrapping one module's Input/Output directly,
-# under the "pages" nav id rather than "<type>-<type>"), so it needs its own
-# smoke test rather than reusing the rnaseq-embedded heatmap tab test below
-
-test_that("the standalone heatmap app renders an interactive heatmap", {
-  skip_on_cran()
-
-  app <- shinytest2_app_driver("heatmap", "heatmap-standalone")
-  withr::defer(app$stop())
-
-  app$wait_for_idle(timeout = 20000)
-
-  outputs <- names(app$get_values()$output)
-  expect_true("heatmap-interactiveHeatmap" %in% outputs)
-  expect_true("heatmap-heatmap-selectmatrix-geneSelect_ui" %in% outputs)
-
-  # 12 samples in shinytest2_eselist(); the expression heatmap's main trace is
-  # a gene-by-sample matrix, so its column count should match sample number.
-  widget <- jsonlite::fromJSON(
-    app$get_value(output = "heatmap-interactiveHeatmap"),
-    simplifyVector = FALSE
-  )
-  heatmap_traces <- Filter(function(tr) identical(tr$type, "heatmap"), widget$x$data)
-  expect_gt(length(heatmap_traces), 0)
-
-  main_trace <- heatmap_traces[[which.max(vapply(heatmap_traces, function(tr) length(tr$z), integer(1)))]]
-  expect_equal(length(main_trace$x), 12)
-})
-
 # pca module (exercises selectmatrix internally)
 
 test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
@@ -174,15 +87,6 @@ test_that("the Clustering Heatmap tab renders an interactive heatmap", {
   expect_equal(length(main_trace$y), 12)
 })
 
-# selectmatrix + contrasts modules, as composed by differentialtable()
-#
-# Driven via shiny::testServer() rather than AppDriver: the differential
-# table tab's contrast filter is inserted client-side via insertUI(), and
-# reliably reproducing that DOM insertion under headless chromote (including
-# its selectize.js-backed dropdown) needs more investigation than this PR's
-# scope covers. testServer exercises the same server-side reactive graph
-# directly and deterministically.
-
 # URL bookmarking round-trip
 #
 # Runs from an on-disk app.R (see shinytest2_bookmark_app_driver) so bookmarking
@@ -235,24 +139,4 @@ test_that("a bookmark URL restores the active tab and a contrast filter value", 
     app$get_js("(window.Shiny && Shiny.shinyapp) ? String(Shiny.shinyapp.$inputValues['rnaseq-rnaseq']) : 'NA'"),
     "diff_tables"
   )
-})
-
-test_that("differentialtable computes a table without error given a real contrast", {
-  skip_on_cran()
-
-  eselist <- shinytest2_eselist()
-
-  shiny::testServer(differentialtable, args = list(id = "differential", eselist = eselist), {
-    session$setInputs(
-      "expression-assay" = "counts",
-      "expression-experiment" = "counts",
-      "expression-selectmatrix-obs" = 60,
-      "expression-selectmatrix-sampleSelect" = "all",
-      "expression-selectmatrix-geneSelect" = "all"
-    )
-
-    rendered <- output$differentialtable
-    expect_type(rendered, "list")
-    expect_match(rendered[[1]], "Differential expression in assay: counts")
-  })
 })

--- a/tests/testthat/test-upset.R
+++ b/tests/testthat/test-upset.R
@@ -46,10 +46,9 @@ make_upset_eselist <- function() {
 }
 
 # Drives the upset module up to the point where its reactives are ready to
-# read, mirroring the differentialtable testServer test in
-# test-shinytest2.R: selectmatrix/contrasts inputs are only rendered
-# client-side (via uiOutput()/insertUI()), so testServer needs every one of
-# them set explicitly rather than relying on the widget defaults.
+# read. selectmatrix/contrasts inputs are only rendered client-side (via
+# uiOutput()/insertUI()), so testServer needs every one of them set
+# explicitly rather than relying on the widget defaults.
 
 run_upset_server <- function(eselist, extra_inputs = list(), expr) {
   args <- modifyList(


### PR DESCRIPTION
## Summary
- Enables testthat's built-in parallel test execution (`Config/testthat/parallel: true` in `DESCRIPTION`). Checked first for parallel-unsafe patterns (unguarded `setwd()`/`options()`/`Sys.setenv()`, shared snapshot state) — none found.
- testthat parallelizes at *file* granularity, so the old `test-shinytest2.R` (the suite's heaviest file, with ~9 headless-Chrome `AppDriver` launches across 4 app types) is split into `test-shinytest2-rnaseq.R`, `test-shinytest2-chipseq.R`, `test-shinytest2-illuminaarray.R`, `test-shinytest2-heatmap.R`, and `test-shinytest2-bookmark.R` (the single heaviest test — 40s timeouts, spins up a separate on-disk app process — split out on its own so it doesn't dominate whichever worker picks up the rnaseq file).
- Drops the one `testServer`-based `differentialtable` test that was at the end of the old file — fully superseded by the dedicated coverage already in `test-differentialtable.R` (same assertions, plus much more). Fixed two now-stale comments in `test-differentialtable.R`/`test-upset.R` that referenced the old filename and the deleted test.
- No changes to `R/` source, tests/CI config only.

## Measured impact — verified on real CI, not just local benchmarking
Local `devtools::test()` runs on a 10-core machine suggested a much bigger win, but that doesn't reflect the actual `ubuntu-latest` runner (4 cores). Pushing `TESTTHAT_CPUS=4` to match its core count actually **failed CI**: 4 concurrent `shinytest2` AppDriver tests (each launching a Shiny app + headless Chrome) oversubscribed the runner and a Chromote `Page.navigate` call timed out. Reverted to testthat's conservative built-in default of 2 workers, which passes cleanly and gives a real, CI-verified improvement:

| | Baseline (sequential, pre-PR) | This PR (parallel, 2 workers) |
|---|---|---|
| `R CMD check` step | 451s | 384s (−15%) |
| `covr` coverage step | 437s | 340s (−22%) |
| **Total job** | **19m8s** | **15m43s (≈18% faster)** |

`covr::package_coverage()` confirmed compatible with parallel testthat enabled (89.3% reported locally, no instrumentation issues; CI run stayed above the 55% floor).

## Test plan
- [x] CI run at `TESTTHAT_CPUS=4` — failed (Chrome/Shiny resource contention, see above)
- [x] CI run reverted to testthat's default of 2 workers — passed, 0 failures / 880 pass
- [x] `lintr::lint_package()` — no lints

🤖 Generated with [Claude Code](https://claude.com/claude-code)