### PR TITLE
Expose cor_method/cluster_method on interactive_heatmap()

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -521,13 +521,27 @@ heatmap <- function(id, eselist, type = "expression") {
 #'   \code{heatmaply()}. The default of 1 reads fine for small heatmaps, but on
 #'   a heatmap with hundreds of rows the gaps can visually dominate and obscure
 #'   cross-column colour patterns; pass 0 for contiguous cells in that case.
+#' @param cor_method Correlation method passed to
+#'   \code{\link{calculate_dendrogram}} when clustering rows and/or columns
+#'   (default: 'spearman'). Match this to the method used by another
+#'   clustering of the same data (e.g. a \code{ComplexHeatmap::Heatmap()}
+#'   call's \code{clustering_distance_columns}) to reproduce its dendrogram
+#'   topology here.
+#' @param cluster_method Clustering method passed to
+#'   \code{\link{calculate_dendrogram}} (default: 'ward.D2'). Match this to
+#'   another clustering's \code{clustering_method_columns}/-\code{_rows} for
+#'   the same reason as \code{cor_method}.
 #' @param plot_height The total rendered height of the plot in pixels. Passed
 #'   through to \code{heatmaply()} as its \code{height} argument, and also used
 #'   to convert the fixed-pixel annotation row height into the fraction
 #'   \code{heatmaply()} expects. When displayed inside a
 #'   \code{plotlyOutput()}, the latter's own \code{height} argument should
 #'   match this value so the container and the widget agree.
-#' @param ... Additional arguments passed to \code{heatmaply()}
+#' @param ... Additional arguments passed to \code{heatmaply()}. For example,
+#'   \code{heatmaply()} reorders dendrogram leaves for visual clarity
+#'   (\code{seriate = "OLO"}) by default; pass \code{seriate = "none"} here to
+#'   keep the plain \code{hclust} leaf order instead, matching
+#'   \code{ComplexHeatmap::Heatmap()}'s default display.
 #'
 #' @return output A plotly htmlwidget as produced by heatmaply()
 #'
@@ -544,7 +558,7 @@ heatmap <- function(id, eselist, type = "expression") {
 #' )
 #' interactive_heatmap(mat, mat, sample_annotation, row_labels = rownames(mat))
 #'
-interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cluster_rows = TRUE, cluster_cols = FALSE, scale = "row", row_labels, colors = viridisLite::viridis(100), cexCol = 0.7, cexRow = 0.7, display_numbers = FALSE, hide_colorbar = FALSE, grid_gap = 1, plot_height = 600, ...) {
+interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cluster_rows = TRUE, cluster_cols = FALSE, scale = "row", row_labels, colors = viridisLite::viridis(100), cexCol = 0.7, cexRow = 0.7, display_numbers = FALSE, hide_colorbar = FALSE, grid_gap = 1, cor_method = "spearman", cluster_method = "ward.D2", plot_height = 600, ...) {
   # should be possible to specify this in the labRow parameter- but the clustering messes it up
 
   rownames(plotmatrix) <- row_labels
@@ -570,14 +584,14 @@ interactive_heatmap <- function(plotmatrix, displaymatrix, sample_annotation, cl
 
   if (all(cluster_rows, cluster_cols)) {
     dendrogram <- "both"
-    Rowv <- calculate_dendrogram(t(plotmatrix))
-    Colv <- calculate_dendrogram(plotmatrix)
+    Rowv <- calculate_dendrogram(t(plotmatrix), cor_method = cor_method, cluster_method = cluster_method)
+    Colv <- calculate_dendrogram(plotmatrix, cor_method = cor_method, cluster_method = cluster_method)
   } else if (cluster_rows) {
     dendrogram <- "row"
-    Rowv <- calculate_dendrogram(t(plotmatrix))
+    Rowv <- calculate_dendrogram(t(plotmatrix), cor_method = cor_method, cluster_method = cluster_method)
   } else if (cluster_cols) {
     dendrogram <- "column"
-    Colv <- calculate_dendrogram(plotmatrix)
+    Colv <- calculate_dendrogram(plotmatrix, cor_method = cor_method, cluster_method = cluster_method)
   }
 
   # Turn off scaling if there's only 2 possible values in the matrix, otherwise things look a bit odd

--- a/man/interactive_heatmap.Rd
+++ b/man/interactive_heatmap.Rd
@@ -18,6 +18,8 @@ interactive_heatmap(
   display_numbers = FALSE,
   hide_colorbar = FALSE,
   grid_gap = 1,
+  cor_method = "spearman",
+  cluster_method = "ward.D2",
   plot_height = 600,
   ...
 )
@@ -55,6 +57,18 @@ values in \code{plotmatrix} be displayed on the heatmap cells?}
 a heatmap with hundreds of rows the gaps can visually dominate and obscure
 cross-column colour patterns; pass 0 for contiguous cells in that case.}
 
+\item{cor_method}{Correlation method passed to
+\code{\link{calculate_dendrogram}} when clustering rows and/or columns
+(default: 'spearman'). Match this to the method used by another
+clustering of the same data (e.g. a \code{ComplexHeatmap::Heatmap()}
+call's \code{clustering_distance_columns}) to reproduce its dendrogram
+topology here.}
+
+\item{cluster_method}{Clustering method passed to
+\code{\link{calculate_dendrogram}} (default: 'ward.D2'). Match this to
+another clustering's \code{clustering_method_columns}/-\code{_rows} for
+the same reason as \code{cor_method}.}
+
 \item{plot_height}{The total rendered height of the plot in pixels. Passed
 through to \code{heatmaply()} as its \code{height} argument, and also used
 to convert the fixed-pixel annotation row height into the fraction
@@ -62,7 +76,11 @@ to convert the fixed-pixel annotation row height into the fraction
 \code{plotlyOutput()}, the latter's own \code{height} argument should
 match this value so the container and the widget agree.}
 
-\item{...}{Additional arguments passed to \code{heatmaply()}}
+\item{...}{Additional arguments passed to \code{heatmaply()}. For example,
+\code{heatmaply()} reorders dendrogram leaves for visual clarity
+(\code{seriate = "OLO"}) by default; pass \code{seriate = "none"} here to
+keep the plain \code{hclust} leaf order instead, matching
+\code{ComplexHeatmap::Heatmap()}'s default display.}
 }
 \value{
 output A plotly htmlwidget as produced by heatmaply()

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -53,6 +53,37 @@ test_that("interactive_heatmap defaults to a 1px grid_gap but lets callers overr
   expect_equal(find_grid_gap(p_no_gap), 0)
 })
 
+test_that("interactive_heatmap's cor_method/cluster_method drive the column dendrogram it builds", {
+  set.seed(42)
+  pm <- matrix(rnorm(60), nrow = 6, dimnames = list(paste0("gene", 1:6), paste0("s", 1:10)))
+  pm[1, ] <- pm[1, ] * -1
+
+  # heatmaply lists the leaves in the reverse of dendrogram order; seriate =
+  # "none" keeps that order as calculate_dendrogram() produced it rather than
+  # heatmaply's own optimal-leaf-ordering reseriation.
+  column_order <- function(p) p$x$layout$xaxis$ticktext
+
+  make_heatmap <- function(cor_method, cluster_method) {
+    interactive_heatmap(
+      plotmatrix = pm, displaymatrix = pm, sample_annotation = NULL,
+      cluster_rows = FALSE, cluster_cols = TRUE, scale = "none",
+      row_labels = rownames(pm), hide_colorbar = TRUE, seriate = "none",
+      cor_method = cor_method, cluster_method = cluster_method
+    )
+  }
+
+  p_default <- make_heatmap("spearman", "ward.D2")
+  expect_equal(column_order(p_default), rev(labels(calculate_dendrogram(pm))))
+
+  p_pearson_complete <- make_heatmap("pearson", "complete")
+  expect_equal(column_order(p_pearson_complete), rev(labels(calculate_dendrogram(pm, cor_method = "pearson", cluster_method = "complete"))))
+
+  # A different cor_method/cluster_method pair should, for this matrix, produce
+  # a genuinely different leaf order - otherwise the arguments risk being
+  # silently ignored.
+  expect_false(identical(column_order(p_default), column_order(p_pearson_complete)))
+})
+
 # interactive_pca_metadata_heatmap()
 
 test_that("interactive_pca_metadata_heatmap colors by -log10(p) but keeps the raw p value as a cell note", {


### PR DESCRIPTION
## Summary
- `interactive_heatmap()` always built its row/column dendrograms with `calculate_dendrogram()`'s defaults (`spearman`/`ward.D2`); it now takes `cor_method`/`cluster_method` arguments and threads them through to both dendrogram calls, defaulting to the previous behaviour so no caller sees a change unless they opt in.
- Documents that `heatmaply()`'s own `seriate` argument (leaf reordering, default `"OLO"`) is already reachable through `interactive_heatmap()`'s `...`, so passing `seriate = "none"` alongside matching `cor_method`/`cluster_method` reproduces `ComplexHeatmap::Heatmap()`'s plain `hclust` leaf order too.

Closes #286.

## Test plan
- [x] `devtools::document()` regenerated `man/interactive_heatmap.Rd`
- [x] `testthat::test_file("tests/testthat/test-heatmap.R")` - new test verifies `cor_method`/`cluster_method` actually drive the resulting column order (matches `calculate_dendrogram()` directly, and differs between two method pairs)
- [x] `devtools::test()` - full suite passes (pre-existing shinytest2 headless-browser failures unrelated to this change, reproduced identically on `develop`)
- [x] `lintr::lint("R/heatmap.R")` - no lints