### PR TITLE
Escape table content and generated links

### DIFF
--- a/R/gene.R
+++ b/R/gene.R
@@ -262,21 +262,27 @@ gene <- function(id, eselist) {
 
     # Make a table of the annotation data
 
-    output$geneInfoTable <- DT::renderDataTable(
-      {
+    output$geneInfoTable <- DT::renderDataTable({
         rows <- gene_label_reactives$getSelectedIds()
         ese <- selectmatrix_reactives$getExperiment()
 
         validate(need(all(rows %in% rownames(ese)), FALSE))
 
-        gene_info <- data.frame(SummarizedExperiment::mcols(ese[rows, , drop = FALSE]), check.names = FALSE, row.names = id_to_label(rows, ese, sep = " /<br/ >"))
-        gene_info <- t(linkMatrix(gene_info, eselist@url_roots))
+        gene_info <- data.frame(SummarizedExperiment::mcols(ese[rows, , drop = FALSE]), check.names = FALSE, row.names = id_to_label(rows, ese))
+        gene_info <- linkMatrix(gene_info, eselist@url_roots)
+        link_columns <- attr(gene_info, "shinyngs_html_columns", exact = TRUE)
+        text_columns <- setdiff(colnames(gene_info), link_columns)
+        gene_info[text_columns] <- lapply(gene_info[text_columns], htmltools::htmlEscape)
+        gene_info <- as.data.frame(t(gene_info), check.names = FALSE)
         rownames(gene_info) <- prettify_variable_name(rownames(gene_info))
-        gene_info
-      },
-      options = list(rownames = TRUE, pageLength = 20, dom = "t"),
-      escape = FALSE
-    )
+        attr(gene_info, "shinyngs_html_columns") <- colnames(gene_info)
+
+        DT::datatable(
+          gene_info,
+          options = list(rownames = TRUE, pageLength = 20, dom = "t"),
+          escape = datatable_escape_columns(gene_info, rownames = TRUE)
+        )
+      })
 
     # Make the gene info table update (probably invisibly) even when hidden, so there's not a delay in rendering when the link to the modal is clicked.
 

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -429,10 +429,12 @@ linkMatrix <- function(matrix, url_roots, display_values = data.frame()) {
         # Use a simple column paste for single-value columns. Different aproach for multi-value columns
 
         make_link <- function(href, display) {
-          as.character(tags$a(
-            href = paste0(url_root, utils::URLencode(as.character(href), reserved = TRUE)),
-            as.character(display)
-          ))
+          href <- paste0(url_root, utils::URLencode(as.character(href), reserved = TRUE))
+          paste0(
+            '<a href="', htmltools::htmlEscape(href, attribute = TRUE), '">',
+            htmltools::htmlEscape(as.character(display)),
+            "</a>"
+          )
         }
 
         if (any(grepl(" ", matrix[[fieldname]]), na.rm = TRUE) && !fieldname %in% "gene_set_id") {
@@ -440,14 +442,10 @@ linkMatrix <- function(matrix, url_roots, display_values = data.frame()) {
           fvs_for_display <- strsplit(fvs_for_display, " ")
 
           matrix[[fieldname]][notna] <- unlist(lapply(seq_along(fvs_for_href), function(x) {
-            paste(Map(make_link, fvs_for_href[[x]], fvs_for_display[[x]]), collapse = " ")
+            paste(make_link(fvs_for_href[[x]], fvs_for_display[[x]]), collapse = " ")
           }))
         } else {
-          matrix[[fieldname]][notna] <- unname(vapply(
-            Map(make_link, fvs_for_href, fvs_for_display),
-            identity,
-            character(1)
-          ))
+          matrix[[fieldname]][notna] <- make_link(fvs_for_href, fvs_for_display)
         }
         html_columns <- c(html_columns, fieldname)
       }

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -412,8 +412,14 @@ linkMatrix <- function(matrix, url_roots, display_values = data.frame()) {
       url_roots[[prettify_variable_name(fieldname)]] <- url_roots[[fieldname]]
     }
 
+    html_columns <- character()
     for (fieldname in names(url_roots)) {
       if (fieldname %in% colnames(matrix)) {
+        url_root <- url_roots[[fieldname]]
+        if (length(url_root) != 1 || is.na(url_root) || !grepl("^(https?://|[/?#])", url_root, ignore.case = TRUE)) {
+          stop("URL root for '", fieldname, "' must use HTTP, HTTPS, or a relative URL")
+        }
+
         notna <- !is.na(matrix[[fieldname]])
         fvs_for_href <- fvs_for_display <- matrix[[fieldname]][notna]
         if (fieldname %in% colnames(display_values)) {
@@ -422,18 +428,31 @@ linkMatrix <- function(matrix, url_roots, display_values = data.frame()) {
 
         # Use a simple column paste for single-value columns. Different aproach for multi-value columns
 
-        if (any(grepl(" ", matrix[[fieldname]])) && !fieldname %in% "gene_set_id") {
+        make_link <- function(href, display) {
+          as.character(tags$a(
+            href = paste0(url_root, utils::URLencode(as.character(href), reserved = TRUE)),
+            as.character(display)
+          ))
+        }
+
+        if (any(grepl(" ", matrix[[fieldname]]), na.rm = TRUE) && !fieldname %in% "gene_set_id") {
           fvs_for_href <- strsplit(fvs_for_href, " ")
           fvs_for_display <- strsplit(fvs_for_display, " ")
 
           matrix[[fieldname]][notna] <- unlist(lapply(seq_along(fvs_for_href), function(x) {
-            paste(paste0("<a href='", url_roots[fieldname], fvs_for_href[[x]], "'>", fvs_for_display[[x]], "</a>"), collapse = " ")
+            paste(Map(make_link, fvs_for_href[[x]], fvs_for_display[[x]]), collapse = " ")
           }))
         } else {
-          matrix[[fieldname]][notna] <- paste0("<a href='", url_roots[fieldname], fvs_for_href, "'>", fvs_for_display, "</a>")
+          matrix[[fieldname]][notna] <- unname(vapply(
+            Map(make_link, fvs_for_href, fvs_for_display),
+            identity,
+            character(1)
+          ))
         }
+        html_columns <- c(html_columns, fieldname)
       }
     }
+    attr(matrix, "shinyngs_html_columns") <- unique(html_columns)
     matrix
   })
 }

--- a/R/simpletable.R
+++ b/R/simpletable.R
@@ -110,16 +110,16 @@ simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 1
       options$dom <- paste0("f", options$dom)
     }
 
-    output$datatable <- DT::renderDataTable(
-      {
-        displayMatrix()
-      },
-      options = options,
-      filter = filter,
-      rownames = rownames,
-      escape = FALSE,
-      server = server
-    )
+    output$datatable <- DT::renderDataTable({
+      table_data <- displayMatrix()
+      DT::datatable(
+        table_data,
+        options = options,
+        filter = filter,
+        rownames = rownames,
+        escape = datatable_escape_columns(table_data, rownames)
+      )
+    }, server = server)
 
     output$downloadTable <- downloadHandler(filename = function() {
       if (is.reactive(filename)) {
@@ -130,4 +130,17 @@ simpletable <- function(id, downloadMatrix = NULL, displayMatrix, pageLength = 1
       write.csv(downloadMatrix(), file = file, row.names = rownames)
     })
   })
+}
+
+datatable_escape_columns <- function(data, rownames = FALSE) {
+  html_columns <- attr(data, "shinyngs_html_columns", exact = TRUE)
+  if (is.null(html_columns)) {
+    return(TRUE)
+  }
+
+  columns <- colnames(data)
+  if (isTRUE(rownames)) {
+    columns <- c(" ", columns)
+  }
+  setdiff(columns, html_columns)
 }

