### PR TITLE
Fix dark mode toggle needing two clicks on light-resolved load

### DIFF
--- a/inst/www/shinyngs.js
+++ b/inst/www/shinyngs.js
@@ -85,17 +85,10 @@
     themeAllPlots(false);
   }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-bs-theme"] });
 
-  // Work around a bslib bug (srcts inputDarkMode.ts, shipped in bslib 0.9.0):
-  // <bslib-input-dark-mode>'s connectedCallback resolves an initial "light"
-  // theme with `this.mode == "light"` - a stray comparison, not an assignment
-  // - so its internal mode stays undefined whenever the page resolves to
-  // light on load. It then reflects that undefined mode back onto
-  // data-bs-theme (as the literal string "undefined"), clobbering the value
-  // the no-flash script set - so the attribute can't be trusted as a source
-  // of truth here either. The toggle needs one click just to catch up to the
-  // theme that's actually showing before a second click can flip it. Force
-  // the component's mode from the same OS-preference check the no-flash
-  // script uses, independent of any bslib-internal state.
+  // <bslib-input-dark-mode> can start desynced from the visible theme on a
+  // light-resolved load, needing an extra click before it responds. Force its
+  // mode from the same OS-preference check the no-flash script uses, rather
+  // than trusting data-bs-theme, which the component can itself miswrite.
   $(function () {
     customElements.whenDefined("bslib-input-dark-mode").then(function () {
       var el = document.querySelector("bslib-input-dark-mode");

--- a/inst/www/shinyngs.js
+++ b/inst/www/shinyngs.js
@@ -85,6 +85,26 @@
     themeAllPlots(false);
   }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-bs-theme"] });
 
+  // Work around a bslib bug (srcts inputDarkMode.ts, shipped in bslib 0.9.0):
+  // <bslib-input-dark-mode>'s connectedCallback resolves an initial "light"
+  // theme with `this.mode == "light"` - a stray comparison, not an assignment
+  // - so its internal mode stays undefined whenever the page resolves to
+  // light on load. It then reflects that undefined mode back onto
+  // data-bs-theme (as the literal string "undefined"), clobbering the value
+  // the no-flash script set - so the attribute can't be trusted as a source
+  // of truth here either. The toggle needs one click just to catch up to the
+  // theme that's actually showing before a second click can flip it. Force
+  // the component's mode from the same OS-preference check the no-flash
+  // script uses, independent of any bslib-internal state.
+  $(function () {
+    customElements.whenDefined("bslib-input-dark-mode").then(function () {
+      var el = document.querySelector("bslib-input-dark-mode");
+      if (!el) return;
+      var theme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      if (el.mode !== theme) el.mode = theme;
+    });
+  });
+
   // Re-theme each plot as Shiny (re)renders it. The output element id is
   // e.name; the plotly widget is that element or a descendant of it.
   $(document).on("shiny:value", function (e) {


### PR DESCRIPTION
## Summary
- Works around a bslib 0.9.0 bug where `<bslib-input-dark-mode>` never assigns its internal `mode` on a light-resolved load (`this.mode == "light"` instead of `this.mode = "light"` in its `connectedCallback`), leaving the toggle out of sync with the visible theme until a second click catches it up. The buggy code also clobbers `data-bs-theme` with the literal string `"undefined"`, so that attribute can't be trusted as a source of truth either.
- Forces the toggle's `mode` from the same `prefers-color-scheme` check the existing no-flash script already uses, as soon as the component upgrades, so the toggle starts in sync with the visible theme and flips on the first click in either direction.

## Test plan
- [x] Verified via Playwright against a running app in both OS-light and OS-dark starting conditions: toggle now flips theme on the first click, and repeated clicking continues to work correctly in both directions.