### PR TITLE
Keep sample selection state consistent

### DIFF
--- a/R/sampleselect.R
+++ b/R/sampleselect.R
@@ -129,27 +129,28 @@ sampleselect <- function(id, eselist, getExperiment, allow_summarise = TRUE) {
       withProgress(message = "Selecting samples", value = 0, {
         validate(need(!is.null(getSampleSelect()), "Waiting for form to provide sampleSelect"))
         ese <- getExperiment()
+        sample_select <- getSampleSelect()
 
-        if (getSampleSelect() == "all") {
+        if (sample_select == "all") {
           return(colnames(ese))
-        } else {
-          validate(need(!is.null(input$samples), "Waiting for form to provide samples"))
-
-          if (has_slot_data(eselist, "group_vars")) {
-            validate(need(!is.null(input$sampleGroupVal), FALSE))
-          }
-
-          if (getSampleSelect() == "name") {
-            return(input$samples)
-          } else {
-            # Any NA in the colData will become string '' via the inputs, so make sure we consider that when matching
-
-            samplegroups <- as.character(ese[[isolate(input$sampleGroupVar)]])
-            samplegroups[is.na(samplegroups)] <- ""
-
-            return(colnames(ese)[samplegroups %in% input$sampleGroupVal])
-          }
         }
+
+        if (sample_select == "name") {
+          validate(need(!is.null(input$samples), "Waiting for form to provide samples"))
+          return(input$samples)
+        }
+
+        validate(need(sample_select == "group", paste0("Unknown sample selection mode: ", sample_select)))
+        validate(need(has_slot_data(eselist, "group_vars"), "No sample grouping variables are available"))
+        validate(need(!is.null(input$sampleGroupVar), "Waiting for form to provide sampleGroupVar"))
+        validate(need(!is.null(input$sampleGroupVal), "Waiting for form to provide sampleGroupVal"))
+
+        # Any NA in the colData will become string '' via the inputs, so make sure we consider that when matching
+
+        samplegroups <- as.character(ese[[isolate(input$sampleGroupVar)]])
+        samplegroups[is.na(samplegroups)] <- ""
+
+        colnames(ese)[samplegroups %in% input$sampleGroupVal]
       })
     })
 

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -239,11 +239,14 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
     })
 
     shouldSummarise <- reactive({
+      if (!allow_summarise ||
+        !has_slot_data(eselist, "group_vars") ||
+        !identical(sampleselect_reactives$getSampleSelect(), "group")) {
+        return(FALSE)
+      }
+
       summary_type <- sampleselect_reactives$getSummaryType()
-      allow_summarise &&
-        has_slot_data(eselist, "group_vars") &&
-        identical(sampleselect_reactives$getSampleSelect(), "group") &&
-        length(summary_type) == 1 &&
+      length(summary_type) == 1 &&
         summary_type != "none"
     })
 

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -238,6 +238,13 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
       SummarizedExperiment::assays(ese)[[assay]]
     })
 
