### PR TITLE
Make interactive_heatmap grid_gap configurable

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -517,6 +517,10 @@ heatmap <- function(id, eselist, type = "expression") {
 #' @param display_numbers Boolean, should the (possibly scaled/ transformed)
 #'   values in \code{plotmatrix} be displayed on the heatmap cells?
 #' @param hide_colorbar Boolean, should the color scale legend be hidden?
+#' @param grid_gap Pixel gap drawn between cells, passed through to
+#'   \code{heatmaply()}. The default of 1 reads fine for small heatmaps, but on
+#'   a heatmap with hundreds of rows the gaps can visually dominate and obscure
+#'   cross-column colour patterns; pass 0 for contiguous cells in that case.
 #' @param plot_height The total rendered height of the plot in pixels. Passed
 #'   through to \code{heatmaply()} as its \code{height} argument, and also used
 #'   to convert the fixed-pixel annotation row height into the fraction
@@ -540,7 +544,7 @@ heatmap <- function(id, eselist, type = "expression") {
 #' )
 #' interactive_heatmap(mat, mat, sample_annotation, row_labels = rownames(mat))
 #'
-interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cluster_rows = TRUE, cluster_cols = FALSE, scale = "row", row_labels, colors = viridisLite::viridis(100), cexCol = 0.7, cexRow = 0.7, display_numbers = FALSE, hide_colorbar = FALSE, plot_height = 600, ...) {
+interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cluster_rows = TRUE, cluster_cols = FALSE, scale = "row", row_labels, colors = viridisLite::viridis(100), cexCol = 0.7, cexRow = 0.7, display_numbers = FALSE, hide_colorbar = FALSE, grid_gap = 1, plot_height = 600, ...) {
   # should be possible to specify this in the labRow parameter- but the clustering messes it up
 
   rownames(plotmatrix) <- row_labels
@@ -628,7 +632,7 @@ interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cl
     dendrogram = dendrogram, custom_hovertext = hovertext, Rowv = Rowv, Colv = Colv, scale = scale,
     colors = colors, cexCol = cexCol, cexRow = cexRow, revC = FALSE, labRow = rownames(plotmatrix),
     col_side_colors = col_side_colors, col_side_palette = col_side_palette, plot_method = "plotly",
-    subplot_heights = subplot_heights, subplot_margin = 0.01, grid_gap = 1, hide_colorbar = hide_colorbar,
+    subplot_heights = subplot_heights, subplot_margin = 0.01, grid_gap = grid_gap, hide_colorbar = hide_colorbar,
     cellnote = if (display_numbers) round(plotmatrix, 2) else NULL, draw_cellnote = display_numbers,
     height = plot_height, ...
   )

--- a/man/interactive_heatmap.Rd
+++ b/man/interactive_heatmap.Rd
@@ -17,6 +17,7 @@ interactive_heatmap(
   cexRow = 0.7,
   display_numbers = FALSE,
   hide_colorbar = FALSE,
+  grid_gap = 1,
   plot_height = 600,
   ...
 )
@@ -48,6 +49,11 @@ column side colors and an accompanying legend}
 values in \code{plotmatrix} be displayed on the heatmap cells?}
 
 \item{hide_colorbar}{Boolean, should the color scale legend be hidden?}
+
+\item{grid_gap}{Pixel gap drawn between cells, passed through to
+\code{heatmaply()}. The default of 1 reads fine for small heatmaps, but on
+a heatmap with hundreds of rows the gaps can visually dominate and obscure
+cross-column colour patterns; pass 0 for contiguous cells in that case.}
 
 \item{plot_height}{The total rendered height of the plot in pixels. Passed
 through to \code{heatmaply()} as its \code{height} argument, and also used

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -24,6 +24,35 @@ test_that("interactive_heatmap handles single-row matrices (e.g. one informative
   expect_s3_class(p, "plotly")
 })
 
+test_that("interactive_heatmap defaults to a 1px grid_gap but lets callers override it for large heatmaps", {
+  pm <- matrix(rnorm(24), nrow = 6, dimnames = list(paste0("gene", 1:6), paste0("s", 1:4)))
+
+  # heatmaply only sets xgap/ygap on the trace when grid_gap is non-zero,
+  # so a missing attribute means an effective gap of 0
+  find_grid_gap <- function(p) {
+    for (trace in p$x$data) {
+      if (!is.null(trace$xgap)) {
+        return(trace$xgap)
+      }
+    }
+    0
+  }
+
+  p_default <- interactive_heatmap(
+    plotmatrix = pm, displaymatrix = pm, sample_annotation = NULL,
+    cluster_rows = FALSE, cluster_cols = FALSE, scale = "row",
+    row_labels = rownames(pm), hide_colorbar = TRUE
+  )
+  expect_equal(find_grid_gap(p_default), 1)
+
+  p_no_gap <- interactive_heatmap(
+    plotmatrix = pm, displaymatrix = pm, sample_annotation = NULL,
+    cluster_rows = FALSE, cluster_cols = FALSE, scale = "row",
+    row_labels = rownames(pm), hide_colorbar = TRUE, grid_gap = 0
+  )
+  expect_equal(find_grid_gap(p_no_gap), 0)
+})
+
 # interactive_pca_metadata_heatmap()
 
 test_that("interactive_pca_metadata_heatmap colors by -log10(p) but keeps the raw p value as a cell note", {


### PR DESCRIPTION
## Summary
- `grid_gap` (the pixel gap heatmaply draws between cells) is now an explicit, documented parameter of `interactive_heatmap()` instead of a hard-coded `1`
- Default stays `1`, preserving current appearance for existing callers
- Callers with large heatmaps (e.g. diffab showing hundreds of genes to look at cross-column patterns) can now pass `grid_gap = 0` for contiguous, ComplexHeatmap-like cells - previously impossible since passing it via `...` hit a duplicate-argument error
- `interactive_pca_metadata_heatmap()` already forwards `...` to `interactive_heatmap()`, so it picks up the new parameter for free

Closes #282

## Test plan
- [x] `devtools::document()` regenerated `man/interactive_heatmap.Rd`
- [x] Added a test asserting the default renders a 1px grid gap and `grid_gap = 0` renders none (checked via the plotly trace's `xgap`/`ygap`)
- [x] Full `testthat` suite passes
- [x] `lintr::lint("R/heatmap.R")` clean