### PR TITLE
Fix squished PCA vs Experiment plot

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -1071,11 +1071,8 @@ interactive_pca_variance_heatmap <- function(pca_coords, pcameta, fraction_expla
   ) %>%
     plotly::layout(hovermode = "x")
 
-  # subplot() carries over whichever input plot happened to set an explicit
-  # layout height (here, hm's heatmap_height) rather than deriving one from
-  # its own heights= panel fractions, so the combined figure's own height has
-  # to be set directly - plotly::layout(height = ...) is a documented no-op
-  # for htmlwidgets built this way.
+  # subplot() inherits hm's own height rather than total_height, and
+  # plotly::layout(height = ...) is a documented no-op here, so set it directly.
   p$x$layout$height <- total_height
 
   # See the matching comment in interactive_heatmap() (#291): heights here are

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -1071,6 +1071,13 @@ interactive_pca_variance_heatmap <- function(pca_coords, pcameta, fraction_expla
   ) %>%
     plotly::layout(hovermode = "x")
 
+  # subplot() carries over whichever input plot happened to set an explicit
+  # layout height (here, hm's heatmap_height) rather than deriving one from
+  # its own heights= panel fractions, so the combined figure's own height has
+  # to be set directly - plotly::layout(height = ...) is a documented no-op
+  # for htmlwidgets built this way.
+  p$x$layout$height <- total_height
+
   # See the matching comment in interactive_heatmap() (#291): heights here are
   # always explicitly computed, so don't let knitr/Quarto's own figure-sizing
   # defaults override the container independently of the embedded plotly

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -296,3 +296,21 @@ test_that("interactive_pca_variance_heatmap's combined widget also opts out of k
 
   expect_false(p$sizingPolicy$knitr$figure)
 })
+
+test_that("interactive_pca_variance_heatmap's combined widget height is the sum of the scree and heatmap heights", {
+  # subplot() otherwise carries over whichever input plot happened to set an
+  # explicit layout height (here, the heatmap panel's) rather than deriving
+  # one from its own heights= panel fractions, understating the container the
+  # combined figure needs.
+  set.seed(1)
+  pcameta <- data.frame(
+    row.names = paste0("sample", 1:6),
+    treatment = rep(c("control", "treated"), each = 3),
+    batch = rep(c("a", "b"), 3)
+  )
+  pca_coords <- matrix(rnorm(6 * 4), nrow = 6, dimnames = list(rownames(pcameta), paste0("PC", 1:4)))
+
+  p <- interactive_pca_variance_heatmap(pca_coords, pcameta, fraction_explained = c(45, 25, 20, 10), heatmap_height = 190, scree_height = 200)
+
+  expect_equal(p$x$layout$height, 390)
+})

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -298,10 +298,6 @@ test_that("interactive_pca_variance_heatmap's combined widget also opts out of k
 })
 
 test_that("interactive_pca_variance_heatmap's combined widget height is the sum of the scree and heatmap heights", {
-  # subplot() otherwise carries over whichever input plot happened to set an
-  # explicit layout height (here, the heatmap panel's) rather than deriving
-  # one from its own heights= panel fractions, understating the container the
-  # combined figure needs.
   set.seed(1)
   pcameta <- data.frame(
     row.names = paste0("sample", 1:6),


### PR DESCRIPTION
## Summary

On the QC/exploratory "PCA vs experiment" view, the scree plot + p-value heatmap were rendering squished into a short strip at the top of their container, with a large blank gap before the "Association p-values" table below.

`interactive_pca_variance_heatmap()` combines a scree plot and heatmap into one figure via `plotly::subplot()`, and computes `total_height` to work out the relative row-height split between the two panels. But `subplot()` doesn't derive an overall height from those fractions - it just inherits whichever input plot happened to have an explicit height baked in (the heatmap panel's, which is shorter than the combined total). The surrounding container div was already sized correctly for the combined height; the plotly figure itself just wasn't filling it.

Fix: explicitly set `p$x$layout$height <- total_height` on the merged widget after `subplot()` builds it. (`plotly::layout(height = ...)` looks like the natural fix but is a documented no-op for widgets built this way.)

## Test plan

- [x] Added a regression test asserting the combined widget's `layout$height` equals the sum of the scree and heatmap heights
- [x] Full `test-heatmap.R` suite passes (29/29), including the existing scree/heatmap x-axis sync and knitr-opt-out tests, confirming no regression to the features introduced alongside the original bug (#238, #277)
- [x] Verified visually in the running app (zhangneurons test data): plot now fills its container and flows directly into the p-values table with no gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)