### PR TITLE
Preserve zero fold changes in plots

### DIFF
--- a/R/foldchange-scale.R
+++ b/R/foldchange-scale.R
@@ -150,7 +150,16 @@ resolve_deprecated_unlog_foldchanges <- function(fold_change_scale, unlog_foldch
 # Unlog a signed fold change value from log2 to linear scale (see
 # resolve_foldchange_scale()).
 unlog_fold_change <- function(x) {
-  sign(x) * 2^(abs(x))
+  result <- sign(x) * 2^(abs(x))
+  result[!is.na(x) & x == 0] <- 1
+  result
+}
+
+# Convert signed linear fold changes to log2 while tolerating legacy zeroes.
+log_fold_change <- function(x) {
+  result <- sign(x) * log2(abs(x))
+  result[!is.na(x) & x == 0] <- 0
+  result
 }
 
 # Read the feature id/p value/q value/fold change columns of a differential

--- a/R/maplot.R
+++ b/R/maplot.R
@@ -144,8 +144,7 @@ buildMaTable <- function(contrast_reactives) {
     sct <- contrast_reactives$selectedContrastsTables()
     ct <- sct[[1]][[1]]
 
-    matable <- data.frame(round(log10(rowMeans(ct[, 1:2])), 3), round(sign(ct[["Fold change"]]) *
-      log2(abs(ct[["Fold change"]])), 3), row.names = rownames(ct), check.names = FALSE)
+    matable <- data.frame(round(log10(rowMeans(ct[, 1:2])), 3), round(log_fold_change(ct[["Fold change"]]), 3), row.names = rownames(ct), check.names = FALSE)
     colnames(matable) <- c("log(10) mean expression", paste0("log(2) fold change [source scale: ", contrast_reactives$getFoldChangeScale(), "]"))
 
     matable

--- a/R/volcanoplot.R
+++ b/R/volcanoplot.R
@@ -162,7 +162,7 @@ buildVolcanoTable <- function(contrast_reactives) {
     ct$`q value`[ct$`q value` == 0] <- min(ct$`q value`[ct$`q value` != 0]) / 10
 
     ct <- ct[, c("Fold change", "q value")]
-    ct[["Fold change"]] <- round(sign(ct[["Fold change"]]) * log2(abs(ct[["Fold change"]])), 3)
+    ct[["Fold change"]] <- round(log_fold_change(ct[["Fold change"]]), 3)
     ct[["q value"]] <- round(-log10(ct[["q value"]]), 3)
 
     cont <- contrast_reactives$getSelectedContrasts()[[1]][[1]]

--- a/exec/differential_plots.R
+++ b/exec/differential_plots.R
@@ -197,7 +197,7 @@ hline_thresholds[[paste(opt$p_value_column, "=", opt$p_value_threshold)]] <- -lo
 vline_thresholds[[paste(opt$fold_change_col, "<-", opt$fold_change_threshold)]] <- -log2(opt$fold_change_threshold)
 vline_thresholds[[paste(opt$fold_change_col, ">", opt$fold_change_threshold)]] <- log2(opt$fold_change_threshold)
 
-x <- sign(differential[[opt$fold_change_col]]) * log2(abs(differential[[opt$fold_change_col]]))
+x <- shinyngs:::log_fold_change(differential[[opt$fold_change_col]])
 
 plot_args <- list(
   x = x,

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -465,6 +465,22 @@ test_that("cond_log2_transform_matrix guesses reverse (unlog) status correctly",
 
 # guess_foldchange_scale()
 
+test_that("signed fold-change conversion handles no-change values", {
+  expect_equal(unlog_fold_change(c(-2, -1, 0, 1, 2)), c(-4, -2, 1, 2, 4))
+  expect_equal(log_fold_change(c(-4, -2, 1, 2, 4)), c(-2, -1, 0, 1, 2))
+})
+
+test_that("signed fold-change conversion preserves special values", {
+  expect_equal(log_fold_change(c(0, NA, Inf, -Inf)), c(0, NA, Inf, -Inf))
+  expect_equal(unlog_fold_change(c(0, NA, Inf, -Inf)), c(1, NA, Inf, -Inf))
+})
+
+test_that("signed fold-change conversion round trips its valid domain", {
+  log2_values <- c(-3.5, -1, 0, 0.5, 4, NA, Inf, -Inf)
+
+  expect_equal(log_fold_change(unlog_fold_change(log2_values)), log2_values)
+})
+
 test_that("guess_foldchange_scale detects log2 values via sub-unity magnitudes", {
   expect_equal(guess_foldchange_scale(c(-3.2, 1.1, 0.4, -0.05, 2.8)), "log2")
 })

--- a/tests/testthat/test-maplot.R
+++ b/tests/testthat/test-maplot.R
@@ -1,5 +1,25 @@
 # selectMaLines()
 
+test_that("buildMaTable retains legacy zero fold changes", {
+  contrast_table <- data.frame(
+    reference = c(1, 1),
+    treatment = c(1, 2),
+    `Fold change` = c(0, 2),
+    check.names = FALSE
+  )
+  contrast_reactives <- list(
+    selectedContrastsTables = function() list(list(contrast_table)),
+    getFoldChangeScale = function() "linear"
+  )
+  session <- shiny::MockShinySession$new()
+  on.exit(session$close())
+
+  result <- shiny::withReactiveDomain(session, buildMaTable(contrast_reactives))
+
+  expect_equal(result[[2]], c(0, 1))
+  expect_false(anyNA(result[[2]]))
+})
+
 make_lines <- function(fclim = -2) {
   data.frame(
     name = c(

--- a/tests/testthat/test-volcanoplot.R
+++ b/tests/testthat/test-volcanoplot.R
@@ -1,5 +1,27 @@
 # selectVolcanoLines()
 
+test_that("buildVolcanoTable retains legacy zero fold changes", {
+  contrast_table <- data.frame(
+    reference = c(1, 1),
+    treatment = c(1, 2),
+    `Fold change` = c(0, 2),
+    `q value` = c(0.5, 0.05),
+    check.names = FALSE
+  )
+  contrast_reactives <- list(
+    selectedContrastsTables = function() list(list(contrast_table)),
+    getSelectedContrasts = function() list(list(c("condition", "reference", "treatment"))),
+    getFoldChangeScale = function() "linear"
+  )
+  session <- shiny::MockShinySession$new()
+  on.exit(session$close())
+
+  result <- shiny::withReactiveDomain(session, buildVolcanoTable(contrast_reactives))
+
+  expect_equal(result[[1]], c(0, 1))
+  expect_false(anyNA(result[[1]]))
+})
+
 make_lines <- function(fclim = -2, qvallim = 0.05) {
   data.frame(
     name = c(


### PR DESCRIPTION
## Summary

- map a log2 fold change of zero to a linear fold change of one
- centralize fold-change scale conversion across differential plots
- tolerate legacy zero values without producing NaN coordinates
- add regression coverage for zero and signed fold-change values

## Validation

- full single-process package test suite
- live Playwright checks for finite zero coordinates in volcano and MA plots
- `lintr::lint_package()`
