### PR TITLE
Fix row-selection sliders for small assays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -133,6 +133,9 @@
 
 ## Bug fixes
 
+* Variance-based row selectors use valid slider bounds for assays with fewer
+  rows than the configured default.
+
 * `interactive_heatmap()` left a disproportionately large gap between the
   column annotation bars (and/or column dendrogram) and the heatmap body -
   heatmaply's `subplot_margin` renders as double the fraction passed to it,

--- a/R/geneselect.R
+++ b/R/geneselect.R
@@ -261,6 +261,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
 }
 
 variance_slider_range <- function(value, maximum) {
+  maximum <- max(1, maximum)
   minimum <- min(10, maximum)
   list(min = minimum, max = maximum, value = min(max(value, minimum), maximum))
 }

--- a/R/geneselect.R
+++ b/R/geneselect.R
@@ -99,6 +99,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
     output$geneSelect_ui <- renderUI({
       withProgress(message = "Rendering row selection", value = 0, {
         ns <- session$ns
+        variance_range <- variance_slider_range(var_n, var_max)
 
         gene_select_methods <- c()
         if (provide_none) {
@@ -124,7 +125,7 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
         gene_select <- list(h5("Select genes/ rows"), selectInput(ns("geneSelect"), "Select genes by", gene_select_methods, selected = selected), conditionalPanel(condition = paste0(
           "input['",
           ns("geneSelect"), "'] == 'variance' "
-        ), sliderInput(ns("obs"), with_help_icon("Show top N most variant rows:", "Rows are ranked by variance across samples; increasing this includes more, less variable rows."), min = 10, max = var_max, value = var_n)), conditionalPanel(condition = paste0(
+        ), sliderInput(ns("obs"), with_help_icon("Show top N most variant rows:", "Rows are ranked by variance across samples; increasing this includes more, less variable rows."), min = variance_range$min, max = variance_range$max, value = variance_range$value)), conditionalPanel(condition = paste0(
           "input['",
           ns("geneSelect"), "'] == 'metadata_pick' "
         ), labelselectfieldInput(ns("gene_label_pick"))), conditionalPanel(condition = paste0(
@@ -257,6 +258,11 @@ geneselect <- function(id, eselist, getExperiment, var_n = 50, var_max = 500, se
 
     geneselect_functions
   })
+}
+
+variance_slider_range <- function(value, maximum) {
+  minimum <- min(10, maximum)
+  list(min = minimum, max = maximum, value = min(max(value, minimum), maximum))
 }
 
 #' Generate an integer ordering to select the n most variable genes out of a matrix

--- a/tests/testthat/test-geneselect.R
+++ b/tests/testthat/test-geneselect.R
@@ -51,3 +51,10 @@ test_that("variance_slider_range preserves the standard range for larger assays"
     list(min = 10, max = 100, value = 50)
   )
 })
+
+test_that("variance_slider_range remains valid for an empty assay", {
+  expect_equal(
+    variance_slider_range(value = 50, maximum = 0),
+    list(min = 1, max = 1, value = 1)
+  )
+})

--- a/tests/testthat/test-geneselect.R
+++ b/tests/testthat/test-geneselect.R
@@ -37,3 +37,17 @@ test_that("select_variable_genes errors when neither matrix nor row_variances is
     "a value must be provided for either matrix or row_variances"
   )
 })
+
+test_that("variance_slider_range keeps the default within a small assay", {
+  expect_equal(
+    variance_slider_range(value = 50, maximum = 8),
+    list(min = 8, max = 8, value = 8)
+  )
+})
+
+test_that("variance_slider_range preserves the standard range for larger assays", {
+  expect_equal(
+    variance_slider_range(value = 50, maximum = 100),
+    list(min = 10, max = 100, value = 50)
+  )
+})


### PR DESCRIPTION
### Summary

- Clamp variance selector bounds and defaults to the available assay rows.
- Preserve the existing range for larger assays.
- Add regression coverage for small and standard assay sizes.

### Validation

- Focused geneselect and readreports tests
- Exact CI lintr command
- Ruff format check