### PR TITLE
Fix interactive MAD/outlier plot crash from colorby/colorby_menu ambiguity

### DIFF
--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -359,20 +359,25 @@ drawLines <- function(p, x, y, lines = NULL, hline_thresholds = list(), vline_th
     # A caller-supplied xrange/yrange is used as-is instead, e.g. so a
     # volcano plot's threshold lines can span a symmetric fold-change range
     # rather than the plotted points' raw (and possibly asymmetric) extent.
+    #
+    # x/y are only padded when numeric: a discrete axis (e.g. the MAD/outlier
+    # plot's sample groups) has no meaningful range to pad, so the line
+    # endpoints computed above (from is.finite(), which is FALSE throughout
+    # for non-numeric data) are left as-is rather than forced onto a range.
     if (plot_type != "scatter3d") {
-      if (is.null(xrange)) {
+      if (is.null(xrange) && is.numeric(x)) {
         xrange <- range(x[is.finite(x)])
         xrange <- xrange + c(-1, 1) * diff(xrange) * 0.05
       }
-      if (is.null(yrange)) {
+      if (is.null(yrange) && is.numeric(y)) {
         yrange <- range(y[is.finite(y)])
         yrange <- yrange + c(-1, 1) * diff(yrange) * 0.05
       }
 
       lines <- do.call(rbind, lapply(split(lines, lines$name), function(segment) {
-        if (length(unique(segment$y)) == 1) {
+        if (!is.null(xrange) && length(unique(segment$y)) == 1) {
           segment$x <- xrange
-        } else if (length(unique(segment$x)) == 1) {
+        } else if (!is.null(yrange) && length(unique(segment$x)) == 1) {
           segment$y <- yrange
         }
         segment

--- a/exec/exploratory_plots.R
+++ b/exec/exploratory_plots.R
@@ -362,7 +362,7 @@ if (!is.null(plotdata)) {
   mad_plot_args <- list(
     x = plotdata$group,
     y = plotdata$mad,
-    color = plotdata$outlier,
+    colorby = plotdata$outlier,
     hline_thresholds = c("Outlier threshold" = opt$outlier_mad_threshold),
     legend_title = "Outlier status",
     labels = rownames(plotdata),

--- a/tests/testthat/test-exec-smoke.R
+++ b/tests/testthat/test-exec-smoke.R
@@ -102,6 +102,30 @@ test_that("exploratory_plots.R runs against fixtures and writes plot PNGs", {
   }
 })
 
+test_that("exploratory_plots.R --write_html runs against fixtures and writes interactive plots, including the MAD/outlier plot whose x-axis is the (discrete) sample group", {
+  skip_on_cran()
+
+  outdir <- withr::local_tempdir()
+
+  result <- run_exec_script("exploratory_plots.R", c(
+    "--sample_metadata", exec_smoke_fixture("SRP254919.samplesheet.csv"),
+    "--feature_metadata", exec_smoke_fixture("SRP254919.gene_meta.tsv"),
+    "--assay_files", exec_smoke_fixture("SRP254919.salmon.merged.gene_counts.top1000cov.tsv"),
+    "--contrast_variable", "treatment",
+    "--outdir", outdir,
+    "--write_html"
+  ))
+
+  expect_exec_success(result)
+
+  expected_htmls <- c("boxplot.html", "density.html", "pca2d.html", "pca3d.html", "mad_correlation.html")
+  for (html_file in expected_htmls) {
+    html_path <- file.path(outdir, "html", html_file)
+    expect_true(file.exists(html_path), info = html_path)
+    expect_gt(file.size(html_path), 0)
+  }
+})
+
 test_that("exploratory_plots.R fails clearly when a mandatory argument is missing", {
   skip_on_cran()
 

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -73,6 +73,23 @@ test_that("xrange/yrange override the auto-computed axis range and the extent of
   expect_equal(sort(hline_trace$x), c(-10, 10))
 })
 
+test_that("hline_thresholds don't error against a discrete x-axis (e.g. the MAD/outlier plot's sample groups)", {
+  # The threshold line's endpoints are derived from the (discrete) x range,
+  # which isn't a meaningful concept here, so unlike the numeric-axis case
+  # above this doesn't assert the line itself renders - only that a discrete
+  # x-axis no longer crashes drawLines()'s numeric range/padding logic.
+  x <- c("groupA", "groupA", "groupB", "groupB")
+  y <- c(-6, -1, 2, 7)
+
+  p <- interactive_scatterplot(
+    x = x, y = y,
+    colorby = c(TRUE, FALSE, FALSE, TRUE),
+    hline_thresholds = c("Outlier threshold" = -5)
+  )
+
+  expect_no_error(plotly::plotly_build(p))
+})
+
 # interactive_scatterplot() colorby_menu
 
 test_that("colorby_menu adds a dropdown and shows only the first option's points initially", {


### PR DESCRIPTION
## Summary

- `exec/exploratory_plots.R`'s MAD/outlier plot built its plot args with the abbreviated `color =` key, which unambiguously partial-matched `interactive_scatterplot()`'s `colorby` parameter until `colorby_menu` was added in 3.1.0. With both `colorby` and `colorby_menu` now starting with "color", R can no longer resolve the partial match and errors, so any module call with `--write_html` crashed on the MAD plot. Fixed by spelling out `colorby =` in full.
- Fixing that surfaced a second bug: `drawLines()`'s threshold-line range padding assumes a numeric axis. The MAD plot's x-axis is discrete (sample group), so once past the first bug it hit `diff()` on a non-numeric range and crashed. Guarded the padding/line-extension logic to numeric axes only, matching the pre-3.1.0 behaviour of leaving such lines unpadded (with a benign plotly warning) instead of erroring.
- Neither bug was caught by CI because the `exploratory_plots.R` exec-smoke test never passed `--write_html`, so the interactive/plotly code path was never exercised for any of its plots (boxplot, density, PCA, dendrogram, MAD). Added that coverage, plus a focused `drawLines()` unit test for a discrete x-axis combined with `hline_thresholds`.

## Test plan

- [x] Reproduced both crashes locally against an unpatched 3.1.0 install (direct R repro + the actual `exec/exploratory_plots.R` script against the SRP254919 test fixtures with `--write_html`)
- [x] Confirmed the new tests fail against the unpatched source, and pass with the fix
- [x] Full `testthat` suite green: `FAIL 0 | WARN 52 | SKIP 11 | PASS 835` (skips are DEXSeq/shinytest2 not installed, unrelated)
- [x] `lintr::lint_package()` clean on all changed files