### PR TITLE
Reinstate percent-variance suffix on PC labels in the PCA vs Experiment heatmap

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -767,7 +767,7 @@ anova_pca_metadata <- function(pca_coords, pcameta, fraction_explained, n_compon
       ncol = last_pc,
       dimnames = list(
         colnames(pcameta),
-        pcLabels(last_pc)
+        pcLabels(last_pc, fraction_explained)
       )
     )
 
@@ -895,7 +895,14 @@ interactive_pca_variance_heatmap <- function(pca_coords, pcameta, fraction_expla
                                          heatmap_height = 600, scree_height = 200, ...) {
   n_components <- min(n_components, ncol(pca_coords))
 
-  scree <- interactive_screeplot(fraction_explained, n_components = n_components, title = "")
+  # component_labels matches anova_pca_metadata()'s percent-suffixed column
+  # names exactly, so shareX below lines the two plots' categories up rather
+  # than treating "PC1" and "PC1 (45%)" as distinct categories.
+  scree <- interactive_screeplot(
+    fraction_explained,
+    n_components = n_components, title = "",
+    component_labels = pcLabels(n_components, fraction_explained)
+  )
 
   # The heatmap's own column labels (drawn at the bottom of the combined
   # figure) already identify each PC, so drop the scree plot's x-axis title

--- a/R/pca.R
+++ b/R/pca.R
@@ -395,7 +395,7 @@ calculatePCAFractionExplained <- function(pca) {
   round((pca$sdev)^2 / sum(pca$sdev^2), 3) * 100
 }
 
-#' Plain "PC1", "PC2", ... labels for the leading n components
+#' "PC1", "PC2", ... labels for the leading n components
 #'
 #' Shared by \code{\link{interactive_screeplot}} and
 #' \code{\link[=anova_pca_metadata]{anova_pca_metadata}} so the two produce
@@ -404,11 +404,18 @@ calculatePCAFractionExplained <- function(pca) {
 #' shared x-axis.
 #'
 #' @param n Number of components to label
+#' @param fraction_explained Optional numeric vector of percent variance
+#'   explained by each component. When supplied, each label is suffixed with
+#'   e.g. \code{" (45\%)"}.
 #'
 #' @return output A character vector of length \code{n}
 #'
-pcLabels <- function(n) {
-  paste0("PC", seq_len(n))
+pcLabels <- function(n, fraction_explained = NULL) {
+  labels <- paste0("PC", seq_len(n))
+  if (!is.null(fraction_explained)) {
+    labels <- paste0(labels, " (", fraction_explained[seq_len(n)], "%)")
+  }
+  labels
 }
 
 #' Make a PCA scree plot with \code{plot_ly()}
@@ -425,6 +432,11 @@ pcLabels <- function(n) {
 #' @param cumulative Boolean: add a cumulative variance explained trace?
 #' @param palette_name Valid R color palette name
 #' @param title Plot title
+#' @param component_labels Optional character vector of length \code{n_components}
+#'   to use as the x-axis categories instead of the plain \code{"PC1"}, \code{"PC2"}, ...
+#'   labels. Used by \code{\link{interactive_pca_variance_heatmap}} to match this
+#'   plot's x-categories to the percent-suffixed column labels of the heatmap it's
+#'   stacked with.
 #'
 #' @return output Plotly plot object
 #'
@@ -433,14 +445,17 @@ pcLabels <- function(n) {
 #' @examples
 #' interactive_screeplot(c(45, 25, 15, 10, 5))
 #'
-interactive_screeplot <- function(fraction_explained, n_components = NULL, cumulative = FALSE, palette_name = COLORBLIND_PALETTE_NAME, title = "Scree plot") {
+interactive_screeplot <- function(fraction_explained, n_components = NULL, cumulative = FALSE, palette_name = COLORBLIND_PALETTE_NAME, title = "Scree plot", component_labels = NULL) {
   if (is.null(n_components)) {
     n_components <- length(fraction_explained)
   }
   n_components <- min(n_components, length(fraction_explained))
 
   fraction_explained <- fraction_explained[seq_len(n_components)]
-  components <- factor(pcLabels(n_components), levels = pcLabels(n_components))
+  if (is.null(component_labels)) {
+    component_labels <- pcLabels(n_components)
+  }
+  components <- factor(component_labels, levels = component_labels)
 
   traces <- list(list(y = fraction_explained, name = "% variance explained"))
   if (cumulative) {

--- a/man/interactive_screeplot.Rd
+++ b/man/interactive_screeplot.Rd
@@ -9,7 +9,8 @@ interactive_screeplot(
   n_components = NULL,
   cumulative = FALSE,
   palette_name = COLORBLIND_PALETTE_NAME,
-  title = "Scree plot"
+  title = "Scree plot",
+  component_labels = NULL
 )
 }
 \arguments{
@@ -26,6 +27,12 @@ of \code{fraction_explained}.}
 \item{palette_name}{Valid R color palette name}
 
 \item{title}{Plot title}
+
+\item{component_labels}{Optional character vector of length \code{n_components}
+to use as the x-axis categories instead of the plain \code{"PC1"}, \code{"PC2"}, ...
+labels. Used by \code{\link{interactive_pca_variance_heatmap}} to match this
+plot's x-categories to the percent-suffixed column labels of the heatmap it's
+stacked with.}
 }
 \value{
 output Plotly plot object

--- a/man/pcLabels.Rd
+++ b/man/pcLabels.Rd
@@ -2,12 +2,16 @@
 % Please edit documentation in R/pca.R
 \name{pcLabels}
 \alias{pcLabels}
-\title{Plain "PC1", "PC2", ... labels for the leading n components}
+\title{"PC1", "PC2", ... labels for the leading n components}
 \usage{
-pcLabels(n)
+pcLabels(n, fraction_explained = NULL)
 }
 \arguments{
 \item{n}{Number of components to label}
+
+\item{fraction_explained}{Optional numeric vector of percent variance
+explained by each component. When supplied, each label is suffixed with
+e.g. \code{" (45\%)"}.}
 }
 \value{
 output A character vector of length \code{n}

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -72,7 +72,7 @@ test_that("interactive_pca_metadata_heatmap drops rows with a single value acros
 
 # anova_pca_metadata()
 
-test_that("anova_pca_metadata uses plain PC column names, not percent-suffixed ones", {
+test_that("anova_pca_metadata suffixes column names with each component's percent variance explained", {
   set.seed(1)
   pcameta <- data.frame(
     row.names = paste0("sample", 1:6),
@@ -82,7 +82,7 @@ test_that("anova_pca_metadata uses plain PC column names, not percent-suffixed o
 
   pvals <- anova_pca_metadata(pca_coords, pcameta, fraction_explained = c(50, 30, 20))
 
-  expect_equal(colnames(pvals), c("PC1", "PC2", "PC3"))
+  expect_equal(colnames(pvals), c("PC1 (50%)", "PC2 (30%)", "PC3 (20%)"))
 })
 
 test_that("anova_pca_metadata's n_components limits and clamps the number of components tested", {
@@ -95,7 +95,7 @@ test_that("anova_pca_metadata's n_components limits and clamps the number of com
   fraction_explained <- c(40, 25, 15, 12, 8)
 
   limited <- anova_pca_metadata(pca_coords, pcameta, fraction_explained, n_components = 3)
-  expect_equal(colnames(limited), c("PC1", "PC2", "PC3"))
+  expect_equal(colnames(limited), c("PC1 (40%)", "PC2 (25%)", "PC3 (15%)"))
 
   clamped <- anova_pca_metadata(pca_coords, pcameta, fraction_explained, n_components = 20)
   expect_equal(ncol(clamped), 5)
@@ -141,6 +141,6 @@ test_that("interactive_pca_variance_heatmap respects n_components in both the sc
   scree_trace <- built$x$data[[which(trace_types == "scatter")[1]]]
   heatmap_trace <- built$x$data[[which(trace_types == "heatmap")[1]]]
 
-  expect_equal(as.character(scree_trace$x), c("PC1", "PC2"))
-  expect_equal(colnames(heatmap_trace$z), c("PC1", "PC2"))
+  expect_equal(as.character(scree_trace$x), c("PC1 (40%)", "PC2 (25%)"))
+  expect_equal(colnames(heatmap_trace$z), c("PC1 (40%)", "PC2 (25%)"))
 })

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -109,6 +109,12 @@ test_that("interactive_screeplot respects n_components", {
   expect_equal(as.numeric(built$x$data[[1]]$y), c(45, 25, 15))
 })
 
+test_that("interactive_screeplot uses component_labels verbatim when supplied", {
+  built <- plotly::plotly_build(interactive_screeplot(c(45, 25, 15), component_labels = c("PC1 (45%)", "PC2 (25%)", "PC3 (15%)")))
+
+  expect_equal(as.character(built$x$data[[1]]$x), c("PC1 (45%)", "PC2 (25%)", "PC3 (15%)"))
+})
+
 test_that("interactive_screeplot adds a cumulative trace when requested", {
   built <- plotly::plotly_build(interactive_screeplot(c(45, 25, 15, 10, 5), cumulative = TRUE))
 


### PR DESCRIPTION
## Summary
- Restores the "(NN%)" percent-variance suffix on the "Principal components vs experimental variables" heatmap's column labels, which was dropped when the scree plot was stacked above it (#238).
- The standalone Scree plot tab keeps plain PC1/PC2/... x-axis labels (its y-axis already reads "% variance explained", so the suffix there was redundant) - only the scree plot embedded in the combined heatmap view picks up matching percent-suffixed labels, needed to keep the two plots' shared x-axis aligned.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-pca.R")` - all pass
- [x] `testthat::test_file("tests/testthat/test-heatmap.R")` - all pass
- [x] `roxygen2::roxygenise()` regenerated `man/pcLabels.Rd` and `man/interactive_screeplot.Rd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)