### PR TITLE
Fix excessive row height in standalone interactive_pca_metadata_heatmap

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -517,11 +517,12 @@ heatmap <- function(id, eselist, type = "expression") {
 #' @param display_numbers Boolean, should the (possibly scaled/ transformed)
 #'   values in \code{plotmatrix} be displayed on the heatmap cells?
 #' @param hide_colorbar Boolean, should the color scale legend be hidden?
-#' @param plot_height The total rendered height of the plot in pixels, used to
-#'   convert the fixed-pixel annotation row height into the fraction
-#'   \code{heatmaply()} expects. Should match the \code{height} the plot is
-#'   actually rendered at (e.g. the \code{height} argument of the
-#'   \code{plotlyOutput()} it's displayed in).
+#' @param plot_height The total rendered height of the plot in pixels. Passed
+#'   through to \code{heatmaply()} as its \code{height} argument, and also used
+#'   to convert the fixed-pixel annotation row height into the fraction
+#'   \code{heatmaply()} expects. When displayed inside a
+#'   \code{plotlyOutput()}, the latter's own \code{height} argument should
+#'   match this value so the container and the widget agree.
 #' @param ... Additional arguments passed to \code{heatmaply()}
 #'
 #' @return output A plotly htmlwidget as produced by heatmaply()
@@ -628,7 +629,8 @@ interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cl
     colors = colors, cexCol = cexCol, cexRow = cexRow, revC = FALSE, labRow = rownames(plotmatrix),
     col_side_colors = col_side_colors, col_side_palette = col_side_palette, plot_method = "plotly",
     subplot_heights = subplot_heights, subplot_margin = 0.01, grid_gap = 1, hide_colorbar = hide_colorbar,
-    cellnote = if (display_numbers) round(plotmatrix, 2) else NULL, draw_cellnote = display_numbers, ...
+    cellnote = if (display_numbers) round(plotmatrix, 2) else NULL, draw_cellnote = display_numbers,
+    height = plot_height, ...
   )
 
   # heatmaply's branches_lwd argument only takes effect for plot_method = "ggplot";

--- a/man/interactive_heatmap.Rd
+++ b/man/interactive_heatmap.Rd
@@ -49,11 +49,12 @@ values in \code{plotmatrix} be displayed on the heatmap cells?}
 
 \item{hide_colorbar}{Boolean, should the color scale legend be hidden?}
 
-\item{plot_height}{The total rendered height of the plot in pixels, used to
-convert the fixed-pixel annotation row height into the fraction
-\code{heatmaply()} expects. Should match the \code{height} the plot is
-actually rendered at (e.g. the \code{height} argument of the
-\code{plotlyOutput()} it's displayed in).}
+\item{plot_height}{The total rendered height of the plot in pixels. Passed
+through to \code{heatmaply()} as its \code{height} argument, and also used
+to convert the fixed-pixel annotation row height into the fraction
+\code{heatmaply()} expects. When displayed inside a
+\code{plotlyOutput()}, the latter's own \code{height} argument should
+match this value so the container and the widget agree.}
 
 \item{...}{Additional arguments passed to \code{heatmaply()}}
 }


### PR DESCRIPTION
## Summary
- `interactive_heatmap()` computed a `plot_height` but only used it to convert the fixed-pixel annotation-bar height into a fraction for `heatmaply()` - it never actually passed `height` through to `heatmaply::heatmaply()`.
- Inside the Shiny app this was masked because `plotlyOutput(..., height = plotHeight())` forces the container size regardless. But calling `interactive_pca_metadata_heatmap()` standalone (e.g. from the nf-core/differentialabundance Quarto report) returns a bare widget with no such override, so it fell back to plotly's default sizing and a handful of metadata rows got stretched across it.
- Now passes `height = plot_height` into the `heatmaply()` call, so the widget's own rendered height matches the intended row-scaled height in both contexts.

## Test plan
- [x] Ran the MRE from #270 - widget now reports `height: 190` (2 metadata rows) instead of falling back to a default
- [x] `devtools::test(filter = "^heatmap$")` - 15/15 pass
- [x] Confirmed the pre-existing `test-shinytest2-heatmap.R` failures are unrelated (fail identically on `develop`, environment/headless-browser issue)

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)