### PR TITLE
Validate experiment data at construction

### DIFF
--- a/R/ExploratorySummarizedExperiment-class.R
+++ b/R/ExploratorySummarizedExperiment-class.R
@@ -80,9 +80,6 @@ setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(
 #' correspond to 'contrasts' set in the containing SummarizedExperimentList.
 #' @param assay_measures Optional List of measures to display related to each
 #' assay.
-#' @param assay_digits Number of decimal places retained in assays. The default
-#' reduces compressed serialized object size. Use \code{NULL} to preserve full
-#' numeric precision.
 #' @param gene_set_analyses Three-level nested lists of gene set tables keyed first by
 #' assay, then by gene set type and then by contrast.
 #' @param read_reports A named list of matrices with read counts in columns
@@ -93,6 +90,9 @@ setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(
 #' @param gene_set_analyses_tool Three-level nested lists of a string, nested as \code{gene_set_analyses}.
 #' Each string may be \code{"auto"} (the default), \code{"gsea"} or \code{"roast"}. It defines the format of the
 #' corresponding \code{gene_set_analyses} table.
+#' @param assay_digits Number of decimal places retained in assays. The default
+#' reduces compressed serialized object size. Use \code{NULL} to preserve full
+#' numeric precision.
 #'
 #' @return output An ExploratoryRangedSummarizedExperient object
 #' @rawNamespace import(SummarizedExperiment, except = 'shift')
@@ -119,7 +119,7 @@ setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(
 #' )
 #'
 ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield, labelfield = character(), entrezgenefield = character(), contrast_stats = list(),
-                                            assay_measures = list(), assay_digits = 2, gene_set_analyses = list(), dexseq_results = list(), read_reports = list(), gene_set_analyses_tool = list()) {
+                                            assay_measures = list(), gene_set_analyses = list(), dexseq_results = list(), read_reports = list(), gene_set_analyses_tool = list(), assay_digits = 2) {
   # Reset NULLs to empty
 
   if (is.null(entrezgenefield)) {
@@ -192,7 +192,7 @@ ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield
     if (is.null(assay_digits)) aligned_assay else round(aligned_assay, assay_digits)
   }))
 
-  # The same fix for contrast_stats
+  # Align contrast-statistic rows to the combined assay feature set.
 
   if (length(contrast_stats) > 0) {
     contrast_stats <- lapply(contrast_stats, function(stats) {

--- a/R/ExploratorySummarizedExperiment-class.R
+++ b/R/ExploratorySummarizedExperiment-class.R
@@ -19,6 +19,29 @@ setClass("ExploratorySummarizedExperiment", contains = "SummarizedExperiment", s
   assay_measures = "list", gene_set_analyses = "list", dexseq_results = "list", read_reports = "list", gene_set_analyses_tool = "list"
 ))
 
+setValidity("ExploratorySummarizedExperiment", function(object) {
+  errors <- character()
+  annotation_fields <- colnames(SummarizedExperiment::mcols(object))
+
+  validate_annotation_field <- function(field, slot_name, required = FALSE) {
+    if ((required && length(field) != 1) || (!required && length(field) > 1)) {
+      errors <<- c(errors, paste0(slot_name, " must contain ", if (required) "one field" else "at most one field"))
+    } else if (length(field) == 1 && !field %in% annotation_fields) {
+      errors <<- c(errors, paste0(slot_name, " field '", field, "' is absent from the feature annotation"))
+    }
+  }
+
+  validate_annotation_field(object@idfield, "idfield")
+  validate_annotation_field(object@labelfield, "labelfield")
+  validate_annotation_field(object@entrezgenefield, "entrezgenefield")
+
+  if (length(object@assay_measures) > 0 && (is.null(names(object@assay_measures)) || any(!names(object@assay_measures) %in% SummarizedExperiment::assayNames(object)))) {
+    errors <- c(errors, "assay_measures must be named for assays in the object")
+  }
+
+  if (length(errors) == 0) TRUE else errors
+})
+
 setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(from) {
   as(as(from, "SummarizedExperiment"), "ExploratorySummarizedExperiment")
 })
@@ -57,6 +80,9 @@ setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(
 #' correspond to 'contrasts' set in the containing SummarizedExperimentList.
 #' @param assay_measures Optional List of measures to display related to each
 #' assay.
+#' @param assay_digits Number of decimal places retained in assays. The default
+#' reduces compressed serialized object size. Use \code{NULL} to preserve full
+#' numeric precision.
 #' @param gene_set_analyses Three-level nested lists of gene set tables keyed first by
 #' assay, then by gene set type and then by contrast.
 #' @param read_reports A named list of matrices with read counts in columns
@@ -93,11 +119,43 @@ setAs("RangedSummarizedExperiment", "ExploratorySummarizedExperiment", function(
 #' )
 #'
 ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield, labelfield = character(), entrezgenefield = character(), contrast_stats = list(),
-                                            assay_measures = list(), gene_set_analyses = list(), dexseq_results = list(), read_reports = list(), gene_set_analyses_tool = list()) {
+                                            assay_measures = list(), assay_digits = 2, gene_set_analyses = list(), dexseq_results = list(), read_reports = list(), gene_set_analyses_tool = list()) {
   # Reset NULLs to empty
 
   if (is.null(entrezgenefield)) {
     entrezgenefield <- character()
+  }
+
+  if ((!is.list(assays) && !methods::is(assays, "List")) || length(assays) == 0) {
+    stop("assays must be a non-empty list")
+  }
+  if (!is.null(assay_digits) && (!is.numeric(assay_digits) || length(assay_digits) != 1 || is.na(assay_digits) || assay_digits < 0 || assay_digits != as.integer(assay_digits))) {
+    stop("assay_digits must be NULL or one non-negative integer")
+  }
+  if (is.null(rownames(colData)) || anyDuplicated(rownames(colData))) {
+    stop("colData must have unique sample row names")
+  }
+
+  assay_errors <- vapply(seq_along(assays), function(index) {
+    assay <- assays[[index]]
+    assay_name <- if (!is.null(names(assays)) && nzchar(names(assays)[index])) names(assays)[index] else index
+    if (length(dim(assay)) != 2) {
+      return(paste0("assay '", assay_name, "' is not two-dimensional"))
+    }
+    if (!is.numeric(assay)) {
+      return(paste0("assay '", assay_name, "' must contain numeric values"))
+    }
+    if (is.null(rownames(assay)) || anyDuplicated(rownames(assay))) {
+      return(paste0("assay '", assay_name, "' must have unique feature row names"))
+    }
+    if (is.null(colnames(assay)) || anyDuplicated(colnames(assay))) {
+      return(paste0("assay '", assay_name, "' must have unique sample column names"))
+    }
+    ""
+  }, character(1))
+  assay_errors <- assay_errors[nzchar(assay_errors)]
+  if (length(assay_errors) > 0) {
+    stop(paste(assay_errors, collapse = "; "))
   }
 
   # The assays slot of a summarised experiment needs the same dimensions for every matrix
@@ -110,12 +168,28 @@ ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield
     rbind(x, empty_rows)[all_rows, , drop = FALSE]
   }
 
-  # Subset colData to remove any samples not present in the first assay
+  # The first assay defines which sample metadata rows belong to this object.
 
+  missing_from_first <- setdiff(rownames(colData), colnames(assays[[1]]))
+  if (length(missing_from_first) > 0) {
+    warning("Dropping colData samples absent from the first assay: ", paste(missing_from_first, collapse = ", "))
+  }
   colData <- colData[rownames(colData) %in% colnames(assays[[1]]), , drop = FALSE]
+  if (nrow(colData) == 0) {
+    stop("No colData samples are present in the first assay")
+  }
+  missing_by_assay <- lapply(assays, function(assay) setdiff(rownames(colData), colnames(assay)))
+  if (any(lengths(missing_by_assay) > 0)) {
+    details <- vapply(which(lengths(missing_by_assay) > 0), function(index) {
+      assay_name <- if (!is.null(names(assays)) && nzchar(names(assays)[index])) names(assays)[index] else index
+      paste0("assay '", assay_name, "': ", paste(missing_by_assay[[index]], collapse = ", "))
+    }, character(1))
+    stop("Samples are missing from assays (", paste(details, collapse = "; "), ")")
+  }
 
   assays <- SimpleList(lapply(assays, function(as) {
-    round(add_missing_rows(as)[, rownames(colData), drop = FALSE], 2)
+    aligned_assay <- add_missing_rows(as)[, rownames(colData), drop = FALSE]
+    if (is.null(assay_digits)) aligned_assay else round(aligned_assay, assay_digits)
   }))
 
   # The same fix for contrast_stats
@@ -130,7 +204,26 @@ ExploratorySummarizedExperiment <- function(assays, colData, annotation, idfield
 
   # Annotations need to be strings
 
-  annotation <- data.frame(lapply(annotation, as.character), check.names = FALSE, row.names = rownames(annotation))[all_rows, ]
+  if (is.null(rownames(annotation)) || anyDuplicated(rownames(annotation))) {
+    stop("annotation must have unique feature row names")
+  }
+  missing_annotation <- setdiff(all_rows, rownames(annotation))
+  if (length(missing_annotation) > 0) {
+    stop("Feature annotation is missing assay rows: ", paste(missing_annotation, collapse = ", "))
+  }
+  annotation <- data.frame(lapply(annotation, as.character), check.names = FALSE, row.names = rownames(annotation))[all_rows, , drop = FALSE]
+  annotation_fields <- colnames(annotation)
+  validate_field <- function(field, field_name, required = FALSE) {
+    if ((required && length(field) != 1) || (!required && length(field) > 1)) {
+      stop(field_name, " must contain ", if (required) "one field" else "at most one field")
+    }
+    if (length(field) == 1 && !field %in% annotation_fields) {
+      stop(field_name, " field '", field, "' is absent from the feature annotation")
+    }
+  }
+  validate_field(idfield, "idfield", required = TRUE)
+  validate_field(labelfield, "labelfield")
+  validate_field(entrezgenefield, "entrezgenefield")
 
   # Ensure consistency between gene_set_analyses with gene_set_analyses_tool
   gene_set_analyses_tool <- check_gene_set_analyses_tool_consistency(gene_set_analyses, gene_set_analyses_tool)

--- a/R/ExploratorySummarizedExperimentList-class.R
+++ b/R/ExploratorySummarizedExperimentList-class.R
@@ -20,6 +20,43 @@ setClass("ExploratorySummarizedExperimentList", contains = "list", slots = c(
   group_vars = "character", default_groupvar = "character", contrasts = "list", url_roots = "list", gene_sets = "list", gene_set_id_type = "character", ensembl_species = "character"
 ))
 
+setValidity("ExploratorySummarizedExperimentList", function(object) {
+  errors <- character()
+  eses <- object@.Data
+
+  if (length(object@default_groupvar) > 1 || (length(object@default_groupvar) == 1 && !object@default_groupvar %in% object@group_vars)) {
+    errors <- c(errors, "default_groupvar must contain at most one field from group_vars")
+  }
+  if (length(object@ensembl_species) > 1) {
+    errors <- c(errors, "ensembl_species must contain at most one value")
+  }
+
+  if (length(eses) > 0) {
+    valid_entries <- vapply(eses, function(ese) methods::is(ese, "ExploratorySummarizedExperiment"), logical(1))
+    if (!all(valid_entries)) {
+      errors <- c(errors, "all list entries must be ExploratorySummarizedExperiment objects")
+    } else {
+      missing_group_vars <- unique(unlist(lapply(eses, function(ese) {
+        setdiff(object@group_vars, colnames(SummarizedExperiment::colData(ese)))
+      })))
+      if (length(missing_group_vars) > 0) {
+        errors <- c(errors, paste0("group_vars fields are absent from experiment metadata: ", paste(missing_group_vars, collapse = ", ")))
+      }
+    }
+  }
+
+  if (length(errors) == 0) TRUE else errors
+})
+
+subset_eselist <- function(x, i) {
+  data <- x@.Data
+  names(data) <- names(x)
+  initialize(x, data[i],
+    title = x@title, author = x@author, description = x@description, static_pdf = x@static_pdf, group_vars = x@group_vars, default_groupvar = x@default_groupvar,
+    contrasts = x@contrasts, url_roots = x@url_roots, gene_sets = x@gene_sets, gene_set_id_type = x@gene_set_id_type, ensembl_species = x@ensembl_species
+  )
+}
+
 #' Extract parts of ExploratorySummarizedExperimentList.
 #'
 #' @param x \code{ExploratorySummarizedExperimentList} object
@@ -30,42 +67,7 @@ setClass("ExploratorySummarizedExperimentList", contains = "list", slots = c(
 #' @rdname ExploratorySummarizedExperimentList-class
 #' @export
 setMethod("[", c("ExploratorySummarizedExperimentList", "ANY", "missing", "ANY"), function(x, i, j, ..., drop = TRUE) {
-  initialize(x, x@.Data[i],
-    title = x@title, author = x@author, description = x@description, static_pdf = "character", group_vars = x@group_vars, default_groupvar = x@default_groupvar,
-    contrasts = x@contrasts, url_roots = x@url_roots, gene_sets = x@gene_sets, gene_set_id_type = x@gene_set_id_type, ensembl_species = x@ensembl_species
-  )
-})
-
-#' Extract parts of ExploratorySummarizedExperimentList.
-#'
-#' @param x \code{ExploratorySummarizedExperimentList} object
-#' @param i numeric index for the ExploratorySummarizedExperimentList list
-#' @param j not used
-#' @param drop not used
-#' @param ... additional arguments not used here
-#' @rdname ExploratorySummarizedExperimentList-class
-#' @export
-setMethod("[", c("ExploratorySummarizedExperimentList", "numeric", "missing", "ANY"), function(x, i, j, ..., drop = TRUE) {
-  initialize(x, x@.Data[i],
-    title = x@title, author = x@author, description = x@description, static_pdf = x@static_pdf, group_vars = x@group_vars, default_groupvar = x@default_groupvar,
-    contrasts = x@contrasts, url_roots = x@url_roots, gene_sets = x@gene_sets, gene_set_id_type = x@gene_set_id_type, ensembl_species = x@ensembl_species
-  )
-})
-
-#' Extract parts of ExploratorySummarizedExperimentList.
-#'
-#' @param x \code{ExploratorySummarizedExperimentList} object
-#' @param i boolean index for the ExploratorySummarizedExperimentList list
-#' @param j not used
-#' @param drop not used
-#' @param ... additional arguments not used here
-#' @rdname ExploratorySummarizedExperimentList-class
-#' @export
-setMethod("[", c("ExploratorySummarizedExperimentList", "logical", "missing", "ANY"), function(x, i, j, ..., drop = TRUE) {
-  initialize(x, x@.Data[i],
-    title = x@title, author = x@author, description = x@description, static_pdf = x@static_pdf, group_vars = x@group_vars, default_groupvar = x@default_groupvar,
-    contrasts = x@contrasts, url_roots = x@url_roots, gene_sets = x@gene_sets, gene_set_id_type = x@gene_set_id_type, ensembl_species = x@ensembl_species
-  )
+  subset_eselist(x, i)
 })
 
 #' ExploratorySummarizedExperimentLists, containers for

--- a/R/io-read.R
+++ b/R/io-read.R
@@ -505,7 +505,17 @@ read_matrix <- function(matrix_file, sample_metadata, feature_metadata = NULL, s
     }
   }
 
-  as.matrix(matrix_data[, rownames(sample_metadata), drop = FALSE])
+  matrix_data <- matrix_data[, rownames(sample_metadata), drop = FALSE]
+  non_numeric <- colnames(matrix_data)[!vapply(matrix_data, is.numeric, logical(1))]
+  if (length(non_numeric) > 0) {
+    stop(
+      "Matrix file contains non-numeric assay columns: ",
+      paste(non_numeric, collapse = ", "),
+      " (", matrix_file, ")"
+    )
+  }
+
+  as.matrix(matrix_data)
 }
 
 #' Read a metadata file

--- a/man/ExploratorySummarizedExperiment.Rd
+++ b/man/ExploratorySummarizedExperiment.Rd
@@ -13,6 +13,7 @@ ExploratorySummarizedExperiment(
   entrezgenefield = character(),
   contrast_stats = list(),
   assay_measures = list(),
+  assay_digits = 2,
   gene_set_analyses = list(),
   dexseq_results = list(),
   read_reports = list(),
@@ -46,6 +47,10 @@ correspond to 'contrasts' set in the containing SummarizedExperimentList.}
 
 \item{assay_measures}{Optional List of measures to display related to each
 assay.}
+
+\item{assay_digits}{Number of decimal places retained in assays. The default
+reduces compressed serialized object size. Use \code{NULL} to preserve full
+numeric precision.}
 
 \item{gene_set_analyses}{Three-level nested lists of gene set tables keyed first by
 assay, then by gene set type and then by contrast.}

--- a/man/ExploratorySummarizedExperiment.Rd
+++ b/man/ExploratorySummarizedExperiment.Rd
@@ -13,11 +13,11 @@ ExploratorySummarizedExperiment(
   entrezgenefield = character(),
   contrast_stats = list(),
   assay_measures = list(),
-  assay_digits = 2,
   gene_set_analyses = list(),
   dexseq_results = list(),
   read_reports = list(),
-  gene_set_analyses_tool = list()
+  gene_set_analyses_tool = list(),
+  assay_digits = 2
 )
 }
 \arguments{
@@ -48,10 +48,6 @@ correspond to 'contrasts' set in the containing SummarizedExperimentList.}
 \item{assay_measures}{Optional List of measures to display related to each
 assay.}
 
-\item{assay_digits}{Number of decimal places retained in assays. The default
-reduces compressed serialized object size. Use \code{NULL} to preserve full
-numeric precision.}
-
 \item{gene_set_analyses}{Three-level nested lists of gene set tables keyed first by
 assay, then by gene set type and then by contrast.}
 
@@ -65,6 +61,10 @@ counts per gene type etc}
 \item{gene_set_analyses_tool}{Three-level nested lists of a string, nested as \code{gene_set_analyses}.
 Each string may be \code{"auto"} (the default), \code{"gsea"} or \code{"roast"}. It defines the format of the
 corresponding \code{gene_set_analyses} table.}
+
+\item{assay_digits}{Number of decimal places retained in assays. The default
+reduces compressed serialized object size. Use \code{NULL} to preserve full
+numeric precision.}
 }
 \value{
 output An ExploratoryRangedSummarizedExperient object

--- a/man/ExploratorySummarizedExperimentList-class.Rd
+++ b/man/ExploratorySummarizedExperimentList-class.Rd
@@ -4,20 +4,14 @@
 \name{ExploratorySummarizedExperimentList-class}
 \alias{ExploratorySummarizedExperimentList-class}
 \alias{[,ExploratorySummarizedExperimentList,ANY,missing,ANY-method}
-\alias{[,ExploratorySummarizedExperimentList,numeric,missing,ANY-method}
-\alias{[,ExploratorySummarizedExperimentList,logical,missing,ANY-method}
 \title{The ExploratorySummaizedExperimentList class}
 \usage{
 \S4method{[}{ExploratorySummarizedExperimentList,ANY,missing,ANY}(x, i, j, ..., drop = TRUE)
-
-\S4method{[}{ExploratorySummarizedExperimentList,numeric,missing,ANY}(x, i, j, ..., drop = TRUE)
-
-\S4method{[}{ExploratorySummarizedExperimentList,logical,missing,ANY}(x, i, j, ..., drop = TRUE)
 }
 \arguments{
 \item{x}{\code{ExploratorySummarizedExperimentList} object}
 
-\item{i}{boolean index for the ExploratorySummarizedExperimentList list}
+\item{i}{index for the ExploratorySummarizedExperimentList list}
 
 \item{j}{not used}
 
@@ -27,10 +21,6 @@
 }
 \description{
 The ExploratorySummaizedExperimentList class
-
-Extract parts of ExploratorySummarizedExperimentList.
-
-Extract parts of ExploratorySummarizedExperimentList.
 
 Extract parts of ExploratorySummarizedExperimentList.
 }

--- a/tests/testthat/helper-ese.R
+++ b/tests/testthat/helper-ese.R
@@ -1,0 +1,12 @@
+make_test_ese_inputs <- function() {
+  assay <- matrix(
+    c(1.2345, 2.3456, 3.4567, 4.5678),
+    nrow = 2,
+    dimnames = list(c("g1", "g2"), c("s1", "s2"))
+  )
+  list(
+    assays = list(expression = assay),
+    colData = data.frame(group = c("a", "b"), row.names = c("s1", "s2")),
+    annotation = data.frame(gene_id = c("g1", "g2"), label = c("G1", "G2"), row.names = c("g1", "g2"))
+  )
+}

--- a/tests/testthat/test-ExploratorySummarizedExperiment-class.R
+++ b/tests/testthat/test-ExploratorySummarizedExperiment-class.R
@@ -5,6 +5,10 @@ test_that("ExploratorySummarizedExperiment rounds assays for compact serializati
   expect_equal(SummarizedExperiment::assay(ese, "expression")[1, 1], 1.23)
 })
 
+test_that("assay_digits is appended to the public constructor arguments", {
+  expect_identical(tail(names(formals(ExploratorySummarizedExperiment)), 1), "assay_digits")
+})
+
 test_that("ExploratorySummarizedExperiment can retain full assay precision", {
   inputs <- make_test_ese_inputs()
   ese <- do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id", assay_digits = NULL)))

--- a/tests/testthat/test-ExploratorySummarizedExperiment-class.R
+++ b/tests/testthat/test-ExploratorySummarizedExperiment-class.R
@@ -1,0 +1,46 @@
+test_that("ExploratorySummarizedExperiment rounds assays for compact serialization by default", {
+  inputs <- make_test_ese_inputs()
+  ese <- do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id")))
+
+  expect_equal(SummarizedExperiment::assay(ese, "expression")[1, 1], 1.23)
+})
+
+test_that("ExploratorySummarizedExperiment can retain full assay precision", {
+  inputs <- make_test_ese_inputs()
+  ese <- do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id", assay_digits = NULL)))
+
+  expect_equal(SummarizedExperiment::assay(ese, "expression")[1, 1], 1.2345)
+})
+
+test_that("ExploratorySummarizedExperiment validates annotation fields", {
+  inputs <- make_test_ese_inputs()
+
+  expect_error(
+    do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "missing"))),
+    "idfield field 'missing' is absent"
+  )
+  expect_error(
+    do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id", labelfield = c("label", "gene_id")))),
+    "labelfield must contain at most one field"
+  )
+})
+
+test_that("ExploratorySummarizedExperiment reports sample alignment changes", {
+  inputs <- make_test_ese_inputs()
+  inputs$colData <- rbind(inputs$colData, data.frame(group = "c", row.names = "s3"))
+
+  expect_warning(
+    do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id"))),
+    "Dropping colData samples absent from the first assay: s3"
+  )
+})
+
+test_that("ExploratorySummarizedExperiment rejects non-numeric assays", {
+  inputs <- make_test_ese_inputs()
+  inputs$assays$expression[1, 1] <- "bad"
+
+  expect_error(
+    do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id"))),
+    "must contain numeric values"
+  )
+})

--- a/tests/testthat/test-ExploratorySummarizedExperimentList-class.R
+++ b/tests/testthat/test-ExploratorySummarizedExperimentList-class.R
@@ -21,3 +21,28 @@ test_that("ExploratorySummarizedExperimentList leaves default_groupvar empty whe
   expect_length(eselist@default_groupvar, 0)
   expect_false(has_slot_data(eselist, "default_groupvar"))
 })
+
+test_that("ExploratorySummarizedExperimentList subsetting preserves metadata slots", {
+  inputs <- make_test_ese_inputs()
+  ese <- do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id")))
+  eselist <- ExploratorySummarizedExperimentList(
+    eses = list(first = ese, second = ese),
+    static_pdf = "study.pdf",
+    group_vars = "group",
+    default_groupvar = "group"
+  )
+
+  expect_equal(eselist["first"]@static_pdf, "study.pdf")
+  expect_equal(eselist[1]@static_pdf, "study.pdf")
+  expect_equal(eselist[c(TRUE, FALSE)]@static_pdf, "study.pdf")
+})
+
+test_that("ExploratorySummarizedExperimentList validates grouping fields", {
+  inputs <- make_test_ese_inputs()
+  ese <- do.call(ExploratorySummarizedExperiment, c(inputs, list(idfield = "gene_id")))
+
+  expect_error(
+    ExploratorySummarizedExperimentList(eses = list(ese), group_vars = "missing", default_groupvar = "missing"),
+    "group_vars fields are absent"
+  )
+})

--- a/tests/testthat/test-accessory.R
+++ b/tests/testthat/test-accessory.R
@@ -179,12 +179,12 @@ test_that("read_enrichment_file parses file correctly", {
   up_file <- tempfile(pattern = "test_shinyngs", fileext = ".csv")
   up_df <- read.csv(textConnection(up_text), check.names = FALSE, row.names = 1)
   write(up_text, up_file)
-  
+
   down_text <- "geneset,p value,FDR\ndummy2,0.04,0.01\n"
   down_file <- tempfile(pattern = "test_shinyngs", fileext = ".csv")
   down_df <- read.csv(textConnection(down_text), check.names = FALSE, row.names = 1)
   write(down_text, down_file)
-  
+
   up_df2 <- up_df
   up_df2$Direction <- "Up"
   down_df2 <- down_df
@@ -759,6 +759,20 @@ test_that("read_matrix errors when sample metadata names are absent from the mat
   expect_error(
     read_matrix(matrix_file, samples),
     "SampleMissing.*absent from the matrix"
+  )
+})
+
+test_that("read_matrix rejects non-numeric assay columns", {
+  matrix_content <- "id\tSample1\tSample2\ngene1\t1\tbad\ngene2\t4\t5\n"
+  matrix_file <- tempfile(fileext = ".tsv")
+  writeLines(matrix_content, matrix_file)
+  on.exit(unlink(matrix_file))
+
+  samples <- data.frame(row.names = c("Sample1", "Sample2"))
+
+  expect_error(
+    read_matrix(matrix_file, samples),
+    "non-numeric assay columns: Sample2"
   )
 })
 


### PR DESCRIPTION
## Summary

- validate assay dimensions, numeric values, sample names, feature names, annotations, grouping fields, and assay metadata at construction
- preserve the established two-decimal assay default while allowing full precision explicitly
- preserve positional compatibility by appending the new `assay_digits` argument to the public constructor
- preserve list metadata consistently across name, numeric, and logical subsetting

## Validation

- full single-process package test suite
- focused constructor, validity, precision, and subsetting regressions
- `lintr::lint_package()`
