### PR TITLE
Fix low-contrast RColorBrewer colours for 2-3 category plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,14 @@
   goes through `message()`/`warning()` rather than `print()`, so it can be
   suppressed and captured through R's condition system.
 
+## Bug fixes
+
+* `make_color_scale()` picked a named RColorBrewer palette's own 2-colour
+  scheme by interpolating its full colour set down to 3 shades and
+  subsetting, which could land on adjacent, low-contrast hues (e.g. `"Set1"`
+  giving red and orange rather than red and blue) for 2-3 category plots
+  such as `interactive_topgene_boxplots()`'s group legend.
+
 ## Maintenance
 
 * Removed the unused exported function `geom_mean()`; geometric means are

--- a/R/colormaker.R
+++ b/R/colormaker.R
@@ -130,8 +130,11 @@ make_color_scale <- function(ncolors, palette = COLORBLIND_PALETTE_NAME) {
   if (ncolors > paletteinfo[palette, "maxcolors"]) {
     cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(ncolors)
   } else if (ncolors < 3) {
-    cols <- colorRampPalette(RColorBrewer::brewer.pal(paletteinfo[palette, "maxcolors"], palette))(3)
-    cols <- cols[seq_len(ncolors)]
+    # RColorBrewer refuses n < 3, so pull the 3-colour qualitative set and
+    # subset it rather than colorRampPalette()-ing the full maxcolors palette
+    # down to 3, which picks adjacent hues (e.g. Set1 red/orange) with far
+    # less contrast than the palette's own low-n colours (e.g. red/blue).
+    cols <- RColorBrewer::brewer.pal(3, palette)[seq_len(ncolors)]
   } else {
     cols <- RColorBrewer::brewer.pal(ncolors, palette)
   }

--- a/tests/testthat/test-colormaker.R
+++ b/tests/testthat/test-colormaker.R
@@ -40,3 +40,10 @@ test_that("make_color_scale interpolates and warns when ncolors exceeds the base
   expect_length(cols, 20)
   expect_equal(length(unique(cols)), 20)
 })
+
+test_that("make_color_scale uses an RColorBrewer palette's own low-n colours below 3, not an interpolated subset", {
+  cols <- make_color_scale(2, palette = "Set1")
+
+  expect_equal(sort(cols), sort(RColorBrewer::brewer.pal(3, "Set1")[1:2]))
+  expect_false("#FF7F00" %in% cols) # the muddled orange colorRampPalette() used to produce here
+})


### PR DESCRIPTION
## Summary

- `make_color_scale()` picked a named RColorBrewer palette's 1-2 colour scheme by interpolating the palette's full colour set down to 3 shades with `colorRampPalette()` and subsetting, which could land on adjacent, low-contrast hues instead of the palette's own distinct low-count colours (`"Set1"` gave red and orange rather than red and blue).
- This is the underlying cause of #269: `palette_name = "Set1"` was in fact being honoured by `interactive_topgene_boxplots()`, it just produced another red/orange-ish pair, which read as no change from the colour-blind default.
- Now pulls `RColorBrewer::brewer.pal(3, palette)` directly (RColorBrewer's minimum n) and subsets from that.

## Test plan

- [x] Added a regression test pinning `make_color_scale(2, palette = "Set1")` to Set1's real 3-colour set rather than the muddled interpolated one.
- [x] Verified the issue's MRE with `palette_name = "Set1"` now renders red/blue instead of red/orange.
- [x] `testthat::test_file()` on `test-colormaker.R` and `test-topgeneboxplot.R` pass.
- [x] `lintr::lint()` clean on changed files.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)