### PR TITLE
Document that fold_change_scale=auto converts log2 values to linear

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,13 @@
   (`ExploratorySummarizedExperiment()`,
   `ExploratorySummarizedExperimentList()`), the file readers (`read_matrix()`
   and friends) and several compute helpers.
+* Clarified that `read_differential()`/`compile_contrast_data()` and the
+  `--fold_change_scale` CLI flag always return/store fold changes on a linear
+  scale: whenever the scale resolves to `log2` (the common case for a
+  `log2FoldChange`-named column), the values are converted from the file's
+  log2 scale to linear, so callers relying on passthrough of the raw file
+  values should pass `fold_change_scale = "linear"` explicitly
+  ([#272](https://github.com/pinin4fjords/shinyngs/issues/272)).
 
 ## New features
 

--- a/R/foldchange-scale.R
+++ b/R/foldchange-scale.R
@@ -189,14 +189,19 @@ read_stats_table <- function(filename, feature_id_column = NULL, pval_column = N
 #' @param fc_column Column of stats with fold changes
 #' @param fold_change_scale Scale of the values in \code{fc_column}: one of
 #'   \code{"auto"} (default, infer and validate from the column name and data
-#'   distribution), \code{"log2"} or \code{"linear"}. See
+#'   distribution), \code{"log2"} or \code{"linear"}. Whenever the resolved
+#'   scale is \code{"log2"} (whether resolved automatically or declared
+#'   explicitly), \code{fc_column} in the returned data frame is converted to
+#'   linear scale - it will not match the raw file values. Pass
+#'   \code{"linear"} for passthrough of the file's values as-is. See
 #'   \code{\link{resolve_foldchange_scale}}.
 #' @param unlog_foldchanges Deprecated, use \code{fold_change_scale} instead.
 #'   Reverse a log on fold changes? Set to TRUE if values are logged.
 #'
 #' @return output Validated selected columns of differential stats files as a
 #'   data frame, with the resolved scale attached as the \code{fold_change_scale}
-#'   attribute.
+#'   attribute. \code{fc_column} is always on a linear scale in the returned
+#'   data frame - see \code{fold_change_scale} above.
 #' @export
 #'
 #' @examples
@@ -259,11 +264,18 @@ read_differential <- function(filename,
 #'   \code{"auto"} (default), \code{"log2"} or \code{"linear"}. Resolved once
 #'   across the fold changes combined from all \code{differential_stats_files},
 #'   rather than per-file, so contrasts from the same experiment are treated
-#'   consistently. See \code{\link{resolve_foldchange_scale}}.
+#'   consistently. Whenever the resolved scale is \code{"log2"}, the
+#'   \code{fold_changes} element of the returned list is converted to linear
+#'   scale - it will not match the raw file values. Pass \code{"linear"} for
+#'   passthrough of the files' values as-is. See
+#'   \code{\link{resolve_foldchange_scale}}.
 #' @param unlog_foldchanges Deprecated, use \code{fold_change_scale} instead.
 #'   Should fold change values be unlogged?
 #'
-#' @return output A named list of data frames by statistic, number of columns equal to input file number
+#' @return output A named list of data frames by statistic (\code{fold_changes}
+#'   is always on a linear scale, see \code{fold_change_scale} above;
+#'   also \code{pvals}, \code{qvals}), number of columns equal to input file
+#'   number
 
 compile_contrast_data <-
   function(differential_stats_files,

--- a/man/compile_contrast_data.Rd
+++ b/man/compile_contrast_data.Rd
@@ -29,13 +29,20 @@ compile_contrast_data(
 \code{"auto"} (default), \code{"log2"} or \code{"linear"}. Resolved once
 across the fold changes combined from all \code{differential_stats_files},
 rather than per-file, so contrasts from the same experiment are treated
-consistently. See \code{\link{resolve_foldchange_scale}}.}
+consistently. Whenever the resolved scale is \code{"log2"}, the
+\code{fold_changes} element of the returned list is converted to linear
+scale - it will not match the raw file values. Pass \code{"linear"} for
+passthrough of the files' values as-is. See
+\code{\link{resolve_foldchange_scale}}.}
 
 \item{unlog_foldchanges}{Deprecated, use \code{fold_change_scale} instead.
 Should fold change values be unlogged?}
 }
 \value{
-output A named list of data frames by statistic, number of columns equal to input file number
+output A named list of data frames by statistic (\code{fold_changes}
+  is always on a linear scale, see \code{fold_change_scale} above;
+  also \code{pvals}, \code{qvals}), number of columns equal to input file
+  number
 }
 \description{
 Compile contrast stats for inclusion in shinyngs

--- a/man/read_differential.Rd
+++ b/man/read_differential.Rd
@@ -27,7 +27,11 @@ read_differential(
 
 \item{fold_change_scale}{Scale of the values in \code{fc_column}: one of
 \code{"auto"} (default, infer and validate from the column name and data
-distribution), \code{"log2"} or \code{"linear"}. See
+distribution), \code{"log2"} or \code{"linear"}. Whenever the resolved
+scale is \code{"log2"} (whether resolved automatically or declared
+explicitly), \code{fc_column} in the returned data frame is converted to
+linear scale - it will not match the raw file values. Pass
+\code{"linear"} for passthrough of the file's values as-is. See
 \code{\link{resolve_foldchange_scale}}.}
 
 \item{unlog_foldchanges}{Deprecated, use \code{fold_change_scale} instead.
@@ -36,7 +40,8 @@ Reverse a log on fold changes? Set to TRUE if values are logged.}
 \value{
 output Validated selected columns of differential stats files as a
   data frame, with the resolved scale attached as the \code{fold_change_scale}
-  attribute.
+  attribute. \code{fc_column} is always on a linear scale in the returned
+  data frame - see \code{fold_change_scale} above.
 }
 \description{
 Read tables of differential statistics

--- a/vignettes/articles/build-from-files.Rmd
+++ b/vignettes/articles/build-from-files.Rmd
@@ -145,7 +145,12 @@ the same data model:
   those statistics (usually the normalised matrix).
 * `--fold_change_scale` - `log2`, `linear` or `auto`; `auto` infers the scale
   from the column name and value distribution and errors if the signals
-  disagree.
+  disagree. Whenever the resolved scale is `log2`, the fold changes stored in
+  the app are converted to linear - shinyngs always works with fold changes on
+  a linear scale internally, so a `log2FoldChange`-named column (or one whose
+  values are distributed like log2 fold changes) will not appear in the app
+  as it does in the input file. Pass `--fold_change_scale linear` if you want
+  the input file's values used as-is.
 
 For the complete flag reference, including grouping variables, gene-model
 support (`--ensembl_species`) and shinyapps.io deployment (`--deploy_app`), see

--- a/vignettes/articles/cli.Rmd
+++ b/vignettes/articles/cli.Rmd
@@ -97,7 +97,7 @@ contrast file and differential results even for a largely exploratory app.)
 | `-c`, `--contrast_file` | character; `NULL` | CSV-format contrast file with variable, reference and target in the first 3 columns. |
 | `-d`, `--differential_results` | character; `NULL` | Comma-separated list of CSV/TSV files (fold change and p value at minimum), one per contrast-file row. |
 | `-k`, `--fold_change_column` | character; `"log2FoldChange"` | Column in differential results holding fold changes. |
-| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_column`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals. |
+| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_column`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals; `log2`-resolved values are converted to linear (see the [build-from-files guide](build-from-files.html)). |
 | `-u`, `--unlog_foldchanges` | flag; `NULL` | Deprecated - use `--fold_change_scale=log2`. Set if fold changes should be unlogged. |
 | `-p`, `--pval_column` | character; `"padj"` | Column in differential results holding p values. |
 | `-q`, `--qval_column` | character; `"padj"` | Column in differential results holding q values / adjusted p values. |
@@ -273,7 +273,7 @@ Mandatory arguments: `--differential_file`, `--feature_metadata`, `--outdir`,
 | `-u`, `--p_value_threshold` | double; `0.05` | p value threshold for differential expression. |
 | `-r`, `--reference_level` | character; — | Annotation label: negative fold changes are annotated as higher in this group. |
 | `-t`, `--treatment_level` | character; — | Annotation label: positive fold changes are annotated as higher in this group. |
-| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_col`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals. |
+| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_col`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals; `log2`-resolved values are converted to linear (see the [build-from-files guide](build-from-files.html)). |
 | `-s`, `--unlog_foldchanges` | flag; `NULL` | Deprecated - use `--fold_change_scale=log2`. Set if fold changes should be unlogged. |
 | `-x`, `--write_html` | flag; `FALSE` | Also produce an interactive HTML output alongside the PNG. |
 | `-p`, `--palette_name` | character; `"colorblind"` | `colorblind` for the colour-blind-safe palette, or a valid RColorBrewer palette name. |
@@ -321,7 +321,7 @@ Mandatory arguments: `--sample_metadata`, `--assay_files`.
 | `-c`, `--contrasts_file` | character; `NULL` | CSV-format contrast file with variable, reference and target in the first 3 columns. |
 | `-d`, `--differential_results` | character; `NULL` | Tab-separated files (fold change and p value at minimum), one per contrast-file row. |
 | `-k`, `--fold_change_column` | character; `"log2FoldChange"` | Column in differential results holding fold changes. |
-| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_column`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals. |
+| `--fold_change_scale` | character; `"auto"` | Scale of `--fold_change_column`: `log2`, `linear` or `auto`. `auto` infers from the column name and value distribution, erroring on conflicting signals; `log2`-resolved values are converted to linear (see the [build-from-files guide](build-from-files.html)). |
 | `-u`, `--unlog_foldchanges` | flag; `NULL` | Deprecated - use `--fold_change_scale=log2`. Set if fold changes should be unlogged. |
 | `-p`, `--pval_column` | character; `"padj"` | Column in differential results holding p values. |
 | `-q`, `--qval_column` | character; `"padj"` | Column in differential results holding q values / adjusted p values. |


### PR DESCRIPTION
## Summary

- `read_differential()`, `compile_contrast_data()` and the `--fold_change_scale` CLI flag always return/store fold changes on a linear scale. When the scale resolves to `log2` (the common case for a `log2FoldChange`-named column), the values are converted from log2 to linear before being handed back to the caller.
- This is correct and intentional internally (shinyngs's own plots/thresholds expect linear fold changes), but it wasn't documented anywhere a direct caller of these functions/flags would see it, so a consumer expecting passthrough of the raw file values can be surprised - see nf-core/differentialabundance#748.
- Adds explicit callouts to the `read_differential()`/`compile_contrast_data()` roxygen docs (and regenerated `.Rd` files), the CLI reference table (all three affected flag rows), the build-from-files vignette, and a NEWS.md entry.

Closes #272.

## Test plan

- [x] `devtools::test(filter = "accessory")` passes (unrelated pre-existing warnings only)
- [x] `roxygen2::roxygenise()` run to regenerate `man/read_differential.Rd` and `man/compile_contrast_data.Rd` from the updated roxygen comments
- Docs-only change; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)