### PR TITLE
Add breathing room between consecutive images in the module catalogue

### DIFF
--- a/vignettes/articles/modules.Rmd
+++ b/vignettes/articles/modules.Rmd
@@ -52,7 +52,11 @@ the scree curve via `plotly_screeplot`.
 
 ![Components plot for a 3D PCA, coloured by sample group](img/pca.png)
 
+<br/>
+
 ![Loading plot showing which features contribute most to each component](img/pca-loadings.png)
+
+<br/>
 
 ![Scree plot: percentage and cumulative percentage of variance explained by component](img/pca-scree.png)
 
@@ -373,6 +377,8 @@ are not offered for counting.
 
 ![Sample metadata table](img/sample-metadata.png)
 
+<br/>
+
 ![Category counts for the sample metadata, split by group](img/sample-metadata-categorycounts.png)
 
 ### Row / feature metadata table
@@ -386,5 +392,7 @@ excluding identifier-like fields.
 *Inputs:* row (feature) metadata for the selected experiment.
 
 ![Row/feature metadata table](img/feature-metadata.png)
+
+<br/>
 
 ![Category counts for the feature metadata, by annotation source](img/feature-metadata-categorycounts.png)


### PR DESCRIPTION
## Summary
Small follow-up to #260. A few sections in `vignettes/articles/modules.Rmd` (PCA, sample metadata table, feature metadata table) stack two or three screenshots back to back with no prose between them, so one image's caption sits right up against the next image with no visual gap. Adds a `<br/>` between each pair.

## Test plan
- [x] `pkgdown::build_article("articles/modules")` builds clean
- [x] Verified via Playwright that a visible gap now exists between each caption and the next image, and confirmed no broken images