### PR TITLE
Fix DataTables searchable[j] crash in differential set intersection table

### DIFF
--- a/R/upset.R
+++ b/R/upset.R
@@ -330,7 +330,12 @@ upset <- function(id, eselist, setlimit = 16) {
 
     # Provide the differential set summary for download
 
-    simpletable("upset", downloadMatrix = contrast_reactives$makeDifferentialSetSummary, displayMatrix = contrast_reactives$makeDifferentialSetSummary, filter = "none", filename = "differential_summary", rownames = FALSE)
+    # server = FALSE: the number of columns here changes depending on how many
+    # filter sets are selected (the "Query" column is dropped when there's
+    # only one), which can race a debounced control change against DT's
+    # server-side paging (see simpletable()'s `server` argument).
+
+    simpletable("upset", downloadMatrix = contrast_reactives$makeDifferentialSetSummary, displayMatrix = contrast_reactives$makeDifferentialSetSummary, filter = "none", filename = "differential_summary", rownames = FALSE, server = FALSE)
   })
 }
 


### PR DESCRIPTION
## Summary
- The "Differential set intersection" panel's summary table crashed in the deployed example app with `DataTables warning: table id=DataTables_Table_0 - Error in if (!searchable[j]) next: argument is of length zero`
- The table's data source (`makeDifferentialSetSummary`) varies its column count depending on the number of selected filter sets (drops the "Query" column when only one is selected), which breaks DT's server-side paging assumptions
- Sets `server = FALSE` for this table, matching the existing fix for the same issue in `heatmap.R` and `pca.R`

## Test plan
- [ ] Load the differential set intersection panel and toggle between one and multiple selected filter sets, confirming no DataTables JS error appears