### PR TITLE
Add labels argument to interactive_boxplot() for outlier hover text

### DIFF
--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -173,9 +173,12 @@ boxplot <- function(id, eselist) {
 
     output$sampleBoxplot <- renderPlotly({
       withProgress(message = "Making sample boxplot", value = 0, {
-        interactive_boxplot(selectmatrix_reactives$selectMatrix(), selectmatrix_reactives$selectColData(), groupby_reactives$getGroupby(),
+        selected_matrix <- selectmatrix_reactives$selectMatrix()
+        ese <- selectmatrix_reactives$getExperiment()
+        interactive_boxplot(selected_matrix, selectmatrix_reactives$selectColData(), groupby_reactives$getGroupby(),
           expressiontype = selectmatrix_reactives$getAssayMeasure(), whisker_distance = input$whiskerDistance,
-          palette = groupby_reactives$getPalette(), hidden_groups = hiddenGroups(), source = plot_source
+          palette = groupby_reactives$getPalette(), hidden_groups = hiddenGroups(), source = plot_source,
+          labels = stats::setNames(id_to_label(rownames(selected_matrix), ese), rownames(selected_matrix))
         ) %>%
           shinyngsPlotlyConfig("boxplot", format = session$userData$plotFormat())
       })
@@ -337,6 +340,11 @@ box_summary <- function(values, labels, whisker_distance = 1.5) {
 #'   legend (as \code{legendonly}) so they can be toggled back on.
 #' @param source Optional plotly source id used to route legend-click
 #'   (\code{plotly_restyle}) events back to a Shiny session.
+#' @param labels Optional named character vector keyed by \code{plotmatrices}
+#'   row names, used as the outlier-point hover text instead of the raw row
+#'   name (e.g. a gene ID to symbol mapping). Rows with no entry in
+#'   \code{labels} (or when \code{labels} is \code{NULL}) fall back to their
+#'   row name.
 #'
 #' @export
 #' @return output A \code{plotly} output
@@ -347,7 +355,7 @@ box_summary <- function(values, labels, whisker_distance = 1.5) {
 #' data(airway, package = "airway")
 #' interactive_boxplot(assays(airway)[[1]], data.frame(colData(airway)), colorby = "dex")
 #'
-interactive_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", palette_name = COLORBLIND_PALETTE_NAME, whisker_distance = 1.5, annotate_samples = FALSE, should_transform = NULL, max_outliers = 500, hidden_groups = character(0), source = NULL) {
+interactive_boxplot <- function(plotmatrices, experiment, colorby = NULL, palette = NULL, expressiontype = "expression", palette_name = COLORBLIND_PALETTE_NAME, whisker_distance = 1.5, annotate_samples = FALSE, should_transform = NULL, max_outliers = 500, hidden_groups = character(0), source = NULL, labels = NULL) {
   if (!is.list(plotmatrices)) {
     plotmatrices <- list(" " = plotmatrices)
   }
@@ -387,7 +395,15 @@ interactive_boxplot <- function(plotmatrices, experiment, colorby = NULL, palett
     m <- cond_log2_transform_matrix(as.matrix(plotmatrices[[i]]), should_transform = should_transform, rmzeros = TRUE)
     m <- m[, samples, drop = FALSE]
 
-    stats <- lapply(samples, function(s) box_summary(m[, s], rownames(m), whisker_distance))
+    row_labels <- if (is.null(labels)) {
+      rownames(m)
+    } else {
+      resolved <- unname(labels[rownames(m)])
+      resolved[is.na(resolved)] <- rownames(m)[is.na(resolved)]
+      resolved
+    }
+
+    stats <- lapply(samples, function(s) box_summary(m[, s], row_labels, whisker_distance))
     names(stats) <- samples
 
     p <- if (is.null(event_source)) plot_ly() else plot_ly(source = event_source)

--- a/man/interactive_boxplot.Rd
+++ b/man/interactive_boxplot.Rd
@@ -16,7 +16,8 @@ interactive_boxplot(
   should_transform = NULL,
   max_outliers = 500,
   hidden_groups = character(0),
-  source = NULL
+  source = NULL,
+  labels = NULL
 )
 }
 \arguments{
@@ -54,6 +55,12 @@ legend (as \code{legendonly}) so they can be toggled back on.}
 
 \item{source}{Optional plotly source id used to route legend-click
 (\code{plotly_restyle}) events back to a Shiny session.}
+
+\item{labels}{Optional named character vector keyed by \code{plotmatrices}
+row names, used as the outlier-point hover text instead of the raw row
+name (e.g. a gene ID to symbol mapping). Rows with no entry in
+\code{labels} (or when \code{labels} is \code{NULL}) fall back to their
+row name.}
 }
 \value{
 output A \code{plotly} output

--- a/tests/testthat/test-boxplot.R
+++ b/tests/testthat/test-boxplot.R
@@ -135,6 +135,27 @@ test_that("interactive_boxplot bounds the number of outliers drawn", {
   expect_lte(total_outliers, 20)
 })
 
+test_that("interactive_boxplot uses labels for outlier hover text, falling back to rownames", {
+  genes <- paste0("gene", 1:5)
+  samples <- paste0("s", 1:4)
+  mat <- matrix(5, nrow = 5, ncol = 4, dimnames = list(genes, samples))
+  # One clear outlier per sample, on a different gene each time
+  mat["gene1", "s1"] <- 500
+  mat["gene2", "s2"] <- 500
+  mat["gene3", "s3"] <- 500
+  mat["gene4", "s4"] <- 500
+  experiment <- data.frame(row.names = samples)
+
+  # gene3 has an explicit NA entry, gene4 is absent from the map entirely -
+  # both should fall back to the raw rowname
+  labels <- c(gene1 = "SYMBOL1", gene2 = "SYMBOL2", gene3 = NA_character_)
+
+  built <- plotly::plotly_build(interactive_boxplot(mat, experiment, labels = labels))
+  outlier_trace <- Filter(function(t) identical(t$type, "scatter"), built$x$data)[[1]]
+
+  expect_setequal(outlier_trace$text, c("SYMBOL1", "SYMBOL2", "gene3", "gene4"))
+})
+
 # static_densityplot()
 
 test_that("static_densityplot draws one density area per colorby level", {


### PR DESCRIPTION
## Summary
- `interactive_boxplot()` gains an optional `labels` argument: a named character vector keyed by matrix row names, used as outlier-point hover text instead of the raw rowname. Rows missing from the map (or mapped to `NA`) fall back to their rowname.
- The shinyngs boxplot module now passes `id_to_label()` through as `labels`, so gene-symbol hover text matches the "lines" (`interactive_quartiles`) view, which already resolved labels this way.

This mirrors the label handling already present in `interactive_heatmap()` (`row_labels`) and `interactive_topgene_boxplots()` (`labels`/`annotations`), so external callers like nf-core/differentialabundance can pass an id→symbol map straight through rather than rewriting matrix rownames as a workaround.

Fixes #295

## Test plan
- [x] Added a unit test asserting outlier hover text uses the supplied labels, with fallback to the rowname for entries that are `NA` or absent from the map
- [x] Full `devtools::test()` suite passes (0 failures)