### PR TITLE
Default PCA plots to 2D

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,9 @@
 
 ## Improvements
 
+* PCA component and loading plots open in 2D, with 3D available from the plot
+  type control.
+
 * `interactive_heatmap()` gains a `show_row_labels` argument for suppressing
   row labels, and now defaults `plot_height` to a height scaled to the number
   of rows: generously when labels are shown (fixing large heatmaps rendering

--- a/R/pca.R
+++ b/R/pca.R
@@ -44,7 +44,7 @@ pcaInput <- function(id, eselist) {
   # Output sets of fields in their own containers
 
   fieldSets(ns("fieldset"), list(
-    principal_component_analysis = pca_filters, scatter_plot = list(scatterplotcontrolsInput(ns("pca"), allow_3d = TRUE), groupbyInput(ns("pca"))),
+    principal_component_analysis = pca_filters, scatter_plot = list(scatterplotcontrolsInput(ns("pca"), allow_3d = TRUE, default_3d = FALSE), groupbyInput(ns("pca"))),
     expression = expression_filters, export = list(
       simpletableInput(ns("components"), tabletitle = "Components"), simpletableInput(ns("loading"), tabletitle = "Loading"),
       simpletableInput(ns("screeplot"), tabletitle = "Scree")

--- a/R/scatterplotcontrols.R
+++ b/R/scatterplotcontrols.R
@@ -5,6 +5,7 @@
 #'
 #' @param id Submodule namespace
 #' @param allow_3d Boolean: allow user to choose 3D plotting?
+#' @param default_3d Boolean: select 3D when the controls first render?
 #' @param make_colors Boolean: add controls for coloring?
 #'
 #' @return output An HTML tag object that can be rendered as HTML using
@@ -13,11 +14,11 @@
 #' @examples
 #' scatterplotcontrolsInput("pca", allow_3d = FALSE) # for a 2D plot
 #'
-scatterplotcontrolsInput <- function(id, allow_3d = TRUE, make_colors = FALSE) {
+scatterplotcontrolsInput <- function(id, allow_3d = TRUE, default_3d = TRUE, make_colors = FALSE) {
   ns <- NS(id)
 
   if (allow_3d) {
-    inputs <- list(radioButtons(ns("threedee"), "Plot type", c(`3D` = TRUE, `2D` = FALSE), inline = TRUE))
+    inputs <- list(radioButtons(ns("threedee"), "Plot type", c(`3D` = TRUE, `2D` = FALSE), selected = default_3d, inline = TRUE))
   } else {
     inputs <- list(hidden_input(ns("threedee"), FALSE))
   }

--- a/R/scatterplotcontrols.R
+++ b/R/scatterplotcontrols.R
@@ -5,8 +5,8 @@
 #'
 #' @param id Submodule namespace
 #' @param allow_3d Boolean: allow user to choose 3D plotting?
-#' @param default_3d Boolean: select 3D when the controls first render?
 #' @param make_colors Boolean: add controls for coloring?
+#' @param default_3d Boolean: select 3D when the controls first render?
 #'
 #' @return output An HTML tag object that can be rendered as HTML using
 #' as.character()
@@ -14,7 +14,7 @@
 #' @examples
 #' scatterplotcontrolsInput("pca", allow_3d = FALSE) # for a 2D plot
 #'
-scatterplotcontrolsInput <- function(id, allow_3d = TRUE, default_3d = TRUE, make_colors = FALSE) {
+scatterplotcontrolsInput <- function(id, allow_3d = TRUE, make_colors = FALSE, default_3d = TRUE) {
   ns <- NS(id)
 
   if (allow_3d) {

--- a/man/scatterplotcontrolsInput.Rd
+++ b/man/scatterplotcontrolsInput.Rd
@@ -7,8 +7,8 @@
 scatterplotcontrolsInput(
   id,
   allow_3d = TRUE,
-  default_3d = TRUE,
-  make_colors = FALSE
+  make_colors = FALSE,
+  default_3d = TRUE
 )
 }
 \arguments{
@@ -16,9 +16,9 @@ scatterplotcontrolsInput(
 
 \item{allow_3d}{Boolean: allow user to choose 3D plotting?}
 
-\item{default_3d}{Boolean: select 3D when the controls first render?}
-
 \item{make_colors}{Boolean: add controls for coloring?}
+
+\item{default_3d}{Boolean: select 3D when the controls first render?}
 }
 \value{
 output An HTML tag object that can be rendered as HTML using

--- a/man/scatterplotcontrolsInput.Rd
+++ b/man/scatterplotcontrolsInput.Rd
@@ -4,12 +4,19 @@
 \alias{scatterplotcontrolsInput}
 \title{Input function for scatterplotcontrols module}
 \usage{
-scatterplotcontrolsInput(id, allow_3d = TRUE, make_colors = FALSE)
+scatterplotcontrolsInput(
+  id,
+  allow_3d = TRUE,
+  default_3d = TRUE,
+  make_colors = FALSE
+)
 }
 \arguments{
 \item{id}{Submodule namespace}
 
 \item{allow_3d}{Boolean: allow user to choose 3D plotting?}
+
+\item{default_3d}{Boolean: select 3D when the controls first render?}
 
 \item{make_colors}{Boolean: add controls for coloring?}
 }

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -1,5 +1,11 @@
 # runPCA()
 
+test_that("PCA controls default to a 2D plot", {
+  html <- htmltools::renderTags(pcaInput("pca", shinytest2_eselist()))$html
+
+  expect_match(html, 'value="FALSE" checked')
+})
+
 test_that("runPCA does not scale variables by default", {
   mat <- matrix(
     c(

--- a/tests/testthat/test-scatterplotcontrols.R
+++ b/tests/testthat/test-scatterplotcontrols.R
@@ -2,6 +2,18 @@ make_scatterplot_matrix <- function() {
   matrix(1:12, nrow = 4, dimnames = list(paste0("s", 1:4), c("PC1", "PC2", "PC3")))
 }
 
+test_that("scatterplot controls keep 3D as their backwards-compatible default", {
+  html <- htmltools::renderTags(scatterplotcontrolsInput("scatter"))$html
+
+  expect_match(html, 'value="TRUE" checked')
+})
+
+test_that("scatterplot controls can default to 2D", {
+  html <- htmltools::renderTags(scatterplotcontrolsInput("scatter", default_3d = FALSE))$html
+
+  expect_match(html, 'value="FALSE" checked')
+})
+
 test_that("getXAxis/getYAxis/getZAxis return the selected axis columns in 3D mode", {
   m <- make_scatterplot_matrix()
 

--- a/tests/testthat/test-scatterplotcontrols.R
+++ b/tests/testthat/test-scatterplotcontrols.R
@@ -14,6 +14,12 @@ test_that("scatterplot controls can default to 2D", {
   expect_match(html, 'value="FALSE" checked')
 })
 
+test_that("the existing positional make_colors argument remains compatible", {
+  html <- htmltools::renderTags(scatterplotcontrolsInput("scatter", TRUE, TRUE))$html
+
+  expect_match(html, "scatter-scatterplot-palette_name")
+})
+
 test_that("getXAxis/getYAxis/getZAxis return the selected axis columns in 3D mode", {
   m <- make_scatterplot_matrix()
 

--- a/tests/testthat/test-shinytest2-rnaseq.R
+++ b/tests/testthat/test-shinytest2-rnaseq.R
@@ -37,7 +37,7 @@ test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
   traces <- scatter$x$data
   expect_gt(length(traces), 0)
 
-  point_traces <- Filter(function(tr) length(tr$x) > 0, traces)
+  point_traces <- Filter(function(tr) identical(tr$mode, "markers") && length(tr$x) > 0, traces)
   expect_gt(length(point_traces), 0)
   n_points <- sum(vapply(point_traces, function(tr) length(tr$x), integer(1)))
   expect_equal(n_points, 12)

--- a/tests/testthat/test-shinytest2-rnaseq.R
+++ b/tests/testthat/test-shinytest2-rnaseq.R
@@ -23,6 +23,8 @@ test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
   app$set_inputs(`rnaseq-rnaseq` = "pca")
   app$wait_for_idle(timeout = 20000)
 
+  expect_equal(app$get_value(input = "rnaseq-pca-pca-threedee"), "FALSE")
+
   outputs <- names(app$get_values()$output)
   expect_true("rnaseq-pca-pca-scatter" %in% outputs)
   expect_true("rnaseq-pca-components-datatable" %in% outputs)
@@ -37,9 +39,12 @@ test_that("the PCA tab renders a scatterplot and its selectmatrix controls", {
   traces <- scatter$x$data
   expect_gt(length(traces), 0)
 
-  point_traces <- Filter(function(tr) identical(tr$mode, "markers") && length(tr$x) > 0, traces)
+  point_traces <- Filter(function(tr) identical(tr$mode, "markers") && length(tr$text) > 0, traces)
   expect_gt(length(point_traces), 0)
+  sample_labels <- unlist(lapply(point_traces, function(tr) unlist(tr$text, use.names = FALSE)), use.names = FALSE)
   n_points <- sum(vapply(point_traces, function(tr) length(tr$x), integer(1)))
+  expect_setequal(sample_labels, paste0("sample", seq_len(12)))
+  expect_length(sample_labels, 12)
   expect_equal(n_points, 12)
   expect_equal(sum(vapply(point_traces, function(tr) length(tr$y), integer(1))), 12)
 


### PR DESCRIPTION
### Summary

- Add a configurable initial dimension to shared scatter plot controls.
- Open PCA component and loading plots in 2D while preserving 3D defaults elsewhere.
- Add control and PCA UI regression coverage.

### Validation

- Focused PCA and scatter control tests
- Isolated Illumina array and RNA-seq browser tests
- Interactive PCA browser check
- Exact CI lintr command
- Ruff format check