### PR TITLE
Polish interactive_upset set-size chart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,15 @@
   excluding it from itself. This made `interactive_upset()`'s upset-style
   plots under-report the deepest intersection whenever sets genuinely
   overlapped at every level.
+* `interactive_upset()`'s set-size bar chart had no axis title, was
+  squeezed into a small fraction of the figure's width, and ran left-to-right
+  with 0 on the left, unlike the conventional UpSet layout where the set-size
+  bars grow leftward from a 0 next to the intersection grid. The chart now
+  has a "Set size" axis title (with an explicit `tickangle` to keep it
+  stable when the plot is rendered in an initially-hidden tab), a larger
+  width allocation, and a reversed x-axis. The intersection-size chart's
+  axis title was also corrected from "Intersections size" to "Intersection
+  size".
 
 ## Maintenance
 

--- a/R/upset.R
+++ b/R/upset.R
@@ -482,7 +482,11 @@ upset_set_size_chart <- function(sets) {
   setnames <- names(sets)
 
   plot_ly(x = unlist(lapply(sets, length)), y = setnames, type = "bar", orientation = "h", marker = list(color = "black")) %>%
-    layout(bargap = 0.4, yaxis = list(categoryarray = rev(setnames), categoryorder = "array"))
+    layout(
+      bargap = 0.4,
+      xaxis = list(title = "Set size", autorange = "reversed", tickangle = 0),
+      yaxis = list(categoryarray = rev(setnames), categoryorder = "array")
+    )
 }
 
 #' Make the bar chart illustrating intersect size
@@ -567,15 +571,15 @@ interactive_upset <- function(sets, nintersects = 20, minorder = 1, set_sort = T
 
   set_size_chart <- upset_set_size_chart(sets)
   intersect_size_chart <- upset_intersect_size_chart(ints, nintersects, bar_numbers) %>%
-    layout(yaxis = list(title = "Intersections size"))
+    layout(yaxis = list(title = "Intersection size"))
   grid <- upset_grid_plot(sets, ints, nintersects)
 
   s1 <- subplot(
     plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"), plotly_empty(type = "scatter", mode = "markers"),
     set_size_chart,
-    nrows = 2, widths = c(0.6, 0.4)
+    nrows = 2, widths = c(0.45, 0.55), titleX = TRUE
   )
-  s2 <- subplot(intersect_size_chart, grid, nrows = 2, shareX = TRUE) %>% layout(showlegend = FALSE)
+  s2 <- subplot(intersect_size_chart, grid, nrows = 2, shareX = TRUE, titleY = TRUE) %>% layout(showlegend = FALSE)
 
-  subplot(s1, s2, widths = c(0.3, 0.7))
+  subplot(s1, s2, widths = c(0.35, 0.65), titleX = TRUE, titleY = TRUE)
 }


### PR DESCRIPTION
## Summary
- Add a "Set size" x-axis title to the set-size bar chart (and fix "Intersections size" → "Intersection size" on the intersect chart)
- Give the set-size panel a larger share of the figure width so the bars aren't squished
- Reverse the set-size x-axis so 0 sits on the right, next to the intersection grid, matching conventional UpSet layout
- Set an explicit `tickangle` on the set-size axis to keep tick orientation stable when the plot renders inside an initially-hidden tab (e.g. a Quarto tabset)

Fixes #285.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-upset.R")` — 23 passed, 0 failed
- [x] `lintr::lint("R/upset.R")` — no lints
- [x] Rendered `interactive_upset()` to HTML and screenshotted with Playwright to confirm axis titles, wider bars, and reversed axis all show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)