+    shouldSummarise <- reactive({
+      allow_summarise &&
+        has_slot_data(eselist, "group_vars") &&
+        sampleselect_reactives$getSampleSelect() == "group" &&
+        sampleselect_reactives$getSummaryType() != "none"
+    })
+
     # Generate an expression matrix given the selected experiment, assay, rows and columns
 
     selectMatrix <- reactive({
@@ -249,7 +256,7 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
         rows <- geneselect_reactives$selectRows()
 
         selected_matrix <- assay_matrix[rows, samples, drop = FALSE]
-        if (allow_summarise && sampleselect_reactives$getSampleSelect() == "group" && sampleselect_reactives$getSummaryType() != "none") {
+        if (shouldSummarise()) {
           selected_matrix <- summarize_matrix(selected_matrix, selectColData()[[sampleselect_reactives$getSampleGroupVar()]], sampleselect_reactives$getSummaryType())
         }
 
@@ -277,7 +284,7 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
     # summarised if grouping variables were supplied!
 
     isSummarised <- reactive({
-      allow_summarise && has_slot_data(eselist, "group_vars") && sampleselect_reactives$getSummaryType() != "none"
+      shouldSummarise()
     })
 
     # Extract the annotation from the SummarizedExperiment

--- a/R/selectmatrix.R
+++ b/R/selectmatrix.R
@@ -239,10 +239,12 @@ selectmatrix <- function(id, eselist, var_n = 50, var_max = NULL, select_assays 
     })
 
     shouldSummarise <- reactive({
+      summary_type <- sampleselect_reactives$getSummaryType()
       allow_summarise &&
         has_slot_data(eselist, "group_vars") &&
-        sampleselect_reactives$getSampleSelect() == "group" &&
-        sampleselect_reactives$getSummaryType() != "none"
+        identical(sampleselect_reactives$getSampleSelect(), "group") &&
+        length(summary_type) == 1 &&
+        summary_type != "none"
     })
 
     # Generate an expression matrix given the selected experiment, assay, rows and columns

--- a/tests/testthat/test-assaydatatable.R
+++ b/tests/testthat/test-assaydatatable.R
@@ -43,13 +43,34 @@ test_that("assaydatatable restricts the displayed matrix to the selected samples
       "expression-assay" = "counts",
       "expression-selectmatrix-sampleSelect" = "name",
       "expression-selectmatrix-samples" = c("s1", "s2"),
-      "expression-selectmatrix-sampleGroupVal" = "ctrl",
+      "expression-selectmatrix-summarise-summaryType" = "colMeans",
       "expression-selectmatrix-geneSelect" = "all"
     )
     session$elapse(400)
 
     displayed <- selectmatrix_reactives$selectLabelledMatrix()
     expect_setequal(colnames(displayed), c("Gene id", "s1", "s2"))
+    expect_false(selectmatrix_reactives$isSummarised())
+  })
+})
+
+test_that("assaydatatable reports matrices summarised from sample groups", {
+  eselist <- make_medium_module_eselist()
+
+  shiny::testServer(assaydatatable, args = list(id = "assaydatatable", eselist = eselist), {
+    session$setInputs(
+      "expression-experiment" = "counts",
+      "expression-assay" = "counts",
+      "expression-selectmatrix-sampleSelect" = "group",
+      "expression-selectmatrix-sampleGroupVar" = "condition",
+      "expression-selectmatrix-sampleGroupVal" = c("ctrl", "treated"),
+      "expression-selectmatrix-summarise-summaryType" = "colMeans",
+      "expression-selectmatrix-geneSelect" = "all"
+    )
+    session$elapse(400)
+
+    expect_true(selectmatrix_reactives$isSummarised())
+    expect_equal(colnames(selectmatrix_reactives$selectMatrix()), c("ctrl", "treated"))
   })
 })
 

--- a/tests/testthat/test-sampleselect.R
+++ b/tests/testthat/test-sampleselect.R
@@ -44,7 +44,7 @@ test_that("selectSamples returns exactly the samples picked by name", {
     sampleselect,
     args = list(id = "sampleselect", eselist = eselist, getExperiment = function() eselist[["counts"]]),
     {
-      session$setInputs(sampleSelect = "name", samples = c("s1", "s3"), sampleGroupVal = "ctrl")
+      session$setInputs(sampleSelect = "name", samples = c("s1", "s3"))
       expect_equal(selectSamples(), c("s1", "s3"))
     }
   )

--- a/tests/testthat/test-selectmatrix.R
+++ b/tests/testthat/test-selectmatrix.R
@@ -105,3 +105,30 @@ test_that("single_valid_matrix is FALSE for multiple experiments", {
 
   expect_false(single_valid_matrix(eselist))
 })
+
+test_that("selectmatrix supports callers that disable summarisation", {
+  eselist <- make_medium_module_eselist(n_genes = 12)
+
+  shiny::testServer(
+    selectmatrix,
+    args = list(
+      id = "selectmatrix",
+      eselist = eselist,
+      var_n = 10,
+      provide_all_genes = TRUE,
+      allow_summarise = FALSE
+    ),
+    {
+      session$setInputs(
+        experiment = "counts",
+        assay = "counts",
+        "selectmatrix-sampleSelect" = "all",
+        "selectmatrix-geneSelect" = "all"
+      )
+      session$elapse(400)
+
+      expect_false(isSummarised())
+      expect_equal(dim(selectMatrix()), c(12L, 4L))
+    }
+  )
+})


### PR DESCRIPTION
## Summary

- make by-name sample selection independent of hidden group controls
- validate group-only inputs only while group selection is active
- report matrices as summarised only when group selection and a summary method are both active
- guard dynamic summary state while its UI is being created or summarisation is disabled

## Validation

- full single-process package test suite
- focused sample-selection and matrix-selection regressions
- live Playwright transition from grouped means to selected sample names
- live Playwright 12-by-12 clustering heatmap assertion
- clean browser consoles in both live scenarios
- `lintr::lint_package()`
