### PR TITLE
Only offer selectable gene sets that actually resolve to a result

### DIFF
--- a/R/genesetanalysistable.R
+++ b/R/genesetanalysistable.R
@@ -53,7 +53,7 @@ genesetanalysistableInput <- function(id, eselist) {
 
   expression_filters <- selectmatrixInput(ns("expression"), eselist)
 
-  field_sets <- list(gene_set_types = list(uiOutput(ns("geneSets"))), differential_gene_sets = list(
+  field_sets <- list(gene_set_types = list(uiOutput(ns("geneSets")), uiOutput(ns("geneSetsStatus"))), differential_gene_sets = list(
     numericInput(ns("pval"), "Maximum p value", value = 0.05),
     numericInput(ns("fdr"), "Maximum FDR", value = 0.1)
   ), differential_genes = list(
@@ -190,12 +190,9 @@ genesetanalysistable <- function(id, eselist) {
 
     genesetselect_reactives <- genesetselect("genesetanalysistable", eselist, selectmatrix_reactives$getExperiment, filter_by_type = TRUE, require_select = FALSE)
 
-    observe({
-      genesetselect_reactives$updateGeneSetsList()
-    })
-
     # Resolve the enrichment table, column mapping and tool once per selection,
-    # shared between the table itself and the method label above it.
+    # shared between the table itself, the method label above it, and the
+    # gene set choices offered below.
 
     getEnrichmentInfo <- reactive({
       ese <- selectmatrix_reactives$getExperiment()
@@ -204,6 +201,43 @@ genesetanalysistable <- function(id, eselist) {
       contrast_number <- as.numeric(contrast_reactives$getSelectedContrastNumbers()[[1]])
 
       resolve_enrichment(ese, assay, gene_set_types, contrast_number, eselist@contrasts[[contrast_number]])
+    })
+
+    # Which gene set IDs actually have a result row for the current
+    # assay/type/contrast selection AND pass the current p value/FDR filters -
+    # anything else could only ever resolve to "No results matching specified
+    # filters" in the table below. NULL means "no enrichment resolved at all"
+    # (nothing to filter down from); character(0) means "resolved, but the
+    # filters exclude every set" - the two are distinguished so the message
+    # below only appears in the latter case.
+
+    getFilterablePassingIds <- reactive({
+      enrichment <- getEnrichmentInfo()
+      if (is.null(enrichment) || is.null(input$pval) || is.null(input$fdr)) {
+        return(NULL)
+      }
+
+      passing_gene_set_ids(enrichment$gst, enrichment$col_map, input$pval, input$fdr)
+    })
+
+    # Only push a selectize update when the passing set actually changed -
+    # editing the p value/FDR fields invalidates getFilterablePassingIds() on
+    # every keystroke, but most edits don't change which gene sets pass.
+
+    lastPassingIds <- reactiveVal(NULL)
+
+    observe({
+      passing <- getFilterablePassingIds()
+      if (!identical(passing, isolate(lastPassingIds()))) {
+        lastPassingIds(passing)
+        genesetselect_reactives$updateGeneSetsList(passing)
+      }
+    })
+
+    output$geneSetsStatus <- renderUI({
+      passing <- getFilterablePassingIds()
+      validate(need(is.null(passing) || length(passing) > 0, "No gene sets meet the current p value/FDR filters"))
+      NULL
     })
 
     output$enrichmentMethod <- renderUI({
@@ -241,7 +275,7 @@ genesetanalysistable <- function(id, eselist) {
 
       # Apply the user's filters
 
-      gst <- gst[gst[[col_map$pvalue]] < input$pval & gst[[col_map$fdr]] < input$fdr, , drop = FALSE]
+      gst <- gst[gst$gene_set_id %in% passing_gene_set_ids(gst, col_map, input$pval, input$fdr), , drop = FALSE]
 
       validate(need(nrow(gst) > 0, "No results matching specified filters"))
 
@@ -287,4 +321,21 @@ genesetanalysistable <- function(id, eselist) {
 
     simpletable("genesetanalysistable", downloadMatrix = getGeneSetAnalysis, displayMatrix = getDisplayGeneSetAnalysis, filename = makeFileName, rownames = FALSE)
   })
+}
+
+#' Row names of an enrichment table passing the p value/FDR thresholds
+#'
+#' @param gst An enrichment table (data frame or matrix), row-named by gene
+#' set ID.
+#' @param col_map A column mapping as returned by \code{resolve_enrichment()},
+#' with \code{pvalue} and \code{fdr} entries naming the relevant columns of
+#' \code{gst}.
+#' @param pval Maximum p value to pass.
+#' @param fdr Maximum FDR to pass.
+#'
+#' @return output The row names of \code{gst} whose p value and FDR are both
+#' below the given thresholds.
+#' @noRd
+passing_gene_set_ids <- function(gst, col_map, pval, fdr) {
+  rownames(gst)[gst[[col_map$pvalue]] < pval & gst[[col_map$fdr]] < fdr]
 }

--- a/R/genesetbarcodeplot.R
+++ b/R/genesetbarcodeplot.R
@@ -165,6 +165,11 @@ genesetbarcodeplot <- function(id, eselist) {
 
     genesetselect_reactives <- genesetselect("genesetbarcodeplot", eselist, selectmatrix_reactives$getExperiment, multiple = FALSE)
 
+    # Every gene set stays selectable here, whether or not it has a GSEA/ROAST
+    # result for the current assay/contrast: the plot itself only needs fold
+    # changes and set membership, and barcodeplotTitle() already degrades
+    # gracefully to "(no association)" when there's no matching enrichment row.
+
     observe({
       genesetselect_reactives$updateGeneSetsList()
     })

--- a/R/genesetselect.R
+++ b/R/genesetselect.R
@@ -22,7 +22,7 @@ genesetselectInput <- function(id, multiple = TRUE) {
 
   tagList(uiOutput(ns("geneSetTypes_ui")), selectizeInput(ns("geneSets"), "Gene sets", choices = NULL, options = list(
     placeholder = "Type a gene set keyword",
-    maxItems = 5
+    maxItems = if (multiple) 5 else 1
   ), multiple = multiple), radioButtons(ns("overlapType"), with_help_icon("Overlap type", "'Union' includes genes from any of the selected gene sets; 'intersect' includes only genes common to all of them."), c("union", "intersect")))
 }
 
@@ -118,14 +118,22 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
       )))
     })
 
-    # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list.  This reactive must be called by
-    # the calling module.
+    # Server-side function for populating the selectize input. Client-side takes too long with the likely size of the list. This must be called by
+    # the calling module, from within a reactive context (e.g. observe()).
+    #
+    # available_ids, when supplied, restricts the offered choices to gene set
+    # IDs that are actually present there (e.g. the row names of a resolved
+    # gene_set_analyses table) - so a module backed by sparse test results
+    # doesn't offer sets that can only ever resolve to "no results found".
 
-    updateGeneSetsList <- reactive({
+    updateGeneSetsList <- function(available_ids = NULL) {
       selected <- restored_geneset
       restored_geneset <<- NULL
-      updateSelectizeInput(session, "geneSets", choices = getGeneSetNames(), selected = selected, server = TRUE)
-    })
+
+      choices <- restrict_geneset_choices(getGeneSetNames(), getGeneSetCodesByIDs(), available_ids)
+
+      updateSelectizeInput(session, "geneSets", choices = choices, selected = selected, server = TRUE)
+    }
 
     # Get gene sets with the proper label field keying
 
@@ -199,6 +207,28 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
       updateSelectizeInput(session, "geneSets", selected = geneset_code, choices = getGeneSetNames(), server = TRUE)
     }))
   })
