### PR TITLE
Outline top-gene boxplot points against same-colored box fills

### DIFF
--- a/R/topgeneboxplot.R
+++ b/R/topgeneboxplot.R
@@ -371,8 +371,7 @@ static_topgene_boxplots <- function(assay, groupby, genes, annotations = NULL, l
     scale_fill_manual(name = "Group", values = palette)
 
   if (beeswarm) {
-    p <- p + ggbeeswarm::geom_quasirandom(aes(color = group), width = 0.2, size = 1.5, alpha = 0.8) +
-      scale_color_manual(values = palette, guide = "none")
+    p <- p + ggbeeswarm::geom_quasirandom(shape = 21, color = "black", stroke = 0.3, width = 0.2, size = 1.5, alpha = 0.8)
   }
 
   p <- p + facet_wrap(~gene, ncol = ncol, scales = "free_y", labeller = as_labeller(topgeneFacetLabels(labels, genes)))
@@ -442,7 +441,7 @@ interactive_topgene_boxplots <- function(assay, groupby, genes, annotations = NU
         type = "box", y = values[groups == g], name = g, legendgroup = g,
         boxpoints = if (beeswarm) "all" else "outliers", jitter = 0.4, pointpos = 0,
         fillcolor = palette[[g]], line = list(color = "black"),
-        marker = list(color = palette[[g]]),
+        marker = list(color = palette[[g]], line = list(color = "black", width = 1)),
         showlegend = i == 1
       )
     }


### PR DESCRIPTION
## Summary
- Beeswarm/jitter points in the top-gene boxplots share the box's palette color with no border, so a point sitting inside or on the edge of its box visually blends into the fill or interrupts the box outline.
- Adds a thin black stroke to points in both renderers: `static_topgene_boxplots()` (ggplot, switched the beeswarm layer to `shape = 21` with `stroke = 0.3`) and `interactive_topgene_boxplots()` (plotly, added `marker.line`).

## Test plan
- [x] `lintr::lint()` clean on the changed file
- [x] `testthat` suite for `topgeneboxplot` (46 tests) passes
- [x] Verified visually in the running app (Differential > Top gene boxplots): points that overlap box fills/edges now show a clear black outline instead of disappearing into them