--- a/R/ui-helpers.R
+++ b/R/ui-helpers.R
@@ -17,9 +17,9 @@ SHINYNGS_ACCENT <- "#2780e3"
 #' hidden_input("myid", "iamavalue")
 #'
 hidden_input <- function(id, values) {
-  HTML(paste0(unlist(lapply(values, function(value) paste0("<input type='text' id='", id, "' value='", value, "' style='display: none;'>")))))
-
-  # HTML(paste0('<input type='text' id='', id, '' value='', value, '' style='display: none;'>'))
+  tagList(lapply(values, function(value) {
+    tags$input(type = "text", id = id, value = value, style = "display: none;")
+  }))
 }
 
 #' Simple list push

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -25,9 +25,19 @@ test_that("count_lines works", {
 
 # hidden_input()
 
-test_that("count_lines works", {
-  test_html <- "<input type='text' id='myid' value='foo' style='display: none;'>"
-  expect_equal(as.character(hidden_input("myid", "foo")), test_html)
+test_that("hidden_input returns a text input", {
+  input <- hidden_input("myid", "foo")
+
+  expect_match(as.character(input), 'type="text"', fixed = TRUE)
+  expect_match(as.character(input), 'id="myid"', fixed = TRUE)
+  expect_match(as.character(input), 'value="foo"', fixed = TRUE)
+})
+
+test_that("hidden_input escapes attribute values", {
+  input <- hidden_input("safe", "x'><script>alert(1)</script>")
+
+  expect_false(grepl("<script>", as.character(input), fixed = TRUE))
+  expect_match(as.character(input), "&lt;script&gt;", fixed = TRUE)
 })
 
 # push_to_list()

--- a/tests/testthat/test-selectmatrix.R
+++ b/tests/testthat/test-selectmatrix.R
@@ -75,6 +75,19 @@ test_that("linkMatrix rejects active URL schemes", {
   })
 })
 
+test_that("linkMatrix escapes URL root attributes", {
+  data <- data.frame(gene_id = "g1")
+  session <- shiny::MockShinySession$new()
+  on.exit(session$close())
+
+  linked <- shiny::withReactiveDomain(session, {
+    linkMatrix(data, list(gene_id = '/gene?source=" onmouseover="alert(1)&id='))
+  })
+
+  expect_match(linked$gene_id, "source=&quot; onmouseover=&quot;alert(1)&amp;id=g1", fixed = TRUE)
+  expect_false(grepl('onmouseover="', linked$gene_id, fixed = TRUE))
+})
+
 # convert_ids()
 
 test_that("convert_ids maps row names to a metadata column", {

--- a/tests/testthat/test-selectmatrix.R
+++ b/tests/testthat/test-selectmatrix.R
@@ -45,6 +45,36 @@ test_that("id_to_label accepts a custom separator", {
   expect_equal(id_to_label("g1", ese, sep = "-"), "GeneA-g1")
 })
 
+test_that("linkMatrix escapes labels and encodes identifiers", {
+  data <- data.frame(gene_id = "A/B?<script>", note = "<script>alert(1)</script>")
+  session <- shiny::MockShinySession$new()
+  on.exit(session$close())
+
+  linked <- shiny::withReactiveDomain(session, {
+    linked <- linkMatrix(data, list(gene_id = "https://example.org/id/"))
+    linked
+  })
+
+  expect_match(linked$gene_id, "A%2FB%3F%3Cscript%3E", fixed = TRUE)
+  expect_match(linked$gene_id, "&lt;script&gt;", fixed = TRUE)
+  expect_false(grepl("<script>", linked$gene_id, fixed = TRUE))
+  expect_equal(linked$note, data$note)
+  expect_equal(attr(linked, "shinyngs_html_columns"), "gene_id")
+})
+
+test_that("linkMatrix rejects active URL schemes", {
+  data <- data.frame(gene_id = "alert(1)")
+  session <- shiny::MockShinySession$new()
+  on.exit(session$close())
+
+  shiny::withReactiveDomain(session, {
+    expect_error(
+      linkMatrix(data, list(gene_id = "javascript:")),
+      "must use HTTP, HTTPS, or a relative URL"
+    )
+  })
+})
+
 # convert_ids()
 
 test_that("convert_ids maps row names to a metadata column", {

--- a/tests/testthat/test-simpletable.R
+++ b/tests/testthat/test-simpletable.R
@@ -11,6 +11,20 @@ test_that("simpletable renders the display matrix as a datatable", {
   )
 })
 
+test_that("datatable escaping is enabled for ordinary data", {
+  df <- data.frame(gene = "<script>alert(1)</script>")
+
+  expect_true(datatable_escape_columns(df))
+})
+
+test_that("datatable escaping excludes only generated link columns", {
+  df <- data.frame(gene = "safe link", note = "<script>alert(1)</script>")
+  attr(df, "shinyngs_html_columns") <- "gene"
+
+  expect_equal(datatable_escape_columns(df), "note")
+  expect_equal(datatable_escape_columns(df, rownames = TRUE), c(" ", "note"))
+})
+
 test_that("simpletable's download handler writes downloadMatrix, not displayMatrix, to CSV", {
   display_df <- data.frame(gene = c("g1", "g2"), value = c("<b>1</b>", "<b>2</b>"))
   download_df <- data.frame(gene = c("g1", "g2"), value = c(1, 2))


### PR DESCRIPTION
## Summary

- escape user-controlled content before rendering DataTables
- build generated table links with safe, vectorized HTML escaping and URL encoding
- reject unsafe URL schemes and construct hidden inputs with Shiny tags

## Validation

- full package test suite
- focused link and DataTable regressions
- live Playwright adversarial-markup check with a clean browser console
- 20,000-link render benchmark: 0.34 seconds
- `lintr::lint_package()`