+}
+
+#' Restrict gene set selectize choices to a set of available IDs
+#'
+#' @param choices A named character vector of selectize choices, as returned
+#' by \code{getGeneSetNames()}: values are gene set codes (e.g. \code{"1-3"}),
+#' names are display labels.
+#' @param codes_by_id A named character vector of the same codes keyed by
+#' gene set ID instead, as returned by \code{getGeneSetCodesByIDs()}.
+#' @param available_ids Either \code{NULL} (no restriction, \code{choices} is
+#' returned unchanged) or a character vector of gene set IDs to keep.
+#'
+#' @return output \code{choices}, filtered down to the codes whose gene set ID
+#' is in \code{available_ids}.
+#' @noRd
+restrict_geneset_choices <- function(choices, codes_by_id, available_ids) {
+  if (is.null(available_ids)) {
+    return(choices)
+  }
+
+  available_codes <- codes_by_id[intersect(available_ids, names(codes_by_id))]
+  choices[choices %in% available_codes]
 }
 
 #' Prettify gene set names like those from MSigDB

--- a/R/genesetselect.R
+++ b/R/genesetselect.R
@@ -55,14 +55,16 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
   moduleServer(id, function(input, output, session) {
     # The gene-set picker is a server-side selectize, so a bookmarked selection
     # can't restore itself; stash it here and apply it when the list is next
-    # populated (see updateGeneSetsList).
+    # populated (see updateGeneSetsList). Held in an environment field rather
+    # than a bare closure variable so it can be updated with a plain `<-`.
 
-    restored_geneset <- NULL
+    restored_geneset <- new.env(parent = emptyenv())
+    restored_geneset$value <- NULL
 
     onRestore(function(state) {
       val <- bookmarkedInputValue(state, session, "geneSets")
       if (!is.null(val)) {
-        restored_geneset <<- val
+        restored_geneset$value <- val
       }
     })
 
@@ -127,8 +129,8 @@ genesetselect <- function(id, eselist, getExperiment, multiple = TRUE, filter_by
     # doesn't offer sets that can only ever resolve to "no results found".
 
     updateGeneSetsList <- function(available_ids = NULL) {
-      selected <- restored_geneset
-      restored_geneset <<- NULL
+      selected <- restored_geneset$value
+      restored_geneset$value <- NULL
 
       choices <- restrict_geneset_choices(getGeneSetNames(), getGeneSetCodesByIDs(), available_ids)
 

--- a/tests/testthat/test-genesetanalysistable.R
+++ b/tests/testthat/test-genesetanalysistable.R
@@ -1,3 +1,19 @@
+# passing_gene_set_ids()
+
+test_that("passing_gene_set_ids keeps only rows below both thresholds", {
+  gst <- data.frame(pvalue = c(0.01, 0.2, 0.03), fdr = c(0.02, 0.3, 0.2), row.names = c("SET_A", "SET_B", "SET_C"))
+  col_map <- list(pvalue = "pvalue", fdr = "fdr")
+
+  expect_equal(passing_gene_set_ids(gst, col_map, pval = 0.05, fdr = 0.1), "SET_A")
+})
+
+test_that("passing_gene_set_ids returns none when nothing clears the thresholds", {
+  gst <- data.frame(pvalue = c(0.2, 0.3), fdr = c(0.3, 0.4), row.names = c("SET_A", "SET_B"))
+  col_map <- list(pvalue = "pvalue", fdr = "fdr")
+
+  expect_equal(passing_gene_set_ids(gst, col_map, pval = 0.05, fdr = 0.1), character(0))
+})
+
 make_genesetanalysistable_eselist <- function() {
   n_genes <- 60
   n_samples <- 4
@@ -108,6 +124,26 @@ test_that("getGeneSetAnalysis reports no results when the p/FDR filters exclude 
     expr = quote({
       err <- tryCatch(getGeneSetAnalysis(), error = function(e) e)
       expect_s3_class(err, "validation")
+    })
+  )
+})
+
+test_that("getFilterablePassingIds only includes gene sets passing the current p/FDR filters", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
+    expect_equal(getFilterablePassingIds(), "SET_A")
+    expect_null(output$geneSetsStatus)
+  }))
+})
+
+test_that("getFilterablePassingIds is empty when the p/FDR filters exclude everything, and geneSetsStatus reports it", {
+  run_genesetanalysistable_server(make_genesetanalysistable_eselist(),
+    extra_inputs = list(pval = 0.001),
+    expr = quote({
+      expect_equal(getFilterablePassingIds(), character(0))
+
+      err <- tryCatch(output$geneSetsStatus, error = function(e) e)
+      expect_s3_class(err, "validation")
+      expect_match(conditionMessage(err), "No gene sets meet the current p value/FDR filters")
     })
   )
 })

--- a/tests/testthat/test-genesetselect.R
+++ b/tests/testthat/test-genesetselect.R
@@ -14,3 +14,49 @@ test_that("prettify_gene_set_name vectorises over multiple gene set names", {
     c("KEGG glycolysis", "GO cell cycle")
   )
 })
+
+# genesetselectInput()
+
+test_that("genesetselectInput caps maxItems at 1 when multiple selection is disallowed", {
+  single_html <- as.character(genesetselectInput("myid", multiple = FALSE))
+  expect_match(single_html, '"maxItems":1')
+})
+
+test_that("genesetselectInput allows several items when multiple selection is allowed", {
+  multi_html <- as.character(genesetselectInput("myid", multiple = TRUE))
+  expect_match(multi_html, '"maxItems":5')
+})
+
+# restrict_geneset_choices()
+
+test_that("restrict_geneset_choices returns choices unchanged when available_ids is NULL", {
+  choices <- c("SET A (KEGG)" = "1-1", "SET B (KEGG)" = "1-2")
+  codes_by_id <- c(SET_A = "1-1", SET_B = "1-2")
+
+  expect_equal(restrict_geneset_choices(choices, codes_by_id, NULL), choices)
+})
+
+test_that("restrict_geneset_choices keeps only choices whose gene set ID is available", {
+  choices <- c("SET A (KEGG)" = "1-1", "SET B (KEGG)" = "1-2", "SET C (KEGG)" = "1-3")
+  codes_by_id <- c(SET_A = "1-1", SET_B = "1-2", SET_C = "1-3")
+
+  restricted <- restrict_geneset_choices(choices, codes_by_id, c("SET_A", "SET_C"))
+
+  expect_equal(restricted, c("SET A (KEGG)" = "1-1", "SET C (KEGG)" = "1-3"))
+})
+
+test_that("restrict_geneset_choices returns no choices when nothing is available", {
+  choices <- c("SET A (KEGG)" = "1-1")
+  codes_by_id <- c(SET_A = "1-1")
+
+  expect_length(restrict_geneset_choices(choices, codes_by_id, character(0)), 0)
+})
+
+test_that("restrict_geneset_choices ignores available IDs that don't correspond to any gene set", {
+  choices <- c("SET A (KEGG)" = "1-1")
+  codes_by_id <- c(SET_A = "1-1")
+
+  restricted <- restrict_geneset_choices(choices, codes_by_id, c("SET_A", "NOT_A_REAL_SET"))
+
+  expect_equal(restricted, choices)
+})


### PR DESCRIPTION
## Summary
- The gene set analysis table's selector now only offers gene sets that pass the current p value/FDR filters for the selected assay/contrast, instead of the full collection (picking one that didn't have a result just showed "not available in test results"). When none pass, it shows "No gene sets meet the current p value/FDR filters" next to the selector.
- The barcode plot module keeps offering every gene set, since it doesn't need an enrichment result to be meaningful - it plots ranks/fold changes for any set, with the FDR/direction annotation already degrading gracefully to "no association" when there's no matching result.
- Fixes `genesetselectInput()`'s selectize `maxItems` option, which was hardcoded to 5 regardless of the `multiple` parameter, so single-select callers like the barcode plot's gene set picker could still end up with multiple items selected (which suppressed the plot/table output entirely).

## Test plan
- [x] `testthat` suite passes (module-level tests added for the new filtering/status-message behaviour and the `maxItems` fix)
- [x] Manually verified in a running app against real GSEA output: gene set analysis table dropdown correctly restricts to passing sets and shows the "none pass" message; barcode plot dropdown still offers all sets and enforces single selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)