### PR TITLE
Fix suppressed assay facet labels in interactive_boxplot

### DIFF
--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -439,6 +439,9 @@ interactive_boxplot <- function(plotmatrices, experiment, colorby = NULL, palett
     }
 
     xaxis <- list(title = if (length(plotmatrices) > 1) facet_names[i] else NULL)
+    if (length(plotmatrices) > 1) {
+      xaxis$showticklabels <- i == length(plotmatrices)
+    }
     if (length(visible_samples) > 0) {
       xaxis$categoryorder <- "array"
       xaxis$categoryarray <- unname(axis_labels[visible_samples])
@@ -454,7 +457,7 @@ interactive_boxplot <- function(plotmatrices, experiment, colorby = NULL, palett
   if (length(facet_plots) == 1) {
     p <- facet_plots[[1]]
   } else {
-    p <- subplot(facet_plots, nrows = length(facet_plots), shareX = TRUE, shareY = FALSE, titleX = TRUE, titleY = TRUE)
+    p <- subplot(facet_plots, nrows = length(facet_plots), shareX = FALSE, shareY = FALSE, titleX = TRUE, titleY = TRUE)
   }
 
   p <- p %>%

--- a/tests/testthat/test-boxplot.R
+++ b/tests/testthat/test-boxplot.R
@@ -135,6 +135,28 @@ test_that("interactive_boxplot bounds the number of outliers drawn", {
   expect_lte(total_outliers, 20)
 })
 
+test_that("interactive_boxplot labels every facet's x-axis, not just the bottom one", {
+  set.seed(2)
+  mat <- matrix(rpois(500 * 4, lambda = 50) + 1, nrow = 500)
+  colnames(mat) <- paste0("s", 1:4)
+  rownames(mat) <- paste0("gene", 1:500)
+  experiment <- data.frame(row.names = colnames(mat), group = rep(c("A", "B"), each = 2))
+
+  built <- suppressWarnings(plotly::plotly_build(
+    interactive_boxplot(list(Raw = mat, Filtered = mat[1:250, ]), experiment, colorby = "group")
+  ))
+  layout <- built$x$layout
+  axis_names <- grep("^xaxis", names(layout), value = TRUE)
+
+  expect_length(axis_names, 2)
+  titles <- vapply(axis_names, function(a) layout[[a]]$title, character(1))
+  expect_equal(unname(titles), c("Raw", "Filtered"))
+
+  # Only the bottom facet repeats the sample tick labels
+  showticklabels <- vapply(axis_names, function(a) isTRUE(layout[[a]]$showticklabels), logical(1))
+  expect_equal(unname(showticklabels), c(FALSE, TRUE))
+})
+
 # static_densityplot()
 
 test_that("static_densityplot draws one density area per colorby level", {


### PR DESCRIPTION
## Summary
- `interactive_boxplot()` facets by assay, each setting its assay name as its x-axis title, but the subplot used `shareX = TRUE`, which keeps only the bottom panel's title. With multiple assays (e.g. Raw / Normalised / Variance stabilised) only the last panel showed its label.
- Switch to `shareX = FALSE` so every facet keeps its own x-axis title, and hide the repeated sample tick labels on all but the bottom panel so the fix doesn't clutter the plot with duplicated axis text.

## Test plan
- [x] Added a regression test asserting every facet's x-axis title is set and only the bottom facet shows tick labels
- [x] `testthat::test_file("tests/testthat/test-boxplot.R")` passes (40/40)
- [x] Full test suite run file-by-file with no failures
- [x] `lintr::lint("R/boxplot.R")` — no lints

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)