### PR TITLE
Fix highest-order intersection always counted as 0 in upset_calculate_intersections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,13 @@
   subsetting, which could land on adjacent, low-contrast hues (e.g. `"Set1"`
   giving red and orange rather than red and blue) for 2-3 category plots
   such as `interactive_topgene_boxplots()`'s group legend.
+* `upset_calculate_intersections()` always reported the highest-order
+  (all-sets) intersection as 0 under the default
+  `intersection_assignment_type = "upset"`, because the top intersection's
+  own index range for "higher-order" members counted backwards and ended up
+  excluding it from itself. This made `interactive_upset()`'s upset-style
+  plots under-report the deepest intersection whenever sets genuinely
+  overlapped at every level.
 
 ## Maintenance
 

--- a/R/upset.R
+++ b/R/upset.R
@@ -382,7 +382,11 @@ upset_calculate_intersections <- function(sets, show_empty_intersections = TRUE,
 
   intersects <- lapply(seq_along(intersects), function(i) {
     intersectno <- intersects[[i]]
-    members_in_higher_levels <- unlist(intersects[(i + 1):length(intersects)])
+    members_in_higher_levels <- if (i < length(intersects)) {
+      unlist(intersects[(i + 1):length(intersects)])
+    } else {
+      character(0)
+    }
     lapply(intersectno, function(intersect) {
       if (intersection_assignment_type == "upset") {
         length(setdiff(intersect, members_in_higher_levels))

--- a/tests/testthat/test-upset.R
+++ b/tests/testthat/test-upset.R
@@ -121,6 +121,18 @@ test_that("calculateIntersections assigns overlapping members only to their high
   }))
 })
 
+test_that("upset_calculate_intersections counts the highest-order intersection correctly under 'upset' assignment", {
+  # contrast1-only = {g1} = 1, contrast2-only = {g4} = 1, contrast1 & contrast2 = {g2, g3} = 2
+  sets <- list(contrast1 = c("g1", "g2", "g3"), contrast2 = c("g2", "g3", "g4"))
+
+  ints <- upset_calculate_intersections(sets, intersection_assignment_type = "upset")
+  names(ints$intersections) <- vapply(ints$combinations, function(combo) paste(names(sets)[combo], collapse = "&"), character(1))
+
+  expect_equal(unname(ints$intersections[["contrast1"]]), 1)
+  expect_equal(unname(ints$intersections[["contrast2"]]), 1)
+  expect_equal(unname(ints$intersections[["contrast1&contrast2"]]), 2)
+})
+
 test_that("getUpsetPlot draws a set-size bar chart, an intersection-size bar chart and a membership grid", {
   run_upset_server(make_upset_eselist(), expr = quote({
     built <- plotly::plotly_build(getUpsetPlot())


### PR DESCRIPTION
## Summary

* `upset_calculate_intersections()` always reported the highest-order (all-sets) intersection as 0 under the default `intersection_assignment_type = "upset"`. The "members already claimed by a higher-order intersection" index, `(i + 1):length(intersects)`, counted backwards when `i` was the last (top-order) intersection (e.g. `3:2` for a 2-set case), which indexed back into the intersection itself and zeroed it out via `setdiff(x, x)`.
* Guards the top-order case so there are no higher levels to subtract, matching `UpSetR`'s behaviour.
* Added a regression test using the MRE from the issue, and a NEWS entry.

Fixes #278

## Test plan

- [x] `upset_calculate_intersections()` on the issue's MRE now returns 2 for the top-order intersection instead of 0
- [x] `devtools::test(filter = "upset")` passes (23/23), including existing fixtures which were constructed so as not to exercise this bug (no non-empty 3-/4-way intersections)
- [x] `lintr::lint()` clean on changed files