### PR TITLE
Show legend for single-level fill in interactive_count_barplot; expose ylab

### DIFF
--- a/R/barplot.R
+++ b/R/barplot.R
@@ -67,6 +67,8 @@ barplot <- function(id, getPlotmatrix, getYLabel, barmode = "stack") {
 #' @param ylab Y axis label
 #' @param palette_name Valid R color palette name
 #' @param title Plot title
+#' @param showlegend Show the trace legend? Default \code{NULL}: shown when
+#'   \code{matrix} has more than one row.
 #'
 #' @return output A plotly htmlwidget
 #'
@@ -76,8 +78,12 @@ barplot <- function(id, getPlotmatrix, getYLabel, barmode = "stack") {
 #' m <- matrix(1:6, nrow = 2, dimnames = list(c("up", "down"), c("s1", "s2", "s3")))
 #' interactive_barchart(m, barmode = "stack", ylab = "Count")
 #'
-interactive_barchart <- function(matrix, barmode = c("stack", "group", "overlay"), ylab = "", palette_name = COLORBLIND_PALETTE_NAME, title = NULL) {
+interactive_barchart <- function(matrix, barmode = c("stack", "group", "overlay"), ylab = "", palette_name = COLORBLIND_PALETTE_NAME, title = NULL, showlegend = NULL) {
   barmode <- match.arg(barmode)
+
+  if (is.null(showlegend)) {
+    showlegend <- nrow(matrix) > 1
+  }
 
   if (barmode == "overlay") {
     matrix <- matrix[order(rowMeans(matrix), decreasing = TRUE), , drop = FALSE]
@@ -98,7 +104,7 @@ interactive_barchart <- function(matrix, barmode = c("stack", "group", "overlay"
   plotdata %>%
     plot_ly(x = ~Var2, y = ~value, color = ~Var1, colors = palette, type = "bar") %>%
     layout(
-      title = title, margin = list(b = 100), barmode = barmode, showlegend = nrow(matrix) > 1,
+      title = title, margin = list(b = 100), barmode = barmode, showlegend = showlegend,
       xaxis = list(title = " ", categoryorder = "array", categoryarray = column_order), yaxis = list(title = ylab)
     )
 }
@@ -147,6 +153,7 @@ countMatrixByCategory <- function(annotation, category, fill = NULL) {
 #'   (dodged bars, the default) or \code{"stack"}.
 #' @param palette_name Valid R color palette name
 #' @param title Plot title
+#' @param ylab Y axis label
 #'
 #' @return output Plotly plot object
 #'
@@ -161,7 +168,7 @@ countMatrixByCategory <- function(annotation, category, fill = NULL) {
 #'   category = "biotype", fill = "direction"
 #' )
 #'
-interactive_count_barplot <- function(annotation, category, fill = NULL, barmode = c("group", "stack"), palette_name = COLORBLIND_PALETTE_NAME, title = NULL) {
+interactive_count_barplot <- function(annotation, category, fill = NULL, barmode = c("group", "stack"), palette_name = COLORBLIND_PALETTE_NAME, title = NULL, ylab = "Count") {
   barmode <- match.arg(barmode)
 
   if (!category %in% colnames(annotation)) {
@@ -181,5 +188,5 @@ interactive_count_barplot <- function(annotation, category, fill = NULL, barmode
     title <- paste("Counts by", prettify_variable_name(category))
   }
 
-  interactive_barchart(plotmatrix, barmode = barmode, ylab = "Count", palette_name = palette_name, title = title)
+  interactive_barchart(plotmatrix, barmode = barmode, ylab = ylab, palette_name = palette_name, title = title, showlegend = !is.null(fill))
 }

--- a/man/interactive_barchart.Rd
+++ b/man/interactive_barchart.Rd
@@ -9,7 +9,8 @@ interactive_barchart(
   barmode = c("stack", "group", "overlay"),
   ylab = "",
   palette_name = COLORBLIND_PALETTE_NAME,
-  title = NULL
+  title = NULL,
+  showlegend = NULL
 )
 }
 \arguments{
@@ -24,6 +25,9 @@ are reordered by decreasing mean so each is more likely to be visible}
 \item{palette_name}{Valid R color palette name}
 
 \item{title}{Plot title}
+
+\item{showlegend}{Show the trace legend? Default \code{NULL}: shown when
+\code{matrix} has more than one row.}
 }
 \value{
 output A plotly htmlwidget

--- a/man/interactive_count_barplot.Rd
+++ b/man/interactive_count_barplot.Rd
@@ -11,7 +11,8 @@ interactive_count_barplot(
   fill = NULL,
   barmode = c("group", "stack"),
   palette_name = COLORBLIND_PALETTE_NAME,
-  title = NULL
+  title = NULL,
+  ylab = "Count"
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ count per category.}
 \item{palette_name}{Valid R color palette name}
 
 \item{title}{Plot title}
+
+\item{ylab}{Y axis label}
 }
 \value{
 output Plotly plot object

--- a/tests/testthat/test-barplot.R
+++ b/tests/testthat/test-barplot.R
@@ -35,6 +35,14 @@ test_that("interactive_barchart hides the legend for a single-row matrix", {
   expect_false(p$x$layoutAttrs[[1]]$showlegend)
 })
 
+test_that("interactive_barchart's showlegend overrides the row-count default", {
+  single_row <- matrix(c(3, 2), nrow = 1, dimnames = list("Up", c("x", "y")))
+  multi_row <- matrix(1:4, nrow = 2, dimnames = list(c("Up", "Down"), c("x", "y")))
+
+  expect_true(interactive_barchart(single_row, showlegend = TRUE)$x$layoutAttrs[[1]]$showlegend)
+  expect_false(interactive_barchart(multi_row, showlegend = FALSE)$x$layoutAttrs[[1]]$showlegend)
+})
+
 test_that("interactive_barchart pins the x axis to matrix's column order, not alphabetical", {
   m <- matrix(c(3, 2, 1), nrow = 1, dimnames = list("Count", c("zebra", "mango", "apple")))
   built <- plotly::plotly_build(interactive_barchart(m))
@@ -95,6 +103,30 @@ test_that("interactive_count_barplot splits counts by a fill column into separat
   built <- plotly::plotly_build(interactive_count_barplot(annotation, "biotype", fill = "direction"))
 
   expect_length(built$x$data, 2)
+})
+
+test_that("interactive_count_barplot shows the legend when fill is used, even with a single fill level", {
+  annotation <- data.frame(
+    biotype = c("protein_coding", "protein_coding", "lncRNA"),
+    direction = c("Up", "Up", "Up")
+  )
+  p <- interactive_count_barplot(annotation, "biotype", fill = "direction")
+
+  expect_true(p$x$layoutAttrs[[1]]$showlegend)
+})
+
+test_that("interactive_count_barplot hides the legend when no fill is used", {
+  annotation <- data.frame(biotype = c("lncRNA", "protein_coding", "protein_coding"))
+  p <- interactive_count_barplot(annotation, "biotype")
+
+  expect_false(p$x$layoutAttrs[[1]]$showlegend)
+})
+
+test_that("interactive_count_barplot passes through a custom ylab", {
+  annotation <- data.frame(biotype = c("lncRNA", "protein_coding"))
+  built <- plotly::plotly_build(interactive_count_barplot(annotation, "biotype", ylab = "Number of differentially expressed genes"))
+
+  expect_equal(built$x$layout$yaxis$title, "Number of differentially expressed genes")
 })
 
 test_that("interactive_count_barplot errors for an unknown column", {


### PR DESCRIPTION
## Summary
- `interactive_barchart()` gains a `showlegend` parameter (default `NULL`, falling back to the previous `nrow(matrix) > 1` behaviour) so callers can override the legend visibility.
- `interactive_count_barplot()` now sets `showlegend = !is.null(fill)`, so a fill split with a single level (e.g. a contrast whose DE genes are all "Up") still shows its legend, while an unfilled plain count barplot stays legend-free.
- `interactive_count_barplot()` gains a `ylab` parameter (default `"Count"`) so callers can supply a more meaningful axis label instead of being stuck with the hardcoded one.

## Test plan
- [x] Added/updated tests in `tests/testthat/test-barplot.R` covering: `showlegend` override on `interactive_barchart`, legend shown for single-level `fill`, legend hidden with no `fill`, and custom `ylab` passthrough.
- [x] `devtools::test(".")` — full suite passes (934 passed, 0 failed).
- [x] `lintr::lint("R/barplot.R")` — no lints.
- [x] Regenerated roxygen docs (`devtools::document(".")`).

Fixes #293