### PR TITLE
Fix preview UI regressions

### DIFF
--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -342,6 +342,9 @@ contrastEnumeration <- function(eselist, selectmatrix_reactives) {
 # (not a reactive) since it's pure given its input.
 makeContrastNamesFor <- function(contrasts) {
   lapply(contrasts, function(x) {
+    if (is.null(names(x))) {
+      names(x) <- c("Variable", "Group.1", "Group.2")
+    }
     x <- x[!names(x) %in% "id"]
     contrast_name <- paste(prettify_variable_name(x["Variable"]), paste(x["Group.2"], x["Group.1"], sep = " vs "), sep = ": ")
     extras <- setdiff(names(x), c("Variable", "Group.1", "Group.2"))

--- a/R/genesetanalysistable.R
+++ b/R/genesetanalysistable.R
@@ -305,8 +305,10 @@ genesetanalysistable <- function(id, eselist) {
 
       # Add links, but use a prettified version of the gene set name that re-flows to take up less space
 
-      gst <- linkMatrix(gst, eselist@url_roots, data.frame(gene_set_id = prettify_gene_set_name(gst$gene_set_id)))
+      display_values <- data.frame(gene_set_id = prettify_gene_set_name(gst$gene_set_id))
       colnames(gst) <- prettify_variable_name(colnames(gst))
+      colnames(display_values) <- prettify_variable_name(colnames(display_values))
+      gst <- linkMatrix(gst, eselist@url_roots, display_values)
 
       gst
     })

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -445,9 +445,10 @@ heatmap <- function(id, eselist, type = "expression", heatmap_layout = heatmap_l
 
     heatmapOnlyHeight <- reactive({
       plot_annotation <- getPlotAnnotation()
+      display_matrix <- getDisplayMatrix()
 
       heatmap_layout_height(
-        n_rows = nrow(getDisplayMatrix()), row_height_px = rowHeight(), cluster_cols = as.logical(input$cluster_cols),
+        n_rows = nrow(display_matrix), row_height_px = rowHeight(), cluster_cols = as.logical(input$cluster_cols),
         n_annotation_cols = if (is.null(plot_annotation)) 0 else ncol(plot_annotation), heatmap_layout = heatmap_layout
       )
     })

--- a/tests/testthat/test-enrichmentoverview.R
+++ b/tests/testthat/test-enrichmentoverview.R
@@ -7,6 +7,18 @@ test_that("compile_enrichment_overview resolves every available contrast", {
   expect_equal(attr(data, "contrast_levels"), c("Condition: treated vs control", "Batch: b vs a"))
 })
 
+test_that("compile_enrichment_overview labels positional legacy contrasts", {
+  eselist <- make_enrichmentoverview_eselist()
+  eselist@contrasts <- lapply(eselist@contrasts, function(contrast) {
+    unname(unlist(contrast[c("Variable", "Group.1", "Group.2")]))
+  })
+
+  data <- compile_enrichment_overview(eselist[[1]], "counts", "KEGG", eselist@contrasts)
+
+  expect_equal(unique(data$contrast), c("Condition: treated vs control", "Batch: b vs a"))
+  expect_equal(attr(data, "contrast_levels"), c("Condition: treated vs control", "Batch: b vs a"))
+})
+
 test_that("prepare_enrichment_overview retains missing gene-set contrast combinations", {
   eselist <- make_enrichmentoverview_eselist()
   data <- compile_enrichment_overview(eselist[[1]], "counts", "KEGG", eselist@contrasts)

--- a/tests/testthat/test-genesetanalysistable.R
+++ b/tests/testthat/test-genesetanalysistable.R
@@ -166,6 +166,19 @@ test_that("genesetanalysistable renders a simpletable datatable of the filtered 
   }))
 })
 
+test_that("gene set links remain HTML after display columns are prettified", {
+  eselist <- make_genesetanalysistable_eselist()
+  eselist@url_roots$gene_set_id <- "?geneset="
+
+  run_genesetanalysistable_server(eselist, expr = quote({
+    display_table <- getDisplayGeneSetAnalysis()
+
+    expect_match(display_table[["Gene set id"]], '^<a href="\\?geneset=SET_A">')
+    expect_equal(attr(display_table, "shinyngs_html_columns"), "Gene set id")
+    expect_false("Gene set id" %in% datatable_escape_columns(display_table))
+  }))
+})
+
 test_that("output$enrichmentMethod reports the resolved enrichment tool", {
   run_genesetanalysistable_server(make_genesetanalysistable_eselist(), expr = quote({
     rendered <- output$enrichmentMethod

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -1,5 +1,26 @@
 # interactive_heatmap()
 
+test_that("PCA heatmap height preserves pending sample-group validation", {
+  eselist <- shinytest2_eselist()
+
+  shiny::testServer(shinyngs:::heatmap, args = list(id = "heatmap", eselist = eselist, type = "pca"), {
+    session$setInputs(
+      `heatmap-experiment` = "counts",
+      `heatmap-assay` = "counts",
+      `heatmap-selectmatrix-geneSelect` = "all",
+      `heatmap-selectmatrix-sampleSelect` = "group",
+      `heatmap-selectmatrix-sampleGroupVar` = "condition",
+      cluster_rows = FALSE,
+      cluster_cols = FALSE
+    )
+    session$flushReact()
+
+    pending <- tryCatch(heatmapOnlyHeight(), error = identity)
+    expect_s3_class(pending, "validation")
+    expect_match(conditionMessage(pending), "Waiting for form to provide sampleGroupVal", fixed = TRUE)
+  })
+})
+
 test_that("interactive_heatmap handles single-row matrices (e.g. one informative sample variable)", {
   # A single-row matrix is the shape anova_pca_metadata() produces for the
   # "PCA vs Experiment" heatmap when only one sample metadata variable is


### PR DESCRIPTION
## Summary

- preserve quiet Shiny validation while the PCA heatmap waits for dynamic sample-group controls
- render generated gene-set links after display column names are finalized
- label legacy positional contrasts correctly in the cross-contrast gene-set overview

## Validation

- lintr::lint_package()
- release-style R CMD check with all tests passing
- Playwright sweep of all 22 Zhang neurons panels with expected plots and tables, no raw UI errors, literal HTML, broken images, console errors, or page exceptions
- end-to-end gene-set link navigation into the matching barcode